### PR TITLE
formatted using clang-format-9

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,120 @@
+# Style file for MLSE Libraries based on the modified rocBLAS style
+
+# Common settings
+BasedOnStyle:  WebKit
+TabWidth:        4
+IndentWidth:     4
+UseTab:          Never
+ColumnLimit: 100
+
+# Other languages JavaScript, Proto
+
+---
+Language: Cpp
+
+# http://releases.llvm.org/6.0.1/tools/clang/docs/ClangFormatStyleOptions.html#disabling-formatting-on-a-piece-of-code
+# int formatted_code;
+# // clang-format off
+#     void    unformatted_code  ;
+# // clang-format on
+# void formatted_code_again;
+
+DisableFormat:   false
+Standard: Cpp11
+
+AccessModifierOffset: -4
+AlignAfterOpenBracket: true
+AlignConsecutiveAssignments: true
+AlignConsecutiveDeclarations: true
+AlignEscapedNewlinesLeft: true
+AlignOperands:   true
+AlignTrailingComments: false
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: false
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: false
+BinPackParameters: false
+
+# Configure each individual brace in BraceWrapping
+BreakBeforeBraces: Custom
+# Control of individual brace wrapping cases
+BraceWrapping: {
+    AfterClass: 'true'
+    AfterControlStatement: 'true'
+    AfterEnum : 'true'
+    AfterFunction : 'true'
+    AfterNamespace : 'true'
+    AfterStruct : 'true'
+    AfterUnion : 'true'
+    BeforeCatch : 'true'
+    BeforeElse : 'true'
+    IndentBraces : 'false'
+#    AfterExternBlock : 'true'
+}
+
+#BreakAfterJavaFieldAnnotations: true
+#BreakBeforeInheritanceComma: false
+#BreakBeforeBinaryOperators: None
+#BreakBeforeTernaryOperators: true
+#BreakConstructorInitializersBeforeComma: true
+#BreakStringLiterals: true
+
+CommentPragmas:  '^ IWYU pragma:'
+#CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+#SpaceBeforeCpp11BracedList: false
+DerivePointerAlignment: false
+ExperimentalAutoDetectBinPacking: false
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+IndentCaseLabels: false
+#FixNamespaceComments: true
+IndentWrappedFunctionNames: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+#JavaScriptQuotes: Double
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: All
+ObjCBlockIndentWidth: 4
+#ObjCSpaceAfterProperty: true
+#ObjCSpaceBeforeProtocolList: true
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Left
+SpaceAfterCStyleCast: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: Never
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+#SpaceAfterTemplateKeyword: true
+#SpaceBeforeInheritanceColon: true
+
+#SortUsingDeclarations: true
+SortIncludes: true
+
+# Comments are for developers, they should arrange them
+ReflowComments: false
+
+#IncludeBlocks: Preserve
+#IndentPPDirectives: AfterHash
+---

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -4,7 +4,7 @@
 # are installed, and if so, uses the installed version to format
 # the staged changes.
 
-base=clang-format-3.8
+base=/opt/rocm/hcc/bin/clang-format
 format=""
 
 # Redirect output to stderr.
@@ -16,8 +16,8 @@ type "$base" >/dev/null 2>&1 && format="$base"
 # no versions of clang-format are installed
 if [ -z "$format" ]
 then
-    echo "$base is not installed. Commit is cancelled. Delete the hook to force commit."
-    exit 1
+    echo "$base is not installed. Pre-commit hook will not be executed."
+    exit 0
 fi
 
 # Do everything from top - level
@@ -31,28 +31,13 @@ else
     against=4b825dc642cb6eb9a060e54bf8d69288fbee4904
 fi
 
-exitCode=0
-
 # do the formatting
 for file in $(git diff-index --cached --name-only $against | grep -E '\.h$|\.hpp$|\.cpp$|\.cl$|\.h\.in$|\.hpp\.in$|\.cpp\.in$')
 do
     if [ -e "$file" ]
     then
-       # echo "$format $file"
-	"$format" -style=file -output-replacements-xml "$file" | grep "\<replacement\>" >/dev/null
-	if [ $? -ne 1 ]; then
-            echo "$format" -i -style=file "$file"
-	    exitCode=1
-	fi
-	
+        echo "$format $file"
+        "$format" -i -style=file "$file"
     fi
 done
 
-if [ $exitCode -eq 1 ]; then
-    echo "Please fix the errors by running the commands listed above."
-    echo "Commit is cancelled. You may force by deleting the hook in .githook"
-else
-    echo "Clang format checks passed"
-fi
-
-exit $exitCode

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 // This shared library is available at https://github.com/ROCmSoftwarePlatform/rocJENKINS/
-@Library('rocJenkins') _
+@Library('rocJenkins@clang9') _
 
 // This is file for internal AMD use.
 // If you are interested in running your own Jenkins, please raise a github issue for assistance.

--- a/hipcub/include/hipcub/config.hpp
+++ b/hipcub/include/hipcub/config.hpp
@@ -31,9 +31,9 @@
 #define HIPCUB_CONFIG_HPP_
 
 #ifndef HIPCUB_MAIN_HEADER_INCLUDED
-    // Unlike CUB, hipCUB does not support including particular headers,
-    // because it is a wrapper of two backends
-    #error "Include only the main header file: #include <hipcub/hipcub.hpp>"
+// Unlike CUB, hipCUB does not support including particular headers,
+// because it is a wrapper of two backends
+#error "Include only the main header file: #include <hipcub/hipcub.hpp>"
 #endif
 
 #include <hip/hip_runtime.h>
@@ -41,67 +41,67 @@
 #define HIPCUB_NAMESPACE hipcub
 
 #define BEGIN_HIPCUB_NAMESPACE \
-    namespace hipcub {
+    namespace hipcub           \
+    {
 
-#define END_HIPCUB_NAMESPACE \
-    } /* hipcub */
+#define END_HIPCUB_NAMESPACE } /* hipcub */
 
 #ifdef __HIP_PLATFORM_HCC__
-    #include <rocprim/rocprim.hpp>
+#include <rocprim/rocprim.hpp>
 
-    #define HIPCUB_ROCPRIM_API 1
-    #define HIPCUB_DEVICE __device__
-    #define HIPCUB_HOST __host__
-    #define HIPCUB_HOST_DEVICE __host__ __device__
-    #define HIPCUB_RUNTIME_FUNCTION __host__
-    #define HIPCUB_SHARED_MEMORY __shared__
+#define HIPCUB_ROCPRIM_API 1
+#define HIPCUB_DEVICE __device__
+#define HIPCUB_HOST __host__
+#define HIPCUB_HOST_DEVICE __host__ __device__
+#define HIPCUB_RUNTIME_FUNCTION __host__
+#define HIPCUB_SHARED_MEMORY __shared__
 #elif defined(__HIP_PLATFORM_NVCC__)
-    // Block
-    #include <cub/block/block_histogram.cuh>
-    #include <cub/block/block_discontinuity.cuh>
-    #include <cub/block/block_exchange.cuh>
-    #include <cub/block/block_load.cuh>
-    #include <cub/block/block_radix_rank.cuh>
-    #include <cub/block/block_radix_sort.cuh>
-    #include <cub/block/block_reduce.cuh>
-    #include <cub/block/block_scan.cuh>
-    #include <cub/block/block_store.cuh>
+// Block
+#include <cub/block/block_discontinuity.cuh>
+#include <cub/block/block_exchange.cuh>
+#include <cub/block/block_histogram.cuh>
+#include <cub/block/block_load.cuh>
+#include <cub/block/block_radix_rank.cuh>
+#include <cub/block/block_radix_sort.cuh>
+#include <cub/block/block_reduce.cuh>
+#include <cub/block/block_scan.cuh>
+#include <cub/block/block_store.cuh>
 
-    // Thread
-    #include <cub/thread/thread_load.cuh>
-    #include <cub/thread/thread_operators.cuh>
-    #include <cub/thread/thread_reduce.cuh>
-    #include <cub/thread/thread_scan.cuh>
-    #include <cub/thread/thread_store.cuh>
+// Thread
+#include <cub/thread/thread_load.cuh>
+#include <cub/thread/thread_operators.cuh>
+#include <cub/thread/thread_reduce.cuh>
+#include <cub/thread/thread_scan.cuh>
+#include <cub/thread/thread_store.cuh>
 
-    // Warp
-    #include <cub/warp/warp_reduce.cuh>
-    #include <cub/warp/warp_scan.cuh>
+// Warp
+#include <cub/warp/warp_reduce.cuh>
+#include <cub/warp/warp_scan.cuh>
 
-    // Iterator
-    #include <cub/iterator/arg_index_input_iterator.cuh>
-    #include <cub/iterator/cache_modified_input_iterator.cuh>
-    #include <cub/iterator/cache_modified_output_iterator.cuh>
-    #include <cub/iterator/constant_input_iterator.cuh>
-    #include <cub/iterator/counting_input_iterator.cuh>
-    #include <cub/iterator/tex_obj_input_iterator.cuh>
-    #include <cub/iterator/tex_ref_input_iterator.cuh>
-    #include <cub/iterator/transform_input_iterator.cuh>
+// Iterator
+#include <cub/iterator/arg_index_input_iterator.cuh>
+#include <cub/iterator/cache_modified_input_iterator.cuh>
+#include <cub/iterator/cache_modified_output_iterator.cuh>
+#include <cub/iterator/constant_input_iterator.cuh>
+#include <cub/iterator/counting_input_iterator.cuh>
+#include <cub/iterator/tex_obj_input_iterator.cuh>
+#include <cub/iterator/tex_ref_input_iterator.cuh>
+#include <cub/iterator/transform_input_iterator.cuh>
 
-    // Util
-    #include <cub/util_arch.cuh>
-    #include <cub/util_debug.cuh>
-    #include <cub/util_device.cuh>
-    #include <cub/util_macro.cuh>
-    #include <cub/util_ptx.cuh>
-    #include <cub/util_type.cuh>
+// Util
+#include <cub/util_arch.cuh>
+#include <cub/util_debug.cuh>
+#include <cub/util_device.cuh>
+#include <cub/util_macro.cuh>
+#include <cub/util_ptx.cuh>
+#include <cub/util_type.cuh>
 
-    #define HIPCUB_CUB_API 1
-    #define HIPCUB_DEVICE __device__
-    #define HIPCUB_HOST __host__
-    #define HIPCUB_HOST_DEVICE __host__ __device__
-    #define HIPCUB_RUNTIME_FUNCTION CUB_RUNTIME_FUNCTION
-    #define HIPCUB_SHARED_MEMORY __shared__
+#define HIPCUB_CUB_API 1
+#define HIPCUB_DEVICE __device__
+#define HIPCUB_HOST __host__
+#define HIPCUB_HOST_DEVICE __host__ __device__
+#define HIPCUB_RUNTIME_FUNCTION CUB_RUNTIME_FUNCTION
+#define HIPCUB_SHARED_MEMORY __shared__
 #endif
 
 #endif // HIPCUB_CONFIG_HPP_

--- a/hipcub/include/hipcub/cub/device/device_histogram.hpp
+++ b/hipcub/include/hipcub/cub/device/device_histogram.hpp
@@ -38,256 +38,236 @@ BEGIN_HIPCUB_NAMESPACE
 
 struct DeviceHistogram
 {
-    template<
-        typename SampleIteratorT,
-        typename CounterT,
-        typename LevelT,
-        typename OffsetT
-    >
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t HistogramEven(void * d_temp_storage,
-                             size_t& temp_storage_bytes,
-                             SampleIteratorT d_samples,
-                             CounterT * d_histogram,
-                             int num_levels,
-                             LevelT lower_level,
-                             LevelT upper_level,
-                             OffsetT num_samples,
-                             hipStream_t stream = 0,
-                             bool debug_synchronous = false)
+    template <typename SampleIteratorT, typename CounterT, typename LevelT, typename OffsetT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t HistogramEven(void*           d_temp_storage,
+                                                            size_t&         temp_storage_bytes,
+                                                            SampleIteratorT d_samples,
+                                                            CounterT*       d_histogram,
+                                                            int             num_levels,
+                                                            LevelT          lower_level,
+                                                            LevelT          upper_level,
+                                                            OffsetT         num_samples,
+                                                            hipStream_t     stream = 0,
+                                                            bool debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceHistogram::HistogramEven(
-                d_temp_storage, temp_storage_bytes,
-                d_samples,
-                d_histogram,
-                num_levels, lower_level, upper_level,
-                num_samples,
-                stream, debug_synchronous
-            )
-        );
+        return hipCUDAErrorTohipError(::cub::DeviceHistogram::HistogramEven(d_temp_storage,
+                                                                            temp_storage_bytes,
+                                                                            d_samples,
+                                                                            d_histogram,
+                                                                            num_levels,
+                                                                            lower_level,
+                                                                            upper_level,
+                                                                            num_samples,
+                                                                            stream,
+                                                                            debug_synchronous));
     }
 
-    template<
-        typename SampleIteratorT,
-        typename CounterT,
-        typename LevelT,
-        typename OffsetT
-    >
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t HistogramEven(void * d_temp_storage,
-                             size_t& temp_storage_bytes,
-                             SampleIteratorT d_samples,
-                             CounterT * d_histogram,
-                             int num_levels,
-                             LevelT lower_level,
-                             LevelT upper_level,
-                             OffsetT num_row_samples,
-                             OffsetT num_rows,
-                             size_t row_stride_bytes,
-                             hipStream_t stream = 0,
-                             bool debug_synchronous = false)
+    template <typename SampleIteratorT, typename CounterT, typename LevelT, typename OffsetT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t HistogramEven(void*           d_temp_storage,
+                                                            size_t&         temp_storage_bytes,
+                                                            SampleIteratorT d_samples,
+                                                            CounterT*       d_histogram,
+                                                            int             num_levels,
+                                                            LevelT          lower_level,
+                                                            LevelT          upper_level,
+                                                            OffsetT         num_row_samples,
+                                                            OffsetT         num_rows,
+                                                            size_t          row_stride_bytes,
+                                                            hipStream_t     stream = 0,
+                                                            bool debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceHistogram::HistogramEven(
-                d_temp_storage, temp_storage_bytes,
-                d_samples,
-                d_histogram,
-                num_levels, lower_level, upper_level,
-                num_row_samples, num_rows, row_stride_bytes,
-                stream, debug_synchronous
-            )
-        );
+        return hipCUDAErrorTohipError(::cub::DeviceHistogram::HistogramEven(d_temp_storage,
+                                                                            temp_storage_bytes,
+                                                                            d_samples,
+                                                                            d_histogram,
+                                                                            num_levels,
+                                                                            lower_level,
+                                                                            upper_level,
+                                                                            num_row_samples,
+                                                                            num_rows,
+                                                                            row_stride_bytes,
+                                                                            stream,
+                                                                            debug_synchronous));
     }
 
-    template<
-        int NUM_CHANNELS,
-        int NUM_ACTIVE_CHANNELS,
-        typename SampleIteratorT,
-        typename CounterT,
-        typename LevelT,
-        typename OffsetT
-    >
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t MultiHistogramEven(void * d_temp_storage,
-                                  size_t& temp_storage_bytes,
-                                  SampleIteratorT d_samples,
-                                  CounterT * d_histogram[NUM_ACTIVE_CHANNELS],
-                                  int num_levels[NUM_ACTIVE_CHANNELS],
-                                  LevelT lower_level[NUM_ACTIVE_CHANNELS],
-                                  LevelT upper_level[NUM_ACTIVE_CHANNELS],
-                                  OffsetT num_pixels,
-                                  hipStream_t stream = 0,
-                                  bool debug_synchronous = false)
+    template <int NUM_CHANNELS,
+              int NUM_ACTIVE_CHANNELS,
+              typename SampleIteratorT,
+              typename CounterT,
+              typename LevelT,
+              typename OffsetT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t
+        MultiHistogramEven(void*           d_temp_storage,
+                           size_t&         temp_storage_bytes,
+                           SampleIteratorT d_samples,
+                           CounterT*       d_histogram[NUM_ACTIVE_CHANNELS],
+                           int             num_levels[NUM_ACTIVE_CHANNELS],
+                           LevelT          lower_level[NUM_ACTIVE_CHANNELS],
+                           LevelT          upper_level[NUM_ACTIVE_CHANNELS],
+                           OffsetT         num_pixels,
+                           hipStream_t     stream            = 0,
+                           bool            debug_synchronous = false)
     {
         return hipCUDAErrorTohipError(
             ::cub::DeviceHistogram::MultiHistogramEven<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
-                d_temp_storage, temp_storage_bytes,
+                d_temp_storage,
+                temp_storage_bytes,
                 d_samples,
                 d_histogram,
-                num_levels, lower_level, upper_level,
+                num_levels,
+                lower_level,
+                upper_level,
                 num_pixels,
-                stream, debug_synchronous
-            )
-        );
+                stream,
+                debug_synchronous));
     }
 
-    template<
-        int NUM_CHANNELS,
-        int NUM_ACTIVE_CHANNELS,
-        typename SampleIteratorT,
-        typename CounterT,
-        typename LevelT,
-        typename OffsetT
-    >
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t MultiHistogramEven(void * d_temp_storage,
-                                  size_t& temp_storage_bytes,
-                                  SampleIteratorT d_samples,
-                                  CounterT * d_histogram[NUM_ACTIVE_CHANNELS],
-                                  int num_levels[NUM_ACTIVE_CHANNELS],
-                                  LevelT lower_level[NUM_ACTIVE_CHANNELS],
-                                  LevelT upper_level[NUM_ACTIVE_CHANNELS],
-                                  OffsetT num_row_pixels,
-                                  OffsetT num_rows,
-                                  size_t row_stride_bytes,
-                                  hipStream_t stream = 0,
-                                  bool debug_synchronous = false)
+    template <int NUM_CHANNELS,
+              int NUM_ACTIVE_CHANNELS,
+              typename SampleIteratorT,
+              typename CounterT,
+              typename LevelT,
+              typename OffsetT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t
+        MultiHistogramEven(void*           d_temp_storage,
+                           size_t&         temp_storage_bytes,
+                           SampleIteratorT d_samples,
+                           CounterT*       d_histogram[NUM_ACTIVE_CHANNELS],
+                           int             num_levels[NUM_ACTIVE_CHANNELS],
+                           LevelT          lower_level[NUM_ACTIVE_CHANNELS],
+                           LevelT          upper_level[NUM_ACTIVE_CHANNELS],
+                           OffsetT         num_row_pixels,
+                           OffsetT         num_rows,
+                           size_t          row_stride_bytes,
+                           hipStream_t     stream            = 0,
+                           bool            debug_synchronous = false)
     {
         return hipCUDAErrorTohipError(
             ::cub::DeviceHistogram::MultiHistogramEven<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
-                d_temp_storage, temp_storage_bytes,
+                d_temp_storage,
+                temp_storage_bytes,
                 d_samples,
                 d_histogram,
-                num_levels, lower_level, upper_level,
-                num_row_pixels, num_rows, row_stride_bytes,
-                stream, debug_synchronous
-            )
-        );
+                num_levels,
+                lower_level,
+                upper_level,
+                num_row_pixels,
+                num_rows,
+                row_stride_bytes,
+                stream,
+                debug_synchronous));
     }
 
-    template<
-        typename SampleIteratorT,
-        typename CounterT,
-        typename LevelT,
-        typename OffsetT
-    >
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t HistogramRange(void * d_temp_storage,
-                              size_t& temp_storage_bytes,
-                              SampleIteratorT d_samples,
-                              CounterT * d_histogram,
-                              int num_levels,
-                              LevelT * d_levels,
-                              OffsetT num_samples,
-                              hipStream_t stream = 0,
-                              bool debug_synchronous = false)
+    template <typename SampleIteratorT, typename CounterT, typename LevelT, typename OffsetT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t HistogramRange(void*           d_temp_storage,
+                                                             size_t&         temp_storage_bytes,
+                                                             SampleIteratorT d_samples,
+                                                             CounterT*       d_histogram,
+                                                             int             num_levels,
+                                                             LevelT*         d_levels,
+                                                             OffsetT         num_samples,
+                                                             hipStream_t     stream = 0,
+                                                             bool debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceHistogram::HistogramRange(
-                d_temp_storage, temp_storage_bytes,
-                d_samples,
-                d_histogram,
-                num_levels, d_levels,
-                num_samples,
-                stream, debug_synchronous
-            )
-        );
+        return hipCUDAErrorTohipError(::cub::DeviceHistogram::HistogramRange(d_temp_storage,
+                                                                             temp_storage_bytes,
+                                                                             d_samples,
+                                                                             d_histogram,
+                                                                             num_levels,
+                                                                             d_levels,
+                                                                             num_samples,
+                                                                             stream,
+                                                                             debug_synchronous));
     }
 
-    template<
-        typename SampleIteratorT,
-        typename CounterT,
-        typename LevelT,
-        typename OffsetT
-    >
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t HistogramRange(void * d_temp_storage,
-                              size_t& temp_storage_bytes,
-                              SampleIteratorT d_samples,
-                              CounterT * d_histogram,
-                              int num_levels,
-                              LevelT * d_levels,
-                              OffsetT num_row_samples,
-                              OffsetT num_rows,
-                              size_t row_stride_bytes,
-                              hipStream_t stream = 0,
-                              bool debug_synchronous = false)
+    template <typename SampleIteratorT, typename CounterT, typename LevelT, typename OffsetT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t HistogramRange(void*           d_temp_storage,
+                                                             size_t&         temp_storage_bytes,
+                                                             SampleIteratorT d_samples,
+                                                             CounterT*       d_histogram,
+                                                             int             num_levels,
+                                                             LevelT*         d_levels,
+                                                             OffsetT         num_row_samples,
+                                                             OffsetT         num_rows,
+                                                             size_t          row_stride_bytes,
+                                                             hipStream_t     stream = 0,
+                                                             bool debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceHistogram::HistogramRange(
-                d_temp_storage, temp_storage_bytes,
-                d_samples,
-                d_histogram,
-                num_levels, d_levels,
-                num_row_samples, num_rows, row_stride_bytes,
-                stream, debug_synchronous
-            )
-        );
+        return hipCUDAErrorTohipError(::cub::DeviceHistogram::HistogramRange(d_temp_storage,
+                                                                             temp_storage_bytes,
+                                                                             d_samples,
+                                                                             d_histogram,
+                                                                             num_levels,
+                                                                             d_levels,
+                                                                             num_row_samples,
+                                                                             num_rows,
+                                                                             row_stride_bytes,
+                                                                             stream,
+                                                                             debug_synchronous));
     }
 
-    template<
-        int NUM_CHANNELS,
-        int NUM_ACTIVE_CHANNELS,
-        typename SampleIteratorT,
-        typename CounterT,
-        typename LevelT,
-        typename OffsetT
-    >
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t MultiHistogramRange(void * d_temp_storage,
-                                   size_t& temp_storage_bytes,
-                                   SampleIteratorT d_samples,
-                                   CounterT * d_histogram[NUM_ACTIVE_CHANNELS],
-                                   int num_levels[NUM_ACTIVE_CHANNELS],
-                                   LevelT * d_levels[NUM_ACTIVE_CHANNELS],
-                                   OffsetT num_pixels,
-                                   hipStream_t stream = 0,
-                                   bool debug_synchronous = false)
+    template <int NUM_CHANNELS,
+              int NUM_ACTIVE_CHANNELS,
+              typename SampleIteratorT,
+              typename CounterT,
+              typename LevelT,
+              typename OffsetT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t
+        MultiHistogramRange(void*           d_temp_storage,
+                            size_t&         temp_storage_bytes,
+                            SampleIteratorT d_samples,
+                            CounterT*       d_histogram[NUM_ACTIVE_CHANNELS],
+                            int             num_levels[NUM_ACTIVE_CHANNELS],
+                            LevelT*         d_levels[NUM_ACTIVE_CHANNELS],
+                            OffsetT         num_pixels,
+                            hipStream_t     stream            = 0,
+                            bool            debug_synchronous = false)
     {
         return hipCUDAErrorTohipError(
             ::cub::DeviceHistogram::MultiHistogramRange<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
-                d_temp_storage, temp_storage_bytes,
+                d_temp_storage,
+                temp_storage_bytes,
                 d_samples,
                 d_histogram,
-                num_levels, d_levels,
+                num_levels,
+                d_levels,
                 num_pixels,
-                stream, debug_synchronous
-            )
-        );
+                stream,
+                debug_synchronous));
     }
 
-    template<
-        int NUM_CHANNELS,
-        int NUM_ACTIVE_CHANNELS,
-        typename SampleIteratorT,
-        typename CounterT,
-        typename LevelT,
-        typename OffsetT
-    >
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t MultiHistogramRange(void * d_temp_storage,
-                                   size_t& temp_storage_bytes,
-                                   SampleIteratorT d_samples,
-                                   CounterT * d_histogram[NUM_ACTIVE_CHANNELS],
-                                   int num_levels[NUM_ACTIVE_CHANNELS],
-                                   LevelT * d_levels[NUM_ACTIVE_CHANNELS],
-                                   OffsetT num_row_pixels,
-                                   OffsetT num_rows,
-                                   size_t row_stride_bytes,
-                                   hipStream_t stream = 0,
-                                   bool debug_synchronous = false)
+    template <int NUM_CHANNELS,
+              int NUM_ACTIVE_CHANNELS,
+              typename SampleIteratorT,
+              typename CounterT,
+              typename LevelT,
+              typename OffsetT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t
+        MultiHistogramRange(void*           d_temp_storage,
+                            size_t&         temp_storage_bytes,
+                            SampleIteratorT d_samples,
+                            CounterT*       d_histogram[NUM_ACTIVE_CHANNELS],
+                            int             num_levels[NUM_ACTIVE_CHANNELS],
+                            LevelT*         d_levels[NUM_ACTIVE_CHANNELS],
+                            OffsetT         num_row_pixels,
+                            OffsetT         num_rows,
+                            size_t          row_stride_bytes,
+                            hipStream_t     stream            = 0,
+                            bool            debug_synchronous = false)
     {
         return hipCUDAErrorTohipError(
             ::cub::DeviceHistogram::MultiHistogramRange<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
-                d_temp_storage, temp_storage_bytes,
+                d_temp_storage,
+                temp_storage_bytes,
                 d_samples,
                 d_histogram,
-                num_levels, d_levels,
-                num_row_pixels, num_rows, row_stride_bytes,
-                stream, debug_synchronous
-            )
-        );
+                num_levels,
+                d_levels,
+                num_row_pixels,
+                num_rows,
+                row_stride_bytes,
+                stream,
+                debug_synchronous));
     }
 };
 

--- a/hipcub/include/hipcub/cub/device/device_radix_sort.hpp
+++ b/hipcub/include/hipcub/cub/device/device_radix_sort.hpp
@@ -38,185 +38,188 @@ BEGIN_HIPCUB_NAMESPACE
 
 struct DeviceRadixSort
 {
-    template<typename KeyT, typename ValueT>
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t SortPairs(void * d_temp_storage,
-                         size_t& temp_storage_bytes,
-                         const KeyT * d_keys_in,
-                         KeyT * d_keys_out,
-                         const ValueT * d_values_in,
-                         ValueT * d_values_out,
-                         int num_items,
-                         int begin_bit = 0,
-                         int end_bit = sizeof(KeyT) * 8,
-                         hipStream_t stream = 0,
-                         bool debug_synchronous = false)
+    template <typename KeyT, typename ValueT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t SortPairs(void*         d_temp_storage,
+                                                        size_t&       temp_storage_bytes,
+                                                        const KeyT*   d_keys_in,
+                                                        KeyT*         d_keys_out,
+                                                        const ValueT* d_values_in,
+                                                        ValueT*       d_values_out,
+                                                        int           num_items,
+                                                        int           begin_bit = 0,
+                                                        int           end_bit   = sizeof(KeyT) * 8,
+                                                        hipStream_t   stream    = 0,
+                                                        bool          debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceRadixSort::SortPairs(
-                d_temp_storage, temp_storage_bytes,
-                d_keys_in, d_keys_out,
-                d_values_in, d_values_out, num_items,
-                begin_bit, end_bit,
-                stream, debug_synchronous
-            )
-        );
+        return hipCUDAErrorTohipError(::cub::DeviceRadixSort::SortPairs(d_temp_storage,
+                                                                        temp_storage_bytes,
+                                                                        d_keys_in,
+                                                                        d_keys_out,
+                                                                        d_values_in,
+                                                                        d_values_out,
+                                                                        num_items,
+                                                                        begin_bit,
+                                                                        end_bit,
+                                                                        stream,
+                                                                        debug_synchronous));
     }
 
-    template<typename KeyT, typename ValueT>
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t SortPairs(void * d_temp_storage,
-                         size_t& temp_storage_bytes,
-                         DoubleBuffer<KeyT>& d_keys,
-                         DoubleBuffer<ValueT>& d_values,
-                         int num_items,
-                         int begin_bit = 0,
-                         int end_bit = sizeof(KeyT) * 8,
-                         hipStream_t stream = 0,
-                         bool debug_synchronous = false)
+    template <typename KeyT, typename ValueT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t SortPairs(void*                 d_temp_storage,
+                                                        size_t&               temp_storage_bytes,
+                                                        DoubleBuffer<KeyT>&   d_keys,
+                                                        DoubleBuffer<ValueT>& d_values,
+                                                        int                   num_items,
+                                                        int                   begin_bit = 0,
+                                                        int         end_bit = sizeof(KeyT) * 8,
+                                                        hipStream_t stream  = 0,
+                                                        bool        debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceRadixSort::SortPairs(
-                d_temp_storage, temp_storage_bytes,
-                d_keys, d_values, num_items,
-                begin_bit, end_bit,
-                stream, debug_synchronous
-            )
-        );
+        return hipCUDAErrorTohipError(::cub::DeviceRadixSort::SortPairs(d_temp_storage,
+                                                                        temp_storage_bytes,
+                                                                        d_keys,
+                                                                        d_values,
+                                                                        num_items,
+                                                                        begin_bit,
+                                                                        end_bit,
+                                                                        stream,
+                                                                        debug_synchronous));
     }
 
-    template<typename KeyT, typename ValueT>
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t SortPairsDescending(void * d_temp_storage,
-                                   size_t& temp_storage_bytes,
-                                   const KeyT * d_keys_in,
-                                   KeyT * d_keys_out,
-                                   const ValueT * d_values_in,
-                                   ValueT * d_values_out,
-                                   int num_items,
-                                   int begin_bit = 0,
-                                   int end_bit = sizeof(KeyT) * 8,
-                                   hipStream_t stream = 0,
-                                   bool debug_synchronous = false)
+    template <typename KeyT, typename ValueT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t SortPairsDescending(void*         d_temp_storage,
+                                                                  size_t&       temp_storage_bytes,
+                                                                  const KeyT*   d_keys_in,
+                                                                  KeyT*         d_keys_out,
+                                                                  const ValueT* d_values_in,
+                                                                  ValueT*       d_values_out,
+                                                                  int           num_items,
+                                                                  int           begin_bit = 0,
+                                                                  int end_bit = sizeof(KeyT) * 8,
+                                                                  hipStream_t stream     = 0,
+                                                                  bool debug_synchronous = false)
     {
         return hipCUDAErrorTohipError(
-            ::cub::DeviceRadixSort::SortPairsDescending(
-                d_temp_storage, temp_storage_bytes,
-                d_keys_in, d_keys_out,
-                d_values_in, d_values_out, num_items,
-                begin_bit, end_bit,
-                stream, debug_synchronous
-            )
-        );
-
+            ::cub::DeviceRadixSort::SortPairsDescending(d_temp_storage,
+                                                        temp_storage_bytes,
+                                                        d_keys_in,
+                                                        d_keys_out,
+                                                        d_values_in,
+                                                        d_values_out,
+                                                        num_items,
+                                                        begin_bit,
+                                                        end_bit,
+                                                        stream,
+                                                        debug_synchronous));
     }
 
-    template<typename KeyT, typename ValueT>
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t SortPairsDescending(void * d_temp_storage,
-                                   size_t& temp_storage_bytes,
-                                   DoubleBuffer<KeyT>& d_keys,
-                                   DoubleBuffer<ValueT>& d_values,
-                                   int num_items,
-                                   int begin_bit = 0,
-                                   int end_bit = sizeof(KeyT) * 8,
-                                   hipStream_t stream = 0,
-                                   bool debug_synchronous = false)
+    template <typename KeyT, typename ValueT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t SortPairsDescending(void*   d_temp_storage,
+                                                                  size_t& temp_storage_bytes,
+                                                                  DoubleBuffer<KeyT>&   d_keys,
+                                                                  DoubleBuffer<ValueT>& d_values,
+                                                                  int                   num_items,
+                                                                  int begin_bit = 0,
+                                                                  int end_bit   = sizeof(KeyT) * 8,
+                                                                  hipStream_t stream     = 0,
+                                                                  bool debug_synchronous = false)
     {
         return hipCUDAErrorTohipError(
-            ::cub::DeviceRadixSort::SortPairsDescending(
-                d_temp_storage, temp_storage_bytes,
-                d_keys, d_values, num_items,
-                begin_bit, end_bit,
-                stream, debug_synchronous
-            )
-        );
+            ::cub::DeviceRadixSort::SortPairsDescending(d_temp_storage,
+                                                        temp_storage_bytes,
+                                                        d_keys,
+                                                        d_values,
+                                                        num_items,
+                                                        begin_bit,
+                                                        end_bit,
+                                                        stream,
+                                                        debug_synchronous));
     }
 
-    template<typename KeyT>
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t SortKeys(void * d_temp_storage,
-                        size_t& temp_storage_bytes,
-                        const KeyT * d_keys_in,
-                        KeyT * d_keys_out,
-                        int num_items,
-                        int begin_bit = 0,
-                        int end_bit = sizeof(KeyT) * 8,
-                        hipStream_t stream = 0,
-                        bool debug_synchronous = false)
+    template <typename KeyT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t SortKeys(void*       d_temp_storage,
+                                                       size_t&     temp_storage_bytes,
+                                                       const KeyT* d_keys_in,
+                                                       KeyT*       d_keys_out,
+                                                       int         num_items,
+                                                       int         begin_bit = 0,
+                                                       int         end_bit   = sizeof(KeyT) * 8,
+                                                       hipStream_t stream    = 0,
+                                                       bool        debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceRadixSort::SortKeys(
-                d_temp_storage, temp_storage_bytes,
-                d_keys_in, d_keys_out, num_items,
-                begin_bit, end_bit,
-                stream, debug_synchronous
-            )
-        );
+        return hipCUDAErrorTohipError(::cub::DeviceRadixSort::SortKeys(d_temp_storage,
+                                                                       temp_storage_bytes,
+                                                                       d_keys_in,
+                                                                       d_keys_out,
+                                                                       num_items,
+                                                                       begin_bit,
+                                                                       end_bit,
+                                                                       stream,
+                                                                       debug_synchronous));
     }
 
-    template<typename KeyT>
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t SortKeys(void * d_temp_storage,
-                        size_t& temp_storage_bytes,
-                        DoubleBuffer<KeyT>& d_keys,
-                        int num_items,
-                        int begin_bit = 0,
-                        int end_bit = sizeof(KeyT) * 8,
-                        hipStream_t stream = 0,
-                        bool debug_synchronous = false)
+    template <typename KeyT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t SortKeys(void*               d_temp_storage,
+                                                       size_t&             temp_storage_bytes,
+                                                       DoubleBuffer<KeyT>& d_keys,
+                                                       int                 num_items,
+                                                       int                 begin_bit = 0,
+                                                       int         end_bit = sizeof(KeyT) * 8,
+                                                       hipStream_t stream  = 0,
+                                                       bool        debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceRadixSort::SortKeys(
-                d_temp_storage, temp_storage_bytes,
-                d_keys, num_items,
-                begin_bit, end_bit,
-                stream, debug_synchronous
-            )
-        );
+        return hipCUDAErrorTohipError(::cub::DeviceRadixSort::SortKeys(d_temp_storage,
+                                                                       temp_storage_bytes,
+                                                                       d_keys,
+                                                                       num_items,
+                                                                       begin_bit,
+                                                                       end_bit,
+                                                                       stream,
+                                                                       debug_synchronous));
     }
 
-    template<typename KeyT>
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t SortKeysDescending(void * d_temp_storage,
-                                  size_t& temp_storage_bytes,
-                                  const KeyT * d_keys_in,
-                                  KeyT * d_keys_out,
-                                  int num_items,
-                                  int begin_bit = 0,
-                                  int end_bit = sizeof(KeyT) * 8,
-                                  hipStream_t stream = 0,
-                                  bool debug_synchronous = false)
+    template <typename KeyT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t SortKeysDescending(void*       d_temp_storage,
+                                                                 size_t&     temp_storage_bytes,
+                                                                 const KeyT* d_keys_in,
+                                                                 KeyT*       d_keys_out,
+                                                                 int         num_items,
+                                                                 int         begin_bit = 0,
+                                                                 int end_bit = sizeof(KeyT) * 8,
+                                                                 hipStream_t stream     = 0,
+                                                                 bool debug_synchronous = false)
     {
         return hipCUDAErrorTohipError(
-            ::cub::DeviceRadixSort::SortKeysDescending(
-                d_temp_storage, temp_storage_bytes,
-                d_keys_in, d_keys_out, num_items,
-                begin_bit, end_bit,
-                stream, debug_synchronous
-            )
-        );
+            ::cub::DeviceRadixSort::SortKeysDescending(d_temp_storage,
+                                                       temp_storage_bytes,
+                                                       d_keys_in,
+                                                       d_keys_out,
+                                                       num_items,
+                                                       begin_bit,
+                                                       end_bit,
+                                                       stream,
+                                                       debug_synchronous));
     }
 
-    template<typename KeyT>
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t SortKeysDescending(void * d_temp_storage,
-                                  size_t& temp_storage_bytes,
-                                  DoubleBuffer<KeyT>& d_keys,
-                                  int num_items,
-                                  int begin_bit = 0,
-                                  int end_bit = sizeof(KeyT) * 8,
-                                  hipStream_t stream = 0,
-                                  bool debug_synchronous = false)
+    template <typename KeyT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t SortKeysDescending(void*   d_temp_storage,
+                                                                 size_t& temp_storage_bytes,
+                                                                 DoubleBuffer<KeyT>& d_keys,
+                                                                 int                 num_items,
+                                                                 int                 begin_bit = 0,
+                                                                 int end_bit = sizeof(KeyT) * 8,
+                                                                 hipStream_t stream     = 0,
+                                                                 bool debug_synchronous = false)
     {
         return hipCUDAErrorTohipError(
-            ::cub::DeviceRadixSort::SortKeysDescending(
-                d_temp_storage, temp_storage_bytes,
-                d_keys, num_items,
-                begin_bit, end_bit,
-                stream, debug_synchronous
-            )
-        );
+            ::cub::DeviceRadixSort::SortKeysDescending(d_temp_storage,
+                                                       temp_storage_bytes,
+                                                       d_keys,
+                                                       num_items,
+                                                       begin_bit,
+                                                       end_bit,
+                                                       stream,
+                                                       debug_synchronous));
     }
 };
 

--- a/hipcub/include/hipcub/cub/device/device_reduce.hpp
+++ b/hipcub/include/hipcub/cub/device/device_reduce.hpp
@@ -39,173 +39,123 @@ BEGIN_HIPCUB_NAMESPACE
 class DeviceReduce
 {
 public:
-    template <
-        typename InputIteratorT,
-        typename OutputIteratorT,
-        typename ReduceOpT,
-        typename T
-    >
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t Reduce(void *d_temp_storage,
-                      size_t &temp_storage_bytes,
-                      InputIteratorT d_in,
-                      OutputIteratorT d_out,
-                      int num_items,
-                      ReduceOpT reduction_op,
-                      T init,
-                      hipStream_t stream = 0,
-                      bool debug_synchronous = false)
+    template <typename InputIteratorT, typename OutputIteratorT, typename ReduceOpT, typename T>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t Reduce(void*           d_temp_storage,
+                                                     size_t&         temp_storage_bytes,
+                                                     InputIteratorT  d_in,
+                                                     OutputIteratorT d_out,
+                                                     int             num_items,
+                                                     ReduceOpT       reduction_op,
+                                                     T               init,
+                                                     hipStream_t     stream            = 0,
+                                                     bool            debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceReduce::Reduce(
-                d_temp_storage, temp_storage_bytes,
-                d_in, d_out, num_items,
-                reduction_op, init,
-                stream, debug_synchronous
-            )
-        );
+        return hipCUDAErrorTohipError(::cub::DeviceReduce::Reduce(d_temp_storage,
+                                                                  temp_storage_bytes,
+                                                                  d_in,
+                                                                  d_out,
+                                                                  num_items,
+                                                                  reduction_op,
+                                                                  init,
+                                                                  stream,
+                                                                  debug_synchronous));
     }
 
-    template <
-        typename InputIteratorT,
-        typename OutputIteratorT
-    >
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t Sum(void *d_temp_storage,
-                   size_t &temp_storage_bytes,
-                   InputIteratorT d_in,
-                   OutputIteratorT d_out,
-                   int num_items,
-                   hipStream_t stream = 0,
-                   bool debug_synchronous = false)
+    template <typename InputIteratorT, typename OutputIteratorT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t Sum(void*           d_temp_storage,
+                                                  size_t&         temp_storage_bytes,
+                                                  InputIteratorT  d_in,
+                                                  OutputIteratorT d_out,
+                                                  int             num_items,
+                                                  hipStream_t     stream            = 0,
+                                                  bool            debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceReduce::Sum(
-                d_temp_storage, temp_storage_bytes,
-                d_in, d_out, num_items,
-                stream, debug_synchronous
-            )
-        );
+        return hipCUDAErrorTohipError(::cub::DeviceReduce::Sum(
+            d_temp_storage, temp_storage_bytes, d_in, d_out, num_items, stream, debug_synchronous));
     }
 
-    template <
-        typename InputIteratorT,
-        typename OutputIteratorT
-    >
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t Min(void *d_temp_storage,
-                   size_t &temp_storage_bytes,
-                   InputIteratorT d_in,
-                   OutputIteratorT d_out,
-                   int num_items,
-                   hipStream_t stream = 0,
-                   bool debug_synchronous = false)
+    template <typename InputIteratorT, typename OutputIteratorT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t Min(void*           d_temp_storage,
+                                                  size_t&         temp_storage_bytes,
+                                                  InputIteratorT  d_in,
+                                                  OutputIteratorT d_out,
+                                                  int             num_items,
+                                                  hipStream_t     stream            = 0,
+                                                  bool            debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceReduce::Min(
-                d_temp_storage, temp_storage_bytes,
-                d_in, d_out, num_items,
-                stream, debug_synchronous
-            )
-        );
+        return hipCUDAErrorTohipError(::cub::DeviceReduce::Min(
+            d_temp_storage, temp_storage_bytes, d_in, d_out, num_items, stream, debug_synchronous));
     }
 
-    template <
-        typename InputIteratorT,
-        typename OutputIteratorT
-    >
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t ArgMin(void *d_temp_storage,
-                      size_t &temp_storage_bytes,
-                      InputIteratorT d_in,
-                      OutputIteratorT d_out,
-                      int num_items,
-                      hipStream_t stream = 0,
-                      bool debug_synchronous = false)
+    template <typename InputIteratorT, typename OutputIteratorT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t ArgMin(void*           d_temp_storage,
+                                                     size_t&         temp_storage_bytes,
+                                                     InputIteratorT  d_in,
+                                                     OutputIteratorT d_out,
+                                                     int             num_items,
+                                                     hipStream_t     stream            = 0,
+                                                     bool            debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceReduce::ArgMin(
-                d_temp_storage, temp_storage_bytes,
-                d_in, d_out, num_items,
-                stream, debug_synchronous
-            )
-        );
+        return hipCUDAErrorTohipError(::cub::DeviceReduce::ArgMin(
+            d_temp_storage, temp_storage_bytes, d_in, d_out, num_items, stream, debug_synchronous));
     }
 
-    template <
-        typename InputIteratorT,
-        typename OutputIteratorT
-    >
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t Max(void *d_temp_storage,
-                   size_t &temp_storage_bytes,
-                   InputIteratorT d_in,
-                   OutputIteratorT d_out,
-                   int num_items,
-                   hipStream_t stream = 0,
-                   bool debug_synchronous = false)
+    template <typename InputIteratorT, typename OutputIteratorT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t Max(void*           d_temp_storage,
+                                                  size_t&         temp_storage_bytes,
+                                                  InputIteratorT  d_in,
+                                                  OutputIteratorT d_out,
+                                                  int             num_items,
+                                                  hipStream_t     stream            = 0,
+                                                  bool            debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceReduce::Max(
-                d_temp_storage, temp_storage_bytes,
-                d_in, d_out, num_items,
-                stream, debug_synchronous
-            )
-        );
+        return hipCUDAErrorTohipError(::cub::DeviceReduce::Max(
+            d_temp_storage, temp_storage_bytes, d_in, d_out, num_items, stream, debug_synchronous));
     }
 
-    template <
-        typename InputIteratorT,
-        typename OutputIteratorT
-    >
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t ArgMax(void *d_temp_storage,
-                      size_t &temp_storage_bytes,
-                      InputIteratorT d_in,
-                      OutputIteratorT d_out,
-                      int num_items,
-                      hipStream_t stream = 0,
-                      bool debug_synchronous = false)
+    template <typename InputIteratorT, typename OutputIteratorT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t ArgMax(void*           d_temp_storage,
+                                                     size_t&         temp_storage_bytes,
+                                                     InputIteratorT  d_in,
+                                                     OutputIteratorT d_out,
+                                                     int             num_items,
+                                                     hipStream_t     stream            = 0,
+                                                     bool            debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceReduce::ArgMax(
-                d_temp_storage, temp_storage_bytes,
-                d_in, d_out, num_items,
-                stream, debug_synchronous
-            )
-        );
+        return hipCUDAErrorTohipError(::cub::DeviceReduce::ArgMax(
+            d_temp_storage, temp_storage_bytes, d_in, d_out, num_items, stream, debug_synchronous));
     }
 
-    template<
-        typename KeysInputIteratorT,
-        typename UniqueOutputIteratorT,
-        typename ValuesInputIteratorT,
-        typename AggregatesOutputIteratorT,
-        typename NumRunsOutputIteratorT,
-        typename ReductionOpT
-    >
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t ReduceByKey(void * d_temp_storage,
-                           size_t& temp_storage_bytes,
-                           KeysInputIteratorT d_keys_in,
-                           UniqueOutputIteratorT d_unique_out,
-                           ValuesInputIteratorT d_values_in,
-                           AggregatesOutputIteratorT d_aggregates_out,
-                           NumRunsOutputIteratorT d_num_runs_out,
-                           ReductionOpT reduction_op,
-                           int num_items,
-                           hipStream_t stream = 0,
-                           bool debug_synchronous = false)
+    template <typename KeysInputIteratorT,
+              typename UniqueOutputIteratorT,
+              typename ValuesInputIteratorT,
+              typename AggregatesOutputIteratorT,
+              typename NumRunsOutputIteratorT,
+              typename ReductionOpT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t
+        ReduceByKey(void*                     d_temp_storage,
+                    size_t&                   temp_storage_bytes,
+                    KeysInputIteratorT        d_keys_in,
+                    UniqueOutputIteratorT     d_unique_out,
+                    ValuesInputIteratorT      d_values_in,
+                    AggregatesOutputIteratorT d_aggregates_out,
+                    NumRunsOutputIteratorT    d_num_runs_out,
+                    ReductionOpT              reduction_op,
+                    int                       num_items,
+                    hipStream_t               stream            = 0,
+                    bool                      debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceReduce::ReduceByKey(
-                d_temp_storage, temp_storage_bytes,
-                d_keys_in, d_unique_out,
-                d_values_in, d_aggregates_out,
-                d_num_runs_out, reduction_op, num_items,
-                stream, debug_synchronous
-            )
-        );
+        return hipCUDAErrorTohipError(::cub::DeviceReduce::ReduceByKey(d_temp_storage,
+                                                                       temp_storage_bytes,
+                                                                       d_keys_in,
+                                                                       d_unique_out,
+                                                                       d_values_in,
+                                                                       d_aggregates_out,
+                                                                       d_num_runs_out,
+                                                                       reduction_op,
+                                                                       num_items,
+                                                                       stream,
+                                                                       debug_synchronous));
     }
 };
 

--- a/hipcub/include/hipcub/cub/device/device_run_length_encode.hpp
+++ b/hipcub/include/hipcub/cub/device/device_run_length_encode.hpp
@@ -39,60 +39,55 @@ BEGIN_HIPCUB_NAMESPACE
 class DeviceRunLengthEncode
 {
 public:
-    template<
-        typename InputIteratorT,
-        typename UniqueOutputIteratorT,
-        typename LengthsOutputIteratorT,
-        typename NumRunsOutputIteratorT
-    >
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t Encode(void * d_temp_storage,
-                      size_t& temp_storage_bytes,
-                      InputIteratorT d_in,
-                      UniqueOutputIteratorT d_unique_out,
-                      LengthsOutputIteratorT d_counts_out,
-                      NumRunsOutputIteratorT d_num_runs_out,
-                      int num_items,
-                      hipStream_t stream = 0,
-                      bool debug_synchronous = false)
+    template <typename InputIteratorT,
+              typename UniqueOutputIteratorT,
+              typename LengthsOutputIteratorT,
+              typename NumRunsOutputIteratorT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t Encode(void*                  d_temp_storage,
+                                                     size_t&                temp_storage_bytes,
+                                                     InputIteratorT         d_in,
+                                                     UniqueOutputIteratorT  d_unique_out,
+                                                     LengthsOutputIteratorT d_counts_out,
+                                                     NumRunsOutputIteratorT d_num_runs_out,
+                                                     int                    num_items,
+                                                     hipStream_t            stream = 0,
+                                                     bool debug_synchronous        = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceRunLengthEncode::Encode(
-                d_temp_storage, temp_storage_bytes,
-                d_in,
-                d_unique_out, d_counts_out, d_num_runs_out,
-                num_items,
-                stream, debug_synchronous
-            )
-        );
+        return hipCUDAErrorTohipError(::cub::DeviceRunLengthEncode::Encode(d_temp_storage,
+                                                                           temp_storage_bytes,
+                                                                           d_in,
+                                                                           d_unique_out,
+                                                                           d_counts_out,
+                                                                           d_num_runs_out,
+                                                                           num_items,
+                                                                           stream,
+                                                                           debug_synchronous));
     }
 
-    template<
-        typename InputIteratorT,
-        typename OffsetsOutputIteratorT,
-        typename LengthsOutputIteratorT,
-        typename NumRunsOutputIteratorT
-    >
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t NonTrivialRuns(void * d_temp_storage,
-                              size_t& temp_storage_bytes,
-                              InputIteratorT d_in,
-                              OffsetsOutputIteratorT d_offsets_out,
-                              LengthsOutputIteratorT d_lengths_out,
-                              NumRunsOutputIteratorT d_num_runs_out,
-                              int num_items,
-                              hipStream_t stream = 0,
-                              bool debug_synchronous = false)
+    template <typename InputIteratorT,
+              typename OffsetsOutputIteratorT,
+              typename LengthsOutputIteratorT,
+              typename NumRunsOutputIteratorT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t NonTrivialRuns(void*          d_temp_storage,
+                                                             size_t&        temp_storage_bytes,
+                                                             InputIteratorT d_in,
+                                                             OffsetsOutputIteratorT d_offsets_out,
+                                                             LengthsOutputIteratorT d_lengths_out,
+                                                             NumRunsOutputIteratorT d_num_runs_out,
+                                                             int                    num_items,
+                                                             hipStream_t            stream = 0,
+                                                             bool debug_synchronous        = false)
     {
         return hipCUDAErrorTohipError(
-            ::cub::DeviceRunLengthEncode::NonTrivialRuns(
-                d_temp_storage, temp_storage_bytes,
-                d_in,
-                d_offsets_out, d_lengths_out, d_num_runs_out,
-                num_items,
-                stream, debug_synchronous
-            )
-        );
+            ::cub::DeviceRunLengthEncode::NonTrivialRuns(d_temp_storage,
+                                                         temp_storage_bytes,
+                                                         d_in,
+                                                         d_offsets_out,
+                                                         d_lengths_out,
+                                                         d_num_runs_out,
+                                                         num_items,
+                                                         stream,
+                                                         debug_synchronous));
     }
 };
 

--- a/hipcub/include/hipcub/cub/device/device_scan.hpp
+++ b/hipcub/include/hipcub/cub/device/device_scan.hpp
@@ -39,98 +39,75 @@ BEGIN_HIPCUB_NAMESPACE
 class DeviceScan
 {
 public:
-    template <
-        typename InputIteratorT,
-        typename OutputIteratorT
-    >
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t InclusiveSum(void *d_temp_storage,
-                            size_t &temp_storage_bytes,
-                            InputIteratorT d_in,
-                            OutputIteratorT d_out,
-                            int num_items,
-                            hipStream_t stream = 0,
-                            bool debug_synchronous = false)
+    template <typename InputIteratorT, typename OutputIteratorT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t InclusiveSum(void*           d_temp_storage,
+                                                           size_t&         temp_storage_bytes,
+                                                           InputIteratorT  d_in,
+                                                           OutputIteratorT d_out,
+                                                           int             num_items,
+                                                           hipStream_t     stream = 0,
+                                                           bool debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceScan::InclusiveSum(
-                d_temp_storage, temp_storage_bytes,
-                d_in, d_out, num_items,
-                stream, debug_synchronous
-            )
-        );
+        return hipCUDAErrorTohipError(::cub::DeviceScan::InclusiveSum(
+            d_temp_storage, temp_storage_bytes, d_in, d_out, num_items, stream, debug_synchronous));
     }
 
-    template <
-        typename InputIteratorT,
-        typename OutputIteratorT,
-        typename ScanOpT
-    >
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t InclusiveScan(void *d_temp_storage,
-                             size_t &temp_storage_bytes,
-                             InputIteratorT d_in,
-                             OutputIteratorT d_out,
-                             ScanOpT scan_op,
-                             int num_items,
-                             hipStream_t stream = 0,
-                             bool debug_synchronous = false)
+    template <typename InputIteratorT, typename OutputIteratorT, typename ScanOpT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t InclusiveScan(void*           d_temp_storage,
+                                                            size_t&         temp_storage_bytes,
+                                                            InputIteratorT  d_in,
+                                                            OutputIteratorT d_out,
+                                                            ScanOpT         scan_op,
+                                                            int             num_items,
+                                                            hipStream_t     stream = 0,
+                                                            bool debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceScan::InclusiveScan(
-                d_temp_storage, temp_storage_bytes,
-                d_in, d_out, scan_op, num_items,
-                stream, debug_synchronous
-            )
-        );
+        return hipCUDAErrorTohipError(::cub::DeviceScan::InclusiveScan(d_temp_storage,
+                                                                       temp_storage_bytes,
+                                                                       d_in,
+                                                                       d_out,
+                                                                       scan_op,
+                                                                       num_items,
+                                                                       stream,
+                                                                       debug_synchronous));
     }
 
-    template <
-        typename InputIteratorT,
-        typename OutputIteratorT
-    >
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t ExclusiveSum(void *d_temp_storage,
-                            size_t &temp_storage_bytes,
-                            InputIteratorT d_in,
-                            OutputIteratorT d_out,
-                            int num_items,
-                            hipStream_t stream = 0,
-                            bool debug_synchronous = false)
+    template <typename InputIteratorT, typename OutputIteratorT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t ExclusiveSum(void*           d_temp_storage,
+                                                           size_t&         temp_storage_bytes,
+                                                           InputIteratorT  d_in,
+                                                           OutputIteratorT d_out,
+                                                           int             num_items,
+                                                           hipStream_t     stream = 0,
+                                                           bool debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceScan::ExclusiveSum(
-                d_temp_storage, temp_storage_bytes,
-                d_in, d_out, num_items,
-                stream, debug_synchronous
-            )
-        );
+        return hipCUDAErrorTohipError(::cub::DeviceScan::ExclusiveSum(
+            d_temp_storage, temp_storage_bytes, d_in, d_out, num_items, stream, debug_synchronous));
     }
 
-    template <
-        typename InputIteratorT,
-        typename OutputIteratorT,
-        typename ScanOpT,
-        typename InitValueT
-    >
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t ExclusiveScan(void *d_temp_storage,
-                             size_t &temp_storage_bytes,
-                             InputIteratorT d_in,
-                             OutputIteratorT d_out,
-                             ScanOpT scan_op,
-                             InitValueT init_value,
-                             int num_items,
-                             hipStream_t stream = 0,
-                             bool debug_synchronous = false)
+    template <typename InputIteratorT,
+              typename OutputIteratorT,
+              typename ScanOpT,
+              typename InitValueT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t ExclusiveScan(void*           d_temp_storage,
+                                                            size_t&         temp_storage_bytes,
+                                                            InputIteratorT  d_in,
+                                                            OutputIteratorT d_out,
+                                                            ScanOpT         scan_op,
+                                                            InitValueT      init_value,
+                                                            int             num_items,
+                                                            hipStream_t     stream = 0,
+                                                            bool debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceScan::ExclusiveScan(
-                d_temp_storage, temp_storage_bytes,
-                d_in, d_out, scan_op, init_value, num_items,
-                stream, debug_synchronous
-            )
-        );
+        return hipCUDAErrorTohipError(::cub::DeviceScan::ExclusiveScan(d_temp_storage,
+                                                                       temp_storage_bytes,
+                                                                       d_in,
+                                                                       d_out,
+                                                                       scan_op,
+                                                                       init_value,
+                                                                       num_items,
+                                                                       stream,
+                                                                       debug_synchronous));
     }
 };
 

--- a/hipcub/include/hipcub/cub/device/device_segmented_radix_sort.hpp
+++ b/hipcub/include/hipcub/cub/device/device_segmented_radix_sort.hpp
@@ -38,224 +38,238 @@ BEGIN_HIPCUB_NAMESPACE
 
 struct DeviceSegmentedRadixSort
 {
-    template<typename KeyT, typename ValueT, typename OffsetIteratorT>
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t SortPairs(void * d_temp_storage,
-                         size_t& temp_storage_bytes,
-                         const KeyT * d_keys_in,
-                         KeyT * d_keys_out,
-                         const ValueT * d_values_in,
-                         ValueT * d_values_out,
-                         int num_items,
-                         int num_segments,
-                         OffsetIteratorT d_begin_offsets,
-                         OffsetIteratorT d_end_offsets,
-                         int begin_bit = 0,
-                         int end_bit = sizeof(KeyT) * 8,
-                         hipStream_t stream = 0,
-                         bool debug_synchronous = false)
+    template <typename KeyT, typename ValueT, typename OffsetIteratorT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t SortPairs(void*           d_temp_storage,
+                                                        size_t&         temp_storage_bytes,
+                                                        const KeyT*     d_keys_in,
+                                                        KeyT*           d_keys_out,
+                                                        const ValueT*   d_values_in,
+                                                        ValueT*         d_values_out,
+                                                        int             num_items,
+                                                        int             num_segments,
+                                                        OffsetIteratorT d_begin_offsets,
+                                                        OffsetIteratorT d_end_offsets,
+                                                        int             begin_bit = 0,
+                                                        int             end_bit = sizeof(KeyT) * 8,
+                                                        hipStream_t     stream  = 0,
+                                                        bool            debug_synchronous = false)
     {
         return hipCUDAErrorTohipError(
-            ::cub::DeviceSegmentedRadixSort::SortPairs(
-                d_temp_storage, temp_storage_bytes,
-                d_keys_in, d_keys_out,
-                d_values_in, d_values_out,
-                num_items, num_segments,
-                d_begin_offsets, d_end_offsets,
-                begin_bit, end_bit,
-                stream, debug_synchronous
-            )
-        );
+            ::cub::DeviceSegmentedRadixSort::SortPairs(d_temp_storage,
+                                                       temp_storage_bytes,
+                                                       d_keys_in,
+                                                       d_keys_out,
+                                                       d_values_in,
+                                                       d_values_out,
+                                                       num_items,
+                                                       num_segments,
+                                                       d_begin_offsets,
+                                                       d_end_offsets,
+                                                       begin_bit,
+                                                       end_bit,
+                                                       stream,
+                                                       debug_synchronous));
     }
 
-    template<typename KeyT, typename ValueT, typename OffsetIteratorT>
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t SortPairs(void * d_temp_storage,
-                         size_t& temp_storage_bytes,
-                         DoubleBuffer<KeyT>& d_keys,
-                         DoubleBuffer<ValueT>& d_values,
-                         int num_items,
-                         int num_segments,
-                         OffsetIteratorT d_begin_offsets,
-                         OffsetIteratorT d_end_offsets,
-                         int begin_bit = 0,
-                         int end_bit = sizeof(KeyT) * 8,
-                         hipStream_t stream = 0,
-                         bool debug_synchronous = false)
+    template <typename KeyT, typename ValueT, typename OffsetIteratorT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t SortPairs(void*                 d_temp_storage,
+                                                        size_t&               temp_storage_bytes,
+                                                        DoubleBuffer<KeyT>&   d_keys,
+                                                        DoubleBuffer<ValueT>& d_values,
+                                                        int                   num_items,
+                                                        int                   num_segments,
+                                                        OffsetIteratorT       d_begin_offsets,
+                                                        OffsetIteratorT       d_end_offsets,
+                                                        int                   begin_bit = 0,
+                                                        int         end_bit = sizeof(KeyT) * 8,
+                                                        hipStream_t stream  = 0,
+                                                        bool        debug_synchronous = false)
     {
         return hipCUDAErrorTohipError(
-            ::cub::DeviceSegmentedRadixSort::SortPairs(
-                d_temp_storage, temp_storage_bytes,
-                d_keys, d_values,
-                num_items, num_segments,
-                d_begin_offsets, d_end_offsets,
-                begin_bit, end_bit,
-                stream, debug_synchronous
-            )
-        );
+            ::cub::DeviceSegmentedRadixSort::SortPairs(d_temp_storage,
+                                                       temp_storage_bytes,
+                                                       d_keys,
+                                                       d_values,
+                                                       num_items,
+                                                       num_segments,
+                                                       d_begin_offsets,
+                                                       d_end_offsets,
+                                                       begin_bit,
+                                                       end_bit,
+                                                       stream,
+                                                       debug_synchronous));
     }
 
-    template<typename KeyT, typename ValueT, typename OffsetIteratorT>
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t SortPairsDescending(void * d_temp_storage,
-                                   size_t& temp_storage_bytes,
-                                   const KeyT * d_keys_in,
-                                   KeyT * d_keys_out,
-                                   const ValueT * d_values_in,
-                                   ValueT * d_values_out,
-                                   int num_items,
-                                   int num_segments,
-                                   OffsetIteratorT d_begin_offsets,
-                                   OffsetIteratorT d_end_offsets,
-                                   int begin_bit = 0,
-                                   int end_bit = sizeof(KeyT) * 8,
-                                   hipStream_t stream = 0,
-                                   bool debug_synchronous = false)
+    template <typename KeyT, typename ValueT, typename OffsetIteratorT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t SortPairsDescending(void*         d_temp_storage,
+                                                                  size_t&       temp_storage_bytes,
+                                                                  const KeyT*   d_keys_in,
+                                                                  KeyT*         d_keys_out,
+                                                                  const ValueT* d_values_in,
+                                                                  ValueT*       d_values_out,
+                                                                  int           num_items,
+                                                                  int           num_segments,
+                                                                  OffsetIteratorT d_begin_offsets,
+                                                                  OffsetIteratorT d_end_offsets,
+                                                                  int             begin_bit = 0,
+                                                                  int end_bit = sizeof(KeyT) * 8,
+                                                                  hipStream_t stream     = 0,
+                                                                  bool debug_synchronous = false)
     {
         return hipCUDAErrorTohipError(
-            ::cub::DeviceSegmentedRadixSort::SortPairsDescending(
-                d_temp_storage, temp_storage_bytes,
-                d_keys_in, d_keys_out,
-                d_values_in, d_values_out,
-                num_items, num_segments,
-                d_begin_offsets, d_end_offsets,
-                begin_bit, end_bit,
-                stream, debug_synchronous
-            )
-        );
+            ::cub::DeviceSegmentedRadixSort::SortPairsDescending(d_temp_storage,
+                                                                 temp_storage_bytes,
+                                                                 d_keys_in,
+                                                                 d_keys_out,
+                                                                 d_values_in,
+                                                                 d_values_out,
+                                                                 num_items,
+                                                                 num_segments,
+                                                                 d_begin_offsets,
+                                                                 d_end_offsets,
+                                                                 begin_bit,
+                                                                 end_bit,
+                                                                 stream,
+                                                                 debug_synchronous));
     }
 
-    template<typename KeyT, typename ValueT, typename OffsetIteratorT>
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t SortPairsDescending(void * d_temp_storage,
-                                   size_t& temp_storage_bytes,
-                                   DoubleBuffer<KeyT>& d_keys,
-                                   DoubleBuffer<ValueT>& d_values,
-                                   int num_items,
-                                   int num_segments,
-                                   OffsetIteratorT d_begin_offsets,
-                                   OffsetIteratorT d_end_offsets,
-                                   int begin_bit = 0,
-                                   int end_bit = sizeof(KeyT) * 8,
-                                   hipStream_t stream = 0,
-                                   bool debug_synchronous = false)
+    template <typename KeyT, typename ValueT, typename OffsetIteratorT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t SortPairsDescending(void*   d_temp_storage,
+                                                                  size_t& temp_storage_bytes,
+                                                                  DoubleBuffer<KeyT>&   d_keys,
+                                                                  DoubleBuffer<ValueT>& d_values,
+                                                                  int                   num_items,
+                                                                  int             num_segments,
+                                                                  OffsetIteratorT d_begin_offsets,
+                                                                  OffsetIteratorT d_end_offsets,
+                                                                  int             begin_bit = 0,
+                                                                  int end_bit = sizeof(KeyT) * 8,
+                                                                  hipStream_t stream     = 0,
+                                                                  bool debug_synchronous = false)
     {
         return hipCUDAErrorTohipError(
-            ::cub::DeviceSegmentedRadixSort::SortPairsDescending(
-                d_temp_storage, temp_storage_bytes,
-                d_keys, d_values,
-                num_items, num_segments,
-                d_begin_offsets, d_end_offsets,
-                begin_bit, end_bit,
-                stream, debug_synchronous
-            )
-        );
+            ::cub::DeviceSegmentedRadixSort::SortPairsDescending(d_temp_storage,
+                                                                 temp_storage_bytes,
+                                                                 d_keys,
+                                                                 d_values,
+                                                                 num_items,
+                                                                 num_segments,
+                                                                 d_begin_offsets,
+                                                                 d_end_offsets,
+                                                                 begin_bit,
+                                                                 end_bit,
+                                                                 stream,
+                                                                 debug_synchronous));
     }
 
-    template<typename KeyT, typename OffsetIteratorT>
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t SortKeys(void * d_temp_storage,
-                        size_t& temp_storage_bytes,
-                        const KeyT * d_keys_in,
-                        KeyT * d_keys_out,
-                        int num_items,
-                        int num_segments,
-                        OffsetIteratorT d_begin_offsets,
-                        OffsetIteratorT d_end_offsets,
-                        int begin_bit = 0,
-                        int end_bit = sizeof(KeyT) * 8,
-                        hipStream_t stream = 0,
-                        bool debug_synchronous = false)
+    template <typename KeyT, typename OffsetIteratorT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t SortKeys(void*           d_temp_storage,
+                                                       size_t&         temp_storage_bytes,
+                                                       const KeyT*     d_keys_in,
+                                                       KeyT*           d_keys_out,
+                                                       int             num_items,
+                                                       int             num_segments,
+                                                       OffsetIteratorT d_begin_offsets,
+                                                       OffsetIteratorT d_end_offsets,
+                                                       int             begin_bit = 0,
+                                                       int             end_bit   = sizeof(KeyT) * 8,
+                                                       hipStream_t     stream    = 0,
+                                                       bool            debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceSegmentedRadixSort::SortKeys(
-                d_temp_storage, temp_storage_bytes,
-                d_keys_in, d_keys_out,
-                num_items, num_segments,
-                d_begin_offsets, d_end_offsets,
-                begin_bit, end_bit,
-                stream, debug_synchronous
-            )
-        );
+        return hipCUDAErrorTohipError(::cub::DeviceSegmentedRadixSort::SortKeys(d_temp_storage,
+                                                                                temp_storage_bytes,
+                                                                                d_keys_in,
+                                                                                d_keys_out,
+                                                                                num_items,
+                                                                                num_segments,
+                                                                                d_begin_offsets,
+                                                                                d_end_offsets,
+                                                                                begin_bit,
+                                                                                end_bit,
+                                                                                stream,
+                                                                                debug_synchronous));
     }
 
-    template<typename KeyT, typename OffsetIteratorT>
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t SortKeys(void * d_temp_storage,
-                        size_t& temp_storage_bytes,
-                        DoubleBuffer<KeyT>& d_keys,
-                        int num_items,
-                        int num_segments,
-                        OffsetIteratorT d_begin_offsets,
-                        OffsetIteratorT d_end_offsets,
-                        int begin_bit = 0,
-                        int end_bit = sizeof(KeyT) * 8,
-                        hipStream_t stream = 0,
-                        bool debug_synchronous = false)
+    template <typename KeyT, typename OffsetIteratorT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t SortKeys(void*               d_temp_storage,
+                                                       size_t&             temp_storage_bytes,
+                                                       DoubleBuffer<KeyT>& d_keys,
+                                                       int                 num_items,
+                                                       int                 num_segments,
+                                                       OffsetIteratorT     d_begin_offsets,
+                                                       OffsetIteratorT     d_end_offsets,
+                                                       int                 begin_bit = 0,
+                                                       int         end_bit = sizeof(KeyT) * 8,
+                                                       hipStream_t stream  = 0,
+                                                       bool        debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceSegmentedRadixSort::SortKeys(
-                d_temp_storage, temp_storage_bytes,
-                d_keys,
-                num_items, num_segments,
-                d_begin_offsets, d_end_offsets,
-                begin_bit, end_bit,
-                stream, debug_synchronous
-            )
-        );
+        return hipCUDAErrorTohipError(::cub::DeviceSegmentedRadixSort::SortKeys(d_temp_storage,
+                                                                                temp_storage_bytes,
+                                                                                d_keys,
+                                                                                num_items,
+                                                                                num_segments,
+                                                                                d_begin_offsets,
+                                                                                d_end_offsets,
+                                                                                begin_bit,
+                                                                                end_bit,
+                                                                                stream,
+                                                                                debug_synchronous));
     }
 
-    template<typename KeyT, typename OffsetIteratorT>
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t SortKeysDescending(void * d_temp_storage,
-                                  size_t& temp_storage_bytes,
-                                  const KeyT * d_keys_in,
-                                  KeyT * d_keys_out,
-                                  int num_items,
-                                  int num_segments,
-                                  OffsetIteratorT d_begin_offsets,
-                                  OffsetIteratorT d_end_offsets,
-                                  int begin_bit = 0,
-                                  int end_bit = sizeof(KeyT) * 8,
-                                  hipStream_t stream = 0,
-                                  bool debug_synchronous = false)
+    template <typename KeyT, typename OffsetIteratorT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t SortKeysDescending(void*           d_temp_storage,
+                                                                 size_t&         temp_storage_bytes,
+                                                                 const KeyT*     d_keys_in,
+                                                                 KeyT*           d_keys_out,
+                                                                 int             num_items,
+                                                                 int             num_segments,
+                                                                 OffsetIteratorT d_begin_offsets,
+                                                                 OffsetIteratorT d_end_offsets,
+                                                                 int             begin_bit = 0,
+                                                                 int end_bit = sizeof(KeyT) * 8,
+                                                                 hipStream_t stream     = 0,
+                                                                 bool debug_synchronous = false)
     {
         return hipCUDAErrorTohipError(
-            ::cub::DeviceSegmentedRadixSort::SortKeysDescending(
-                d_temp_storage, temp_storage_bytes,
-                d_keys_in, d_keys_out,
-                num_items, num_segments,
-                d_begin_offsets, d_end_offsets,
-                begin_bit, end_bit,
-                stream, debug_synchronous
-            )
-        );
+            ::cub::DeviceSegmentedRadixSort::SortKeysDescending(d_temp_storage,
+                                                                temp_storage_bytes,
+                                                                d_keys_in,
+                                                                d_keys_out,
+                                                                num_items,
+                                                                num_segments,
+                                                                d_begin_offsets,
+                                                                d_end_offsets,
+                                                                begin_bit,
+                                                                end_bit,
+                                                                stream,
+                                                                debug_synchronous));
     }
 
-    template<typename KeyT, typename OffsetIteratorT>
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t SortKeysDescending(void * d_temp_storage,
-                                  size_t& temp_storage_bytes,
-                                  DoubleBuffer<KeyT>& d_keys,
-                                  int num_items,
-                                  int num_segments,
-                                  OffsetIteratorT d_begin_offsets,
-                                  OffsetIteratorT d_end_offsets,
-                                  int begin_bit = 0,
-                                  int end_bit = sizeof(KeyT) * 8,
-                                  hipStream_t stream = 0,
-                                  bool debug_synchronous = false)
+    template <typename KeyT, typename OffsetIteratorT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t SortKeysDescending(void*   d_temp_storage,
+                                                                 size_t& temp_storage_bytes,
+                                                                 DoubleBuffer<KeyT>& d_keys,
+                                                                 int                 num_items,
+                                                                 int                 num_segments,
+                                                                 OffsetIteratorT d_begin_offsets,
+                                                                 OffsetIteratorT d_end_offsets,
+                                                                 int             begin_bit = 0,
+                                                                 int end_bit = sizeof(KeyT) * 8,
+                                                                 hipStream_t stream     = 0,
+                                                                 bool debug_synchronous = false)
     {
         return hipCUDAErrorTohipError(
-            ::cub::DeviceSegmentedRadixSort::SortKeysDescending(
-                d_temp_storage, temp_storage_bytes,
-                d_keys,
-                num_items, num_segments,
-                d_begin_offsets, d_end_offsets,
-                begin_bit, end_bit,
-                stream, debug_synchronous
-            )
-        );
+            ::cub::DeviceSegmentedRadixSort::SortKeysDescending(d_temp_storage,
+                                                                temp_storage_bytes,
+                                                                d_keys,
+                                                                num_items,
+                                                                num_segments,
+                                                                d_begin_offsets,
+                                                                d_end_offsets,
+                                                                begin_bit,
+                                                                end_bit,
+                                                                stream,
+                                                                debug_synchronous));
     }
 };
 

--- a/hipcub/include/hipcub/cub/device/device_segmented_reduce.hpp
+++ b/hipcub/include/hipcub/cub/device/device_segmented_reduce.hpp
@@ -38,165 +38,144 @@ BEGIN_HIPCUB_NAMESPACE
 
 struct DeviceSegmentedReduce
 {
-    template<
-        typename InputIteratorT,
-        typename OutputIteratorT,
-        typename OffsetIteratorT,
-        typename ReductionOp,
-        typename T
-    >
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t Reduce(void * d_temp_storage,
-                      size_t& temp_storage_bytes,
-                      InputIteratorT d_in,
-                      OutputIteratorT d_out,
-                      int num_segments,
-                      OffsetIteratorT d_begin_offsets,
-                      OffsetIteratorT d_end_offsets,
-                      ReductionOp reduction_op,
-                      T initial_value,
-                      hipStream_t stream = 0,
-                      bool debug_synchronous = false)
+    template <typename InputIteratorT,
+              typename OutputIteratorT,
+              typename OffsetIteratorT,
+              typename ReductionOp,
+              typename T>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t Reduce(void*           d_temp_storage,
+                                                     size_t&         temp_storage_bytes,
+                                                     InputIteratorT  d_in,
+                                                     OutputIteratorT d_out,
+                                                     int             num_segments,
+                                                     OffsetIteratorT d_begin_offsets,
+                                                     OffsetIteratorT d_end_offsets,
+                                                     ReductionOp     reduction_op,
+                                                     T               initial_value,
+                                                     hipStream_t     stream            = 0,
+                                                     bool            debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceSegmentedReduce::Reduce(
-                d_temp_storage, temp_storage_bytes,
-                d_in, d_out, num_segments,
-                d_begin_offsets, d_end_offsets,
-                reduction_op, initial_value,
-                stream, debug_synchronous
-            )
-        );
+        return hipCUDAErrorTohipError(::cub::DeviceSegmentedReduce::Reduce(d_temp_storage,
+                                                                           temp_storage_bytes,
+                                                                           d_in,
+                                                                           d_out,
+                                                                           num_segments,
+                                                                           d_begin_offsets,
+                                                                           d_end_offsets,
+                                                                           reduction_op,
+                                                                           initial_value,
+                                                                           stream,
+                                                                           debug_synchronous));
     }
 
-    template<
-        typename InputIteratorT,
-        typename OutputIteratorT,
-        typename OffsetIteratorT
-    >
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t Sum(void * d_temp_storage,
-                   size_t& temp_storage_bytes,
-                   InputIteratorT d_in,
-                   OutputIteratorT d_out,
-                   int num_segments,
-                   OffsetIteratorT d_begin_offsets,
-                   OffsetIteratorT d_end_offsets,
-                   hipStream_t stream = 0,
-                   bool debug_synchronous = false)
+    template <typename InputIteratorT, typename OutputIteratorT, typename OffsetIteratorT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t Sum(void*           d_temp_storage,
+                                                  size_t&         temp_storage_bytes,
+                                                  InputIteratorT  d_in,
+                                                  OutputIteratorT d_out,
+                                                  int             num_segments,
+                                                  OffsetIteratorT d_begin_offsets,
+                                                  OffsetIteratorT d_end_offsets,
+                                                  hipStream_t     stream            = 0,
+                                                  bool            debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceSegmentedReduce::Sum(
-                d_temp_storage, temp_storage_bytes,
-                d_in, d_out, num_segments,
-                d_begin_offsets, d_end_offsets,
-                stream, debug_synchronous
-            )
-        );
+        return hipCUDAErrorTohipError(::cub::DeviceSegmentedReduce::Sum(d_temp_storage,
+                                                                        temp_storage_bytes,
+                                                                        d_in,
+                                                                        d_out,
+                                                                        num_segments,
+                                                                        d_begin_offsets,
+                                                                        d_end_offsets,
+                                                                        stream,
+                                                                        debug_synchronous));
     }
 
-    template<
-        typename InputIteratorT,
-        typename OutputIteratorT,
-        typename OffsetIteratorT
-    >
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t Min(void * d_temp_storage,
-                   size_t& temp_storage_bytes,
-                   InputIteratorT d_in,
-                   OutputIteratorT d_out,
-                   int num_segments,
-                   OffsetIteratorT d_begin_offsets,
-                   OffsetIteratorT d_end_offsets,
-                   hipStream_t stream = 0,
-                   bool debug_synchronous = false)
+    template <typename InputIteratorT, typename OutputIteratorT, typename OffsetIteratorT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t Min(void*           d_temp_storage,
+                                                  size_t&         temp_storage_bytes,
+                                                  InputIteratorT  d_in,
+                                                  OutputIteratorT d_out,
+                                                  int             num_segments,
+                                                  OffsetIteratorT d_begin_offsets,
+                                                  OffsetIteratorT d_end_offsets,
+                                                  hipStream_t     stream            = 0,
+                                                  bool            debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceSegmentedReduce::Min(
-                d_temp_storage, temp_storage_bytes,
-                d_in, d_out, num_segments,
-                d_begin_offsets, d_end_offsets,
-                stream, debug_synchronous
-            )
-        );
+        return hipCUDAErrorTohipError(::cub::DeviceSegmentedReduce::Min(d_temp_storage,
+                                                                        temp_storage_bytes,
+                                                                        d_in,
+                                                                        d_out,
+                                                                        num_segments,
+                                                                        d_begin_offsets,
+                                                                        d_end_offsets,
+                                                                        stream,
+                                                                        debug_synchronous));
     }
 
-    template<
-        typename InputIteratorT,
-        typename OutputIteratorT,
-        typename OffsetIteratorT
-    >
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t ArgMin(void * d_temp_storage,
-                      size_t& temp_storage_bytes,
-                      InputIteratorT d_in,
-                      OutputIteratorT d_out,
-                      int num_segments,
-                      OffsetIteratorT d_begin_offsets,
-                      OffsetIteratorT d_end_offsets,
-                      hipStream_t stream = 0,
-                      bool debug_synchronous = false)
+    template <typename InputIteratorT, typename OutputIteratorT, typename OffsetIteratorT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t ArgMin(void*           d_temp_storage,
+                                                     size_t&         temp_storage_bytes,
+                                                     InputIteratorT  d_in,
+                                                     OutputIteratorT d_out,
+                                                     int             num_segments,
+                                                     OffsetIteratorT d_begin_offsets,
+                                                     OffsetIteratorT d_end_offsets,
+                                                     hipStream_t     stream            = 0,
+                                                     bool            debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceSegmentedReduce::ArgMin(
-                d_temp_storage, temp_storage_bytes,
-                d_in, d_out, num_segments,
-                d_begin_offsets, d_end_offsets,
-                stream, debug_synchronous
-            )
-        );
+        return hipCUDAErrorTohipError(::cub::DeviceSegmentedReduce::ArgMin(d_temp_storage,
+                                                                           temp_storage_bytes,
+                                                                           d_in,
+                                                                           d_out,
+                                                                           num_segments,
+                                                                           d_begin_offsets,
+                                                                           d_end_offsets,
+                                                                           stream,
+                                                                           debug_synchronous));
     }
 
-    template<
-        typename InputIteratorT,
-        typename OutputIteratorT,
-        typename OffsetIteratorT
-    >
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t Max(void * d_temp_storage,
-                   size_t& temp_storage_bytes,
-                   InputIteratorT d_in,
-                   OutputIteratorT d_out,
-                   int num_segments,
-                   OffsetIteratorT d_begin_offsets,
-                   OffsetIteratorT d_end_offsets,
-                   hipStream_t stream = 0,
-                   bool debug_synchronous = false)
+    template <typename InputIteratorT, typename OutputIteratorT, typename OffsetIteratorT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t Max(void*           d_temp_storage,
+                                                  size_t&         temp_storage_bytes,
+                                                  InputIteratorT  d_in,
+                                                  OutputIteratorT d_out,
+                                                  int             num_segments,
+                                                  OffsetIteratorT d_begin_offsets,
+                                                  OffsetIteratorT d_end_offsets,
+                                                  hipStream_t     stream            = 0,
+                                                  bool            debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceSegmentedReduce::Max(
-                d_temp_storage, temp_storage_bytes,
-                d_in, d_out, num_segments,
-                d_begin_offsets, d_end_offsets,
-                stream, debug_synchronous
-            )
-        );
+        return hipCUDAErrorTohipError(::cub::DeviceSegmentedReduce::Max(d_temp_storage,
+                                                                        temp_storage_bytes,
+                                                                        d_in,
+                                                                        d_out,
+                                                                        num_segments,
+                                                                        d_begin_offsets,
+                                                                        d_end_offsets,
+                                                                        stream,
+                                                                        debug_synchronous));
     }
 
-    template<
-        typename InputIteratorT,
-        typename OutputIteratorT,
-        typename OffsetIteratorT
-    >
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t ArgMax(void * d_temp_storage,
-                      size_t& temp_storage_bytes,
-                      InputIteratorT d_in,
-                      OutputIteratorT d_out,
-                      int num_segments,
-                      OffsetIteratorT d_begin_offsets,
-                      OffsetIteratorT d_end_offsets,
-                      hipStream_t stream = 0,
-                      bool debug_synchronous = false)
+    template <typename InputIteratorT, typename OutputIteratorT, typename OffsetIteratorT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t ArgMax(void*           d_temp_storage,
+                                                     size_t&         temp_storage_bytes,
+                                                     InputIteratorT  d_in,
+                                                     OutputIteratorT d_out,
+                                                     int             num_segments,
+                                                     OffsetIteratorT d_begin_offsets,
+                                                     OffsetIteratorT d_end_offsets,
+                                                     hipStream_t     stream            = 0,
+                                                     bool            debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceSegmentedReduce::ArgMax(
-                d_temp_storage, temp_storage_bytes,
-                d_in, d_out, num_segments,
-                d_begin_offsets, d_end_offsets,
-                stream, debug_synchronous
-            )
-        );
+        return hipCUDAErrorTohipError(::cub::DeviceSegmentedReduce::ArgMax(d_temp_storage,
+                                                                           temp_storage_bytes,
+                                                                           d_in,
+                                                                           d_out,
+                                                                           num_segments,
+                                                                           d_begin_offsets,
+                                                                           d_end_offsets,
+                                                                           stream,
+                                                                           debug_synchronous));
     }
 };
 

--- a/hipcub/include/hipcub/cub/device/device_select.hpp
+++ b/hipcub/include/hipcub/cub/device/device_select.hpp
@@ -39,82 +39,74 @@ BEGIN_HIPCUB_NAMESPACE
 class DeviceSelect
 {
 public:
-    template <
-        typename InputIteratorT,
-        typename FlagIterator,
-        typename OutputIteratorT,
-        typename NumSelectedIteratorT
-    >
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t Flagged(void *d_temp_storage,
-                       size_t &temp_storage_bytes,
-                       InputIteratorT d_in,
-                       FlagIterator d_flags,
-                       OutputIteratorT d_out,
-                       NumSelectedIteratorT d_num_selected_out,
-                       int num_items,
-                       hipStream_t stream = 0,
-                       bool debug_synchronous = false)
+    template <typename InputIteratorT,
+              typename FlagIterator,
+              typename OutputIteratorT,
+              typename NumSelectedIteratorT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t Flagged(void*                d_temp_storage,
+                                                      size_t&              temp_storage_bytes,
+                                                      InputIteratorT       d_in,
+                                                      FlagIterator         d_flags,
+                                                      OutputIteratorT      d_out,
+                                                      NumSelectedIteratorT d_num_selected_out,
+                                                      int                  num_items,
+                                                      hipStream_t          stream = 0,
+                                                      bool debug_synchronous      = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceSelect::Flagged(
-                d_temp_storage, temp_storage_bytes,
-                d_in, d_flags,
-                d_out, d_num_selected_out, num_items,
-                stream, debug_synchronous
-            )
-        );
+        return hipCUDAErrorTohipError(::cub::DeviceSelect::Flagged(d_temp_storage,
+                                                                   temp_storage_bytes,
+                                                                   d_in,
+                                                                   d_flags,
+                                                                   d_out,
+                                                                   d_num_selected_out,
+                                                                   num_items,
+                                                                   stream,
+                                                                   debug_synchronous));
     }
 
-    template <
-        typename InputIteratorT,
-        typename OutputIteratorT,
-        typename NumSelectedIteratorT,
-        typename SelectOp
-    >
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t If(void *d_temp_storage,
-                  size_t &temp_storage_bytes,
-                  InputIteratorT d_in,
-                  OutputIteratorT d_out,
-                  NumSelectedIteratorT d_num_selected_out,
-                  int num_items,
-                  SelectOp select_op,
-                  hipStream_t stream = 0,
-                  bool debug_synchronous = false)
+    template <typename InputIteratorT,
+              typename OutputIteratorT,
+              typename NumSelectedIteratorT,
+              typename SelectOp>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t If(void*                d_temp_storage,
+                                                 size_t&              temp_storage_bytes,
+                                                 InputIteratorT       d_in,
+                                                 OutputIteratorT      d_out,
+                                                 NumSelectedIteratorT d_num_selected_out,
+                                                 int                  num_items,
+                                                 SelectOp             select_op,
+                                                 hipStream_t          stream            = 0,
+                                                 bool                 debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceSelect::If(
-                d_temp_storage, temp_storage_bytes,
-                d_in, d_out, d_num_selected_out,
-                num_items, select_op,
-                stream, debug_synchronous
-            )
-        );
+        return hipCUDAErrorTohipError(::cub::DeviceSelect::If(d_temp_storage,
+                                                              temp_storage_bytes,
+                                                              d_in,
+                                                              d_out,
+                                                              d_num_selected_out,
+                                                              num_items,
+                                                              select_op,
+                                                              stream,
+                                                              debug_synchronous));
     }
 
-    template <
-        typename InputIteratorT,
-        typename OutputIteratorT,
-        typename NumSelectedIteratorT
-    >
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t Unique(void *d_temp_storage,
-                      size_t &temp_storage_bytes,
-                      InputIteratorT d_in,
-                      OutputIteratorT d_out,
-                      NumSelectedIteratorT d_num_selected_out,
-                      int num_items,
-                      hipStream_t stream = 0,
-                      bool debug_synchronous = false)
+    template <typename InputIteratorT, typename OutputIteratorT, typename NumSelectedIteratorT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t Unique(void*                d_temp_storage,
+                                                     size_t&              temp_storage_bytes,
+                                                     InputIteratorT       d_in,
+                                                     OutputIteratorT      d_out,
+                                                     NumSelectedIteratorT d_num_selected_out,
+                                                     int                  num_items,
+                                                     hipStream_t          stream            = 0,
+                                                     bool                 debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceSelect::Unique(
-                d_temp_storage, temp_storage_bytes,
-                d_in, d_out, d_num_selected_out, num_items,
-                stream, debug_synchronous
-            )
-        );
+        return hipCUDAErrorTohipError(::cub::DeviceSelect::Unique(d_temp_storage,
+                                                                  temp_storage_bytes,
+                                                                  d_in,
+                                                                  d_out,
+                                                                  d_num_selected_out,
+                                                                  num_items,
+                                                                  stream,
+                                                                  debug_synchronous));
     }
 };
 

--- a/hipcub/include/hipcub/cub/hipcub.hpp
+++ b/hipcub/include/hipcub/cub/hipcub.hpp
@@ -51,9 +51,9 @@ END_HIPCUB_NAMESPACE
 #include "device/device_radix_sort.hpp"
 #include "device/device_reduce.hpp"
 #include "device/device_run_length_encode.hpp"
+#include "device/device_scan.hpp"
 #include "device/device_segmented_radix_sort.hpp"
 #include "device/device_segmented_reduce.hpp"
-#include "device/device_scan.hpp"
 #include "device/device_select.hpp"
 
 #endif // HIPCUB_CUB_HIPCUB_HPP_

--- a/hipcub/include/hipcub/cub/util_allocator.hpp
+++ b/hipcub/include/hipcub/cub/util_allocator.hpp
@@ -31,7 +31,7 @@
 #define HIPCUB_CUB_UTIL_ALLOCATOR_HPP_
 
 #if defined(HIPCUB_STDERR) && !defined(CUB_STDERR)
-    #define CUB_STDERR
+#define CUB_STDERR
 #endif
 
 #include "../config.hpp"
@@ -42,57 +42,37 @@ BEGIN_HIPCUB_NAMESPACE
 
 struct CachingDeviceAllocator : public ::cub::CachingDeviceAllocator
 {
-    hipError_t SetMaxCachedBytes(
-        size_t max_cached_bytes)
+    hipError_t SetMaxCachedBytes(size_t max_cached_bytes)
     {
         return hipCUDAErrorTohipError(
-            ::cub::CachingDeviceAllocator::SetMaxCachedBytes(max_cached_bytes)
-        );
+            ::cub::CachingDeviceAllocator::SetMaxCachedBytes(max_cached_bytes));
     }
 
-    hipError_t DeviceAllocate(
-        int             device,
-        void            **d_ptr,
-        size_t          bytes,
-        hipStream_t     active_stream = 0)
+    hipError_t DeviceAllocate(int device, void** d_ptr, size_t bytes, hipStream_t active_stream = 0)
     {
         return hipCUDAErrorTohipError(
-            ::cub::CachingDeviceAllocator::DeviceAllocate(device, d_ptr, bytes, active_stream)
-        );
+            ::cub::CachingDeviceAllocator::DeviceAllocate(device, d_ptr, bytes, active_stream));
     }
 
-    hipError_t DeviceAllocate(
-        void            **d_ptr,
-        size_t          bytes,
-        hipStream_t     active_stream = 0)
+    hipError_t DeviceAllocate(void** d_ptr, size_t bytes, hipStream_t active_stream = 0)
     {
         return hipCUDAErrorTohipError(
-            ::cub::CachingDeviceAllocator::DeviceAllocate(d_ptr, bytes, active_stream)
-        );
+            ::cub::CachingDeviceAllocator::DeviceAllocate(d_ptr, bytes, active_stream));
     }
 
-    hipError_t DeviceFree(
-        int             device,
-        void*           d_ptr)
+    hipError_t DeviceFree(int device, void* d_ptr)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::CachingDeviceAllocator::DeviceFree(device, d_ptr)
-        );
+        return hipCUDAErrorTohipError(::cub::CachingDeviceAllocator::DeviceFree(device, d_ptr));
     }
 
-    hipError_t DeviceFree(
-        void*           d_ptr)
+    hipError_t DeviceFree(void* d_ptr)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::CachingDeviceAllocator::DeviceFree(d_ptr)
-        );
+        return hipCUDAErrorTohipError(::cub::CachingDeviceAllocator::DeviceFree(d_ptr));
     }
 
     hipError_t FreeAllCached()
     {
-        return hipCUDAErrorTohipError(
-            ::cub::CachingDeviceAllocator::FreeAllCached()
-        );
+        return hipCUDAErrorTohipError(::cub::CachingDeviceAllocator::FreeAllCached());
     }
 };
 

--- a/hipcub/include/hipcub/hipcub.hpp
+++ b/hipcub/include/hipcub/hipcub.hpp
@@ -33,9 +33,9 @@
 #include "hipcub_version.hpp"
 
 #ifdef __HIP_PLATFORM_HCC__
-    #include "rocprim/hipcub.hpp"
+#include "rocprim/hipcub.hpp"
 #elif defined(__HIP_PLATFORM_NVCC__)
-    #include "cub/hipcub.hpp"
+#include "cub/hipcub.hpp"
 #endif
 
 #endif // HIPCUB_HPP_

--- a/hipcub/include/hipcub/hipcub_version.hpp.in
+++ b/hipcub/include/hipcub/hipcub_version.hpp.in
@@ -32,10 +32,11 @@
 ///
 /// For example, if HIPCUB_VERSION is 100500, then the major version is 1,
 /// the minor version is 5, and the patch level is 0.
-#define HIPCUB_VERSION @hipcub_VERSION_MAJOR@ * 100000 + @hipcub_VERSION_MINOR@ * 100 + @hipcub_VERSION_PATCH@
+#define HIPCUB_VERSION \
+    @hipcub_VERSION_MAJOR @ * 100000 + @hipcub_VERSION_MINOR @ * 100 + @hipcub_VERSION_PATCH @
 
-#define HIPCUB_VERSION_MAJOR @hipcub_VERSION_MAJOR@
-#define HIPCUB_VERSION_MINOR @hipcub_VERSION_MINOR@
-#define HIPCUB_VERSION_PATCH @hipcub_VERSION_PATCH@
+#define HIPCUB_VERSION_MAJOR @hipcub_VERSION_MAJOR @
+#define HIPCUB_VERSION_MINOR @hipcub_VERSION_MINOR @
+#define HIPCUB_VERSION_PATCH @hipcub_VERSION_PATCH @
 
 #endif // HIPCUB_VERSION_HPP_

--- a/hipcub/include/hipcub/rocprim/block/block_discontinuity.hpp
+++ b/hipcub/include/hipcub/rocprim/block/block_discontinuity.hpp
@@ -34,29 +34,20 @@
 
 BEGIN_HIPCUB_NAMESPACE
 
-template<
-    typename T,
-    int BLOCK_DIM_X,
-    int BLOCK_DIM_Y = 1,
-    int BLOCK_DIM_Z = 1,
-    int ARCH = HIPCUB_ARCH /* ignored */
->
+template <typename T,
+          int BLOCK_DIM_X,
+          int BLOCK_DIM_Y = 1,
+          int BLOCK_DIM_Z = 1,
+          int ARCH        = HIPCUB_ARCH /* ignored */
+          >
 class BlockDiscontinuity
-    : private ::rocprim::block_discontinuity<
-        T,
-        BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z
-      >
+    : private ::rocprim::block_discontinuity<T, BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z>
 {
-    static_assert(
-        BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z > 0,
-        "BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z must be greater than 0"
-    );
+    static_assert(BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z > 0,
+                  "BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z must be greater than 0");
 
     using base_type =
-        typename ::rocprim::block_discontinuity<
-            T,
-            BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z
-        >;
+        typename ::rocprim::block_discontinuity<T, BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z>;
 
     // Reference to temporary storage (usually shared memory)
     typename base_type::storage_type& temp_storage_;
@@ -64,113 +55,100 @@ class BlockDiscontinuity
 public:
     using TempStorage = typename base_type::storage_type;
 
-    HIPCUB_DEVICE inline
-    BlockDiscontinuity() : temp_storage_(private_storage())
+    HIPCUB_DEVICE inline BlockDiscontinuity()
+        : temp_storage_(private_storage())
     {
     }
 
-    HIPCUB_DEVICE inline
-    BlockDiscontinuity(TempStorage& temp_storage) : temp_storage_(temp_storage)
+    HIPCUB_DEVICE inline BlockDiscontinuity(TempStorage& temp_storage)
+        : temp_storage_(temp_storage)
     {
     }
 
-    template<int ITEMS_PER_THREAD, typename FlagT, typename FlagOp>
-    HIPCUB_DEVICE inline
-    void FlagHeads(FlagT (&head_flags)[ITEMS_PER_THREAD],
-                   T (&input)[ITEMS_PER_THREAD],
-                   FlagOp flag_op)
+    template <int ITEMS_PER_THREAD, typename FlagT, typename FlagOp>
+    HIPCUB_DEVICE inline void FlagHeads(FlagT (&head_flags)[ITEMS_PER_THREAD],
+                                        T (&input)[ITEMS_PER_THREAD],
+                                        FlagOp flag_op)
     {
         base_type::flag_heads(head_flags, input, flag_op, temp_storage_);
     }
 
-    template<int ITEMS_PER_THREAD, typename FlagT, typename FlagOp>
-    HIPCUB_DEVICE inline
-    void FlagHeads(FlagT (&head_flags)[ITEMS_PER_THREAD],
-                   T (&input)[ITEMS_PER_THREAD],
-                   FlagOp flag_op,
-                   T tile_predecessor_item)
+    template <int ITEMS_PER_THREAD, typename FlagT, typename FlagOp>
+    HIPCUB_DEVICE inline void FlagHeads(FlagT (&head_flags)[ITEMS_PER_THREAD],
+                                        T (&input)[ITEMS_PER_THREAD],
+                                        FlagOp flag_op,
+                                        T      tile_predecessor_item)
     {
         base_type::flag_heads(head_flags, tile_predecessor_item, input, flag_op, temp_storage_);
     }
 
-    template<int ITEMS_PER_THREAD, typename FlagT, typename FlagOp>
-    HIPCUB_DEVICE inline
-    void FlagTails(FlagT (&tail_flags)[ITEMS_PER_THREAD],
-                   T (&input)[ITEMS_PER_THREAD],
-                   FlagOp flag_op)
+    template <int ITEMS_PER_THREAD, typename FlagT, typename FlagOp>
+    HIPCUB_DEVICE inline void FlagTails(FlagT (&tail_flags)[ITEMS_PER_THREAD],
+                                        T (&input)[ITEMS_PER_THREAD],
+                                        FlagOp flag_op)
     {
         base_type::flag_tails(tail_flags, input, flag_op, temp_storage_);
     }
 
-    template<int ITEMS_PER_THREAD, typename FlagT, typename FlagOp>
-    HIPCUB_DEVICE inline
-    void FlagTails(FlagT (&tail_flags)[ITEMS_PER_THREAD],
-                   T (&input)[ITEMS_PER_THREAD],
-                   FlagOp flag_op,
-                   T tile_successor_item)
+    template <int ITEMS_PER_THREAD, typename FlagT, typename FlagOp>
+    HIPCUB_DEVICE inline void FlagTails(FlagT (&tail_flags)[ITEMS_PER_THREAD],
+                                        T (&input)[ITEMS_PER_THREAD],
+                                        FlagOp flag_op,
+                                        T      tile_successor_item)
     {
         base_type::flag_tails(tail_flags, tile_successor_item, input, flag_op, temp_storage_);
     }
 
-    template<int ITEMS_PER_THREAD, typename FlagT, typename FlagOp>
-    HIPCUB_DEVICE inline
-    void FlagHeadsAndTails(FlagT (&head_flags)[ITEMS_PER_THREAD],
-                           FlagT (&tail_flags)[ITEMS_PER_THREAD],
-                           T (&input)[ITEMS_PER_THREAD],
-                           FlagOp flag_op)
+    template <int ITEMS_PER_THREAD, typename FlagT, typename FlagOp>
+    HIPCUB_DEVICE inline void FlagHeadsAndTails(FlagT (&head_flags)[ITEMS_PER_THREAD],
+                                                FlagT (&tail_flags)[ITEMS_PER_THREAD],
+                                                T (&input)[ITEMS_PER_THREAD],
+                                                FlagOp flag_op)
     {
-        base_type::flag_heads_and_tails(
-            head_flags, tail_flags, input,
-            flag_op, temp_storage_
-        );
+        base_type::flag_heads_and_tails(head_flags, tail_flags, input, flag_op, temp_storage_);
     }
 
-    template<int ITEMS_PER_THREAD, typename FlagT, typename FlagOp>
-    HIPCUB_DEVICE inline
-    void FlagHeadsAndTails(FlagT (&head_flags)[ITEMS_PER_THREAD],
-                           FlagT (&tail_flags)[ITEMS_PER_THREAD],
-                           T tile_successor_item,
-                           T (&input)[ITEMS_PER_THREAD],
-                           FlagOp flag_op)
+    template <int ITEMS_PER_THREAD, typename FlagT, typename FlagOp>
+    HIPCUB_DEVICE inline void FlagHeadsAndTails(FlagT (&head_flags)[ITEMS_PER_THREAD],
+                                                FlagT (&tail_flags)[ITEMS_PER_THREAD],
+                                                T tile_successor_item,
+                                                T (&input)[ITEMS_PER_THREAD],
+                                                FlagOp flag_op)
     {
         base_type::flag_heads_and_tails(
-            head_flags, tail_flags, tile_successor_item, input,
-            flag_op, temp_storage_
-        );
+            head_flags, tail_flags, tile_successor_item, input, flag_op, temp_storage_);
     }
 
-    template<int ITEMS_PER_THREAD, typename FlagT, typename FlagOp>
-    HIPCUB_DEVICE inline
-    void FlagHeadsAndTails(FlagT (&head_flags)[ITEMS_PER_THREAD],
-                           T tile_predecessor_item,
-                           FlagT (&tail_flags)[ITEMS_PER_THREAD],
-                           T (&input)[ITEMS_PER_THREAD],
-                           FlagOp flag_op)
+    template <int ITEMS_PER_THREAD, typename FlagT, typename FlagOp>
+    HIPCUB_DEVICE inline void FlagHeadsAndTails(FlagT (&head_flags)[ITEMS_PER_THREAD],
+                                                T tile_predecessor_item,
+                                                FlagT (&tail_flags)[ITEMS_PER_THREAD],
+                                                T (&input)[ITEMS_PER_THREAD],
+                                                FlagOp flag_op)
     {
         base_type::flag_heads_and_tails(
-            head_flags, tile_predecessor_item, tail_flags, input,
-            flag_op, temp_storage_
-        );
+            head_flags, tile_predecessor_item, tail_flags, input, flag_op, temp_storage_);
     }
 
-    template<int ITEMS_PER_THREAD, typename FlagT, typename FlagOp>
-    HIPCUB_DEVICE inline
-    void FlagHeadsAndTails(FlagT (&head_flags)[ITEMS_PER_THREAD],
-                           T tile_predecessor_item,
-                           FlagT (&tail_flags)[ITEMS_PER_THREAD],
-                           T tile_successor_item,
-                           T (&input)[ITEMS_PER_THREAD],
-                           FlagOp flag_op)
+    template <int ITEMS_PER_THREAD, typename FlagT, typename FlagOp>
+    HIPCUB_DEVICE inline void FlagHeadsAndTails(FlagT (&head_flags)[ITEMS_PER_THREAD],
+                                                T tile_predecessor_item,
+                                                FlagT (&tail_flags)[ITEMS_PER_THREAD],
+                                                T tile_successor_item,
+                                                T (&input)[ITEMS_PER_THREAD],
+                                                FlagOp flag_op)
     {
-        base_type::flag_heads_and_tails(
-            head_flags, tile_predecessor_item, tail_flags, tile_successor_item, input,
-            flag_op, temp_storage_
-        );
+        base_type::flag_heads_and_tails(head_flags,
+                                        tile_predecessor_item,
+                                        tail_flags,
+                                        tile_successor_item,
+                                        input,
+                                        flag_op,
+                                        temp_storage_);
     }
 
 private:
-    HIPCUB_DEVICE inline
-    TempStorage& private_storage()
+    HIPCUB_DEVICE inline TempStorage& private_storage()
     {
         HIPCUB_SHARED_MEMORY TempStorage private_storage;
         return private_storage;

--- a/hipcub/include/hipcub/rocprim/block/block_exchange.hpp
+++ b/hipcub/include/hipcub/rocprim/block/block_exchange.hpp
@@ -34,33 +34,23 @@
 
 BEGIN_HIPCUB_NAMESPACE
 
-template<
-    typename InputT,
-    int BLOCK_DIM_X,
-    int ITEMS_PER_THREAD,
-    bool WARP_TIME_SLICING = false, /* ignored */
-    int BLOCK_DIM_Y = 1,
-    int BLOCK_DIM_Z = 1,
-    int ARCH = HIPCUB_ARCH /* ignored */
->
-class BlockExchange
-    : private ::rocprim::block_exchange<
-        InputT,
-        BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z,
-        ITEMS_PER_THREAD
-      >
+template <typename InputT,
+          int  BLOCK_DIM_X,
+          int  ITEMS_PER_THREAD,
+          bool WARP_TIME_SLICING = false, /* ignored */
+          int  BLOCK_DIM_Y       = 1,
+          int  BLOCK_DIM_Z       = 1,
+          int  ARCH              = HIPCUB_ARCH /* ignored */
+          >
+class BlockExchange : private ::rocprim::block_exchange<InputT,
+                                                        BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z,
+                                                        ITEMS_PER_THREAD>
 {
-    static_assert(
-        BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z > 0,
-        "BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z must be greater than 0"
-    );
+    static_assert(BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z > 0,
+                  "BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z must be greater than 0");
 
-    using base_type =
-        typename ::rocprim::block_exchange<
-            InputT,
-            BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z,
-            ITEMS_PER_THREAD
-        >;
+    using base_type = typename ::rocprim::
+        block_exchange<InputT, BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z, ITEMS_PER_THREAD>;
 
     // Reference to temporary storage (usually shared memory)
     typename base_type::storage_type& temp_storage_;
@@ -68,88 +58,80 @@ class BlockExchange
 public:
     using TempStorage = typename base_type::storage_type;
 
-    HIPCUB_DEVICE inline
-    BlockExchange() : temp_storage_(private_storage())
+    HIPCUB_DEVICE inline BlockExchange()
+        : temp_storage_(private_storage())
     {
     }
 
-    HIPCUB_DEVICE inline
-    BlockExchange(TempStorage& temp_storage) : temp_storage_(temp_storage)
+    HIPCUB_DEVICE inline BlockExchange(TempStorage& temp_storage)
+        : temp_storage_(temp_storage)
     {
     }
 
-    template<typename OutputT>
-    HIPCUB_DEVICE inline
-    void StripedToBlocked(InputT (&input_items)[ITEMS_PER_THREAD],
-                          OutputT (&output_items)[ITEMS_PER_THREAD])
+    template <typename OutputT>
+    HIPCUB_DEVICE inline void StripedToBlocked(InputT (&input_items)[ITEMS_PER_THREAD],
+                                               OutputT (&output_items)[ITEMS_PER_THREAD])
     {
         base_type::striped_to_blocked(input_items, output_items, temp_storage_);
     }
 
-    template<typename OutputT>
-    HIPCUB_DEVICE inline
-    void BlockedToStriped(InputT (&input_items)[ITEMS_PER_THREAD],
-                          OutputT (&output_items)[ITEMS_PER_THREAD])
+    template <typename OutputT>
+    HIPCUB_DEVICE inline void BlockedToStriped(InputT (&input_items)[ITEMS_PER_THREAD],
+                                               OutputT (&output_items)[ITEMS_PER_THREAD])
     {
         base_type::blocked_to_striped(input_items, output_items, temp_storage_);
     }
 
-    template<typename OutputT>
-    HIPCUB_DEVICE inline
-    void WarpStripedToBlocked(InputT (&input_items)[ITEMS_PER_THREAD],
-                              OutputT (&output_items)[ITEMS_PER_THREAD])
+    template <typename OutputT>
+    HIPCUB_DEVICE inline void WarpStripedToBlocked(InputT (&input_items)[ITEMS_PER_THREAD],
+                                                   OutputT (&output_items)[ITEMS_PER_THREAD])
     {
         base_type::warp_striped_to_blocked(input_items, output_items, temp_storage_);
     }
 
-    template<typename OutputT>
-    HIPCUB_DEVICE inline
-    void BlockedToWarpStriped(InputT (&input_items)[ITEMS_PER_THREAD],
-                              OutputT (&output_items)[ITEMS_PER_THREAD])
+    template <typename OutputT>
+    HIPCUB_DEVICE inline void BlockedToWarpStriped(InputT (&input_items)[ITEMS_PER_THREAD],
+                                                   OutputT (&output_items)[ITEMS_PER_THREAD])
     {
         base_type::blocked_to_warp_striped(input_items, output_items, temp_storage_);
     }
 
-    template<typename OutputT, typename OffsetT>
-    HIPCUB_DEVICE inline
-    void ScatterToBlocked(InputT (&input_items)[ITEMS_PER_THREAD],
-                          OutputT (&output_items)[ITEMS_PER_THREAD],
-                          OffsetT (&ranks)[ITEMS_PER_THREAD])
+    template <typename OutputT, typename OffsetT>
+    HIPCUB_DEVICE inline void ScatterToBlocked(InputT (&input_items)[ITEMS_PER_THREAD],
+                                               OutputT (&output_items)[ITEMS_PER_THREAD],
+                                               OffsetT (&ranks)[ITEMS_PER_THREAD])
     {
         base_type::scatter_to_blocked(input_items, output_items, ranks, temp_storage_);
     }
 
-    template<typename OutputT, typename OffsetT>
-    HIPCUB_DEVICE inline
-    void ScatterToStriped(InputT (&input_items)[ITEMS_PER_THREAD],
-                          OutputT (&output_items)[ITEMS_PER_THREAD],
-                          OffsetT (&ranks)[ITEMS_PER_THREAD])
+    template <typename OutputT, typename OffsetT>
+    HIPCUB_DEVICE inline void ScatterToStriped(InputT (&input_items)[ITEMS_PER_THREAD],
+                                               OutputT (&output_items)[ITEMS_PER_THREAD],
+                                               OffsetT (&ranks)[ITEMS_PER_THREAD])
     {
         base_type::scatter_to_striped(input_items, output_items, ranks, temp_storage_);
     }
 
-    template<typename OutputT, typename OffsetT>
-    HIPCUB_DEVICE inline
-    void ScatterToStripedGuarded(InputT (&input_items)[ITEMS_PER_THREAD],
-                                 OutputT (&output_items)[ITEMS_PER_THREAD],
-                                 OffsetT (&ranks)[ITEMS_PER_THREAD])
+    template <typename OutputT, typename OffsetT>
+    HIPCUB_DEVICE inline void ScatterToStripedGuarded(InputT (&input_items)[ITEMS_PER_THREAD],
+                                                      OutputT (&output_items)[ITEMS_PER_THREAD],
+                                                      OffsetT (&ranks)[ITEMS_PER_THREAD])
     {
         base_type::scatter_to_striped_guarded(input_items, output_items, ranks, temp_storage_);
     }
 
-    template<typename OutputT, typename OffsetT, typename ValidFlag>
-    HIPCUB_DEVICE inline
-    void ScatterToStripedFlagged(InputT (&input_items)[ITEMS_PER_THREAD],
-                                 OutputT (&output_items)[ITEMS_PER_THREAD],
-                                 OffsetT (&ranks)[ITEMS_PER_THREAD],
-                                 ValidFlag (&is_valid)[ITEMS_PER_THREAD])
+    template <typename OutputT, typename OffsetT, typename ValidFlag>
+    HIPCUB_DEVICE inline void ScatterToStripedFlagged(InputT (&input_items)[ITEMS_PER_THREAD],
+                                                      OutputT (&output_items)[ITEMS_PER_THREAD],
+                                                      OffsetT (&ranks)[ITEMS_PER_THREAD],
+                                                      ValidFlag (&is_valid)[ITEMS_PER_THREAD])
     {
-        base_type::scatter_to_striped_flagged(input_items, output_items, ranks, is_valid, temp_storage_);
+        base_type::scatter_to_striped_flagged(
+            input_items, output_items, ranks, is_valid, temp_storage_);
     }
 
 private:
-    HIPCUB_DEVICE inline
-    TempStorage& private_storage()
+    HIPCUB_DEVICE inline TempStorage& private_storage()
     {
         HIPCUB_SHARED_MEMORY TempStorage private_storage;
         return private_storage;

--- a/hipcub/include/hipcub/rocprim/block/block_histogram.hpp
+++ b/hipcub/include/hipcub/rocprim/block/block_histogram.hpp
@@ -40,9 +40,8 @@ BEGIN_HIPCUB_NAMESPACE
 
 namespace detail
 {
-    inline constexpr
-    typename std::underlying_type<::rocprim::block_histogram_algorithm>::type
-    to_BlockHistogramAlgorithm_enum(::rocprim::block_histogram_algorithm v)
+    inline constexpr typename std::underlying_type<::rocprim::block_histogram_algorithm>::type
+        to_BlockHistogramAlgorithm_enum(::rocprim::block_histogram_algorithm v)
     {
         using utype = std::underlying_type<::rocprim::block_histogram_algorithm>::type;
         return static_cast<utype>(v);
@@ -52,43 +51,38 @@ namespace detail
 enum BlockHistogramAlgorithm
 {
     BLOCK_HISTO_ATOMIC
-        = detail::to_BlockHistogramAlgorithm_enum(::rocprim::block_histogram_algorithm::using_atomic),
+    = detail::to_BlockHistogramAlgorithm_enum(::rocprim::block_histogram_algorithm::using_atomic),
     BLOCK_HISTO_SORT
-        = detail::to_BlockHistogramAlgorithm_enum(::rocprim::block_histogram_algorithm::using_sort)
+    = detail::to_BlockHistogramAlgorithm_enum(::rocprim::block_histogram_algorithm::using_sort)
 };
 
-template<
-    typename T,
-    int BLOCK_DIM_X,
-    int ITEMS_PER_THREAD,
-    int BINS,
-    BlockHistogramAlgorithm ALGORITHM = BLOCK_HISTO_SORT,
-    int BLOCK_DIM_Y = 1,
-    int BLOCK_DIM_Z = 1,
-    int ARCH = HIPCUB_ARCH /* ignored */
->
+template <typename T,
+          int                     BLOCK_DIM_X,
+          int                     ITEMS_PER_THREAD,
+          int                     BINS,
+          BlockHistogramAlgorithm ALGORITHM   = BLOCK_HISTO_SORT,
+          int                     BLOCK_DIM_Y = 1,
+          int                     BLOCK_DIM_Z = 1,
+          int                     ARCH        = HIPCUB_ARCH /* ignored */
+          >
 class BlockHistogram
-    : private ::rocprim::block_histogram<
-        T,
-        BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z,
-        ITEMS_PER_THREAD,
-        BINS,
-        static_cast<::rocprim::block_histogram_algorithm>(ALGORITHM)
-      >
+    : private ::rocprim::block_histogram<T,
+                                         BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z,
+                                         ITEMS_PER_THREAD,
+                                         BINS,
+                                         static_cast<::rocprim::block_histogram_algorithm>(
+                                             ALGORITHM)>
 {
-    static_assert(
-        BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z > 0,
-        "BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z must be greater than 0"
-    );
+    static_assert(BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z > 0,
+                  "BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z must be greater than 0");
 
     using base_type =
-        typename ::rocprim::block_histogram<
-            T,
-            BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z,
-            ITEMS_PER_THREAD,
-            BINS,
-            static_cast<::rocprim::block_histogram_algorithm>(ALGORITHM)
-        >;
+        typename ::rocprim::block_histogram<T,
+                                            BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z,
+                                            ITEMS_PER_THREAD,
+                                            BINS,
+                                            static_cast<::rocprim::block_histogram_algorithm>(
+                                                ALGORITHM)>;
 
     // Reference to temporary storage (usually shared memory)
     typename base_type::storage_type& temp_storage_;
@@ -96,35 +90,30 @@ class BlockHistogram
 public:
     using TempStorage = typename base_type::storage_type;
 
-    HIPCUB_DEVICE inline
-    BlockHistogram() : temp_storage_(private_storage())
+    HIPCUB_DEVICE inline BlockHistogram()
+        : temp_storage_(private_storage())
     {
     }
 
-    HIPCUB_DEVICE inline
-    BlockHistogram(TempStorage& temp_storage) : temp_storage_(temp_storage)
+    HIPCUB_DEVICE inline BlockHistogram(TempStorage& temp_storage)
+        : temp_storage_(temp_storage)
     {
     }
 
-    template<class CounterT>
-    HIPCUB_DEVICE inline
-    void InitHistogram(CounterT histogram[BINS])
+    template <class CounterT>
+    HIPCUB_DEVICE inline void InitHistogram(CounterT histogram[BINS])
     {
         base_type::init_histogram(histogram);
     }
 
-    template<class CounterT>
-    HIPCUB_DEVICE inline
-    void Composite(T (&items)[ITEMS_PER_THREAD],
-                   CounterT histogram[BINS])
+    template <class CounterT>
+    HIPCUB_DEVICE inline void Composite(T (&items)[ITEMS_PER_THREAD], CounterT histogram[BINS])
     {
         base_type::composite(items, histogram, temp_storage_);
     }
 
-    template<class CounterT>
-    HIPCUB_DEVICE inline
-    void Histogram(T (&items)[ITEMS_PER_THREAD],
-                   CounterT histogram[BINS])
+    template <class CounterT>
+    HIPCUB_DEVICE inline void Histogram(T (&items)[ITEMS_PER_THREAD], CounterT histogram[BINS])
     {
         base_type::init_histogram(histogram);
         CTA_SYNC();
@@ -132,8 +121,7 @@ public:
     }
 
 private:
-    HIPCUB_DEVICE inline
-    TempStorage& private_storage()
+    HIPCUB_DEVICE inline TempStorage& private_storage()
     {
         HIPCUB_SHARED_MEMORY TempStorage private_storage;
         return private_storage;

--- a/hipcub/include/hipcub/rocprim/block/block_load.hpp
+++ b/hipcub/include/hipcub/rocprim/block/block_load.hpp
@@ -40,9 +40,8 @@ BEGIN_HIPCUB_NAMESPACE
 
 namespace detail
 {
-    inline constexpr
-    typename std::underlying_type<::rocprim::block_load_method>::type
-    to_BlockLoadAlgorithm_enum(::rocprim::block_load_method v)
+    inline constexpr typename std::underlying_type<::rocprim::block_load_method>::type
+        to_BlockLoadAlgorithm_enum(::rocprim::block_load_method v)
     {
         using utype = std::underlying_type<::rocprim::block_load_method>::type;
         return static_cast<utype>(v);
@@ -52,46 +51,39 @@ namespace detail
 enum BlockLoadAlgorithm
 {
     BLOCK_LOAD_DIRECT
-        = detail::to_BlockLoadAlgorithm_enum(::rocprim::block_load_method::block_load_direct),
+    = detail::to_BlockLoadAlgorithm_enum(::rocprim::block_load_method::block_load_direct),
     BLOCK_LOAD_VECTORIZE
-        = detail::to_BlockLoadAlgorithm_enum(::rocprim::block_load_method::block_load_vectorize),
+    = detail::to_BlockLoadAlgorithm_enum(::rocprim::block_load_method::block_load_vectorize),
     BLOCK_LOAD_TRANSPOSE
-        = detail::to_BlockLoadAlgorithm_enum(::rocprim::block_load_method::block_load_transpose),
+    = detail::to_BlockLoadAlgorithm_enum(::rocprim::block_load_method::block_load_transpose),
     BLOCK_LOAD_WARP_TRANSPOSE
-        = detail::to_BlockLoadAlgorithm_enum(::rocprim::block_load_method::block_load_warp_transpose),
+    = detail::to_BlockLoadAlgorithm_enum(::rocprim::block_load_method::block_load_warp_transpose),
     BLOCK_LOAD_WARP_TRANSPOSE_TIMESLICED
-        = detail::to_BlockLoadAlgorithm_enum(::rocprim::block_load_method::block_load_warp_transpose)
+    = detail::to_BlockLoadAlgorithm_enum(::rocprim::block_load_method::block_load_warp_transpose)
 };
 
-template<
-    typename T,
-    int BLOCK_DIM_X,
-    int ITEMS_PER_THREAD,
-    BlockLoadAlgorithm ALGORITHM = BLOCK_LOAD_DIRECT,
-    int BLOCK_DIM_Y = 1,
-    int BLOCK_DIM_Z = 1,
-    int ARCH = HIPCUB_ARCH /* ignored */
->
+template <typename T,
+          int                BLOCK_DIM_X,
+          int                ITEMS_PER_THREAD,
+          BlockLoadAlgorithm ALGORITHM   = BLOCK_LOAD_DIRECT,
+          int                BLOCK_DIM_Y = 1,
+          int                BLOCK_DIM_Z = 1,
+          int                ARCH        = HIPCUB_ARCH /* ignored */
+          >
 class BlockLoad
-    : private ::rocprim::block_load<
-        T,
-        BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z,
-        ITEMS_PER_THREAD,
-        static_cast<::rocprim::block_load_method>(ALGORITHM)
-      >
+    : private ::rocprim::block_load<T,
+                                    BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z,
+                                    ITEMS_PER_THREAD,
+                                    static_cast<::rocprim::block_load_method>(ALGORITHM)>
 {
-    static_assert(
-        BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z > 0,
-        "BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z must be greater than 0"
-    );
+    static_assert(BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z > 0,
+                  "BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z must be greater than 0");
 
     using base_type =
-        typename ::rocprim::block_load<
-            T,
-            BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z,
-            ITEMS_PER_THREAD,
-            static_cast<::rocprim::block_load_method>(ALGORITHM)
-        >;
+        typename ::rocprim::block_load<T,
+                                       BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z,
+                                       ITEMS_PER_THREAD,
+                                       static_cast<::rocprim::block_load_method>(ALGORITHM)>;
 
     // Reference to temporary storage (usually shared memory)
     typename base_type::storage_type& temp_storage_;
@@ -99,49 +91,40 @@ class BlockLoad
 public:
     using TempStorage = typename base_type::storage_type;
 
-    HIPCUB_DEVICE inline
-    BlockLoad() : temp_storage_(private_storage())
+    HIPCUB_DEVICE inline BlockLoad()
+        : temp_storage_(private_storage())
     {
     }
 
-    HIPCUB_DEVICE inline
-    BlockLoad(TempStorage& temp_storage) : temp_storage_(temp_storage)
+    HIPCUB_DEVICE inline BlockLoad(TempStorage& temp_storage)
+        : temp_storage_(temp_storage)
     {
     }
 
-    template<class InputIteratorT>
-    HIPCUB_DEVICE inline
-    void Load(InputIteratorT block_iter,
-              T (&items)[ITEMS_PER_THREAD])
+    template <class InputIteratorT>
+    HIPCUB_DEVICE inline void Load(InputIteratorT block_iter, T (&items)[ITEMS_PER_THREAD])
     {
         base_type::load(block_iter, items, temp_storage_);
     }
 
-    template<class InputIteratorT>
-    HIPCUB_DEVICE inline
-    void Load(InputIteratorT block_iter,
-              T (&items)[ITEMS_PER_THREAD],
-              int valid_items)
+    template <class InputIteratorT>
+    HIPCUB_DEVICE inline void
+        Load(InputIteratorT block_iter, T (&items)[ITEMS_PER_THREAD], int valid_items)
     {
         base_type::load(block_iter, items, valid_items, temp_storage_);
     }
 
-    template<
-        class InputIteratorT,
-        class Default
-    >
-    HIPCUB_DEVICE inline
-    void Load(InputIteratorT block_iter,
-              T (&items)[ITEMS_PER_THREAD],
-              int valid_items,
-              Default oob_default)
+    template <class InputIteratorT, class Default>
+    HIPCUB_DEVICE inline void Load(InputIteratorT block_iter,
+                                   T (&items)[ITEMS_PER_THREAD],
+                                   int     valid_items,
+                                   Default oob_default)
     {
         base_type::load(block_iter, items, valid_items, oob_default, temp_storage_);
     }
 
 private:
-    HIPCUB_DEVICE inline
-    TempStorage& private_storage()
+    HIPCUB_DEVICE inline TempStorage& private_storage()
     {
         HIPCUB_SHARED_MEMORY TempStorage private_storage;
         return private_storage;

--- a/hipcub/include/hipcub/rocprim/block/block_load_func.hpp
+++ b/hipcub/include/hipcub/rocprim/block/block_load_func.hpp
@@ -34,168 +34,95 @@
 
 BEGIN_HIPCUB_NAMESPACE
 
-template<
-    typename T,
-    int ITEMS_PER_THREAD,
-    typename InputIteratorT
->
-HIPCUB_DEVICE inline
-void LoadDirectBlocked(int linear_id,
-                       InputIteratorT block_iter,
-                       T (&items)[ITEMS_PER_THREAD])
+template <typename T, int ITEMS_PER_THREAD, typename InputIteratorT>
+HIPCUB_DEVICE inline void
+    LoadDirectBlocked(int linear_id, InputIteratorT block_iter, T (&items)[ITEMS_PER_THREAD])
 {
-    ::rocprim::block_load_direct_blocked(
-        linear_id, block_iter, items
-    );
+    ::rocprim::block_load_direct_blocked(linear_id, block_iter, items);
 }
 
-template<
-    typename T,
-    int ITEMS_PER_THREAD,
-    typename InputIteratorT
->
-HIPCUB_DEVICE inline
-void LoadDirectBlocked(int linear_id,
-                       InputIteratorT block_iter,
-                       T (&items)[ITEMS_PER_THREAD],
-                       int valid_items)
+template <typename T, int ITEMS_PER_THREAD, typename InputIteratorT>
+HIPCUB_DEVICE inline void LoadDirectBlocked(int            linear_id,
+                                            InputIteratorT block_iter,
+                                            T (&items)[ITEMS_PER_THREAD],
+                                            int valid_items)
 {
-    ::rocprim::block_load_direct_blocked(
-        linear_id, block_iter, items, valid_items
-    );
+    ::rocprim::block_load_direct_blocked(linear_id, block_iter, items, valid_items);
 }
 
-template<
-    typename T,
-    typename Default,
-    int ITEMS_PER_THREAD,
-    typename InputIteratorT
->
-HIPCUB_DEVICE inline
-void LoadDirectBlocked(int linear_id,
-                       InputIteratorT block_iter,
-                       T (&items)[ITEMS_PER_THREAD],
-                       int valid_items,
-                       Default oob_default)
+template <typename T, typename Default, int ITEMS_PER_THREAD, typename InputIteratorT>
+HIPCUB_DEVICE inline void LoadDirectBlocked(int            linear_id,
+                                            InputIteratorT block_iter,
+                                            T (&items)[ITEMS_PER_THREAD],
+                                            int     valid_items,
+                                            Default oob_default)
 {
-    ::rocprim::block_load_direct_blocked(
-        linear_id, block_iter, items, valid_items, oob_default
-    );
+    ::rocprim::block_load_direct_blocked(linear_id, block_iter, items, valid_items, oob_default);
 }
 
-template <
-    typename T,
-    int ITEMS_PER_THREAD
->
-HIPCUB_DEVICE inline
-void LoadDirectBlockedVectorized(int linear_id,
-                                 T* block_iter,
-                                 T (&items)[ITEMS_PER_THREAD])
+template <typename T, int ITEMS_PER_THREAD>
+HIPCUB_DEVICE inline void
+    LoadDirectBlockedVectorized(int linear_id, T* block_iter, T (&items)[ITEMS_PER_THREAD])
 {
-    ::rocprim::block_load_direct_blocked_vectorized(
-        linear_id, block_iter, items
-    );
+    ::rocprim::block_load_direct_blocked_vectorized(linear_id, block_iter, items);
 }
 
-template<
-    int BLOCK_THREADS,
-    typename T,
-    int ITEMS_PER_THREAD,
-    typename InputIteratorT
->
-HIPCUB_DEVICE inline
-void LoadDirectStriped(int linear_id,
-                       InputIteratorT block_iter,
-                       T (&items)[ITEMS_PER_THREAD])
+template <int BLOCK_THREADS, typename T, int ITEMS_PER_THREAD, typename InputIteratorT>
+HIPCUB_DEVICE inline void
+    LoadDirectStriped(int linear_id, InputIteratorT block_iter, T (&items)[ITEMS_PER_THREAD])
+{
+    ::rocprim::block_load_direct_striped<BLOCK_THREADS>(linear_id, block_iter, items);
+}
+
+template <int BLOCK_THREADS, typename T, int ITEMS_PER_THREAD, typename InputIteratorT>
+HIPCUB_DEVICE inline void LoadDirectStriped(int            linear_id,
+                                            InputIteratorT block_iter,
+                                            T (&items)[ITEMS_PER_THREAD],
+                                            int valid_items)
+{
+    ::rocprim::block_load_direct_striped<BLOCK_THREADS>(linear_id, block_iter, items, valid_items);
+}
+
+template <int BLOCK_THREADS,
+          typename T,
+          typename Default,
+          int ITEMS_PER_THREAD,
+          typename InputIteratorT>
+HIPCUB_DEVICE inline void LoadDirectStriped(int            linear_id,
+                                            InputIteratorT block_iter,
+                                            T (&items)[ITEMS_PER_THREAD],
+                                            int     valid_items,
+                                            Default oob_default)
 {
     ::rocprim::block_load_direct_striped<BLOCK_THREADS>(
-        linear_id, block_iter, items
-    );
+        linear_id, block_iter, items, valid_items, oob_default);
 }
 
-template<
-    int BLOCK_THREADS,
-    typename T,
-    int ITEMS_PER_THREAD,
-    typename InputIteratorT
->
-HIPCUB_DEVICE inline
-void LoadDirectStriped(int linear_id,
-                       InputIteratorT block_iter,
-                       T (&items)[ITEMS_PER_THREAD],
-                       int valid_items)
+template <typename T, int ITEMS_PER_THREAD, typename InputIteratorT>
+HIPCUB_DEVICE inline void
+    LoadDirectWarpStriped(int linear_id, InputIteratorT block_iter, T (&items)[ITEMS_PER_THREAD])
 {
-    ::rocprim::block_load_direct_striped<BLOCK_THREADS>(
-        linear_id, block_iter, items, valid_items
-    );
+    ::rocprim::block_load_direct_warp_striped(linear_id, block_iter, items);
 }
 
-template<
-    int BLOCK_THREADS,
-    typename T,
-    typename Default,
-    int ITEMS_PER_THREAD,
-    typename InputIteratorT
->
-HIPCUB_DEVICE inline
-void LoadDirectStriped(int linear_id,
-                       InputIteratorT block_iter,
-                       T (&items)[ITEMS_PER_THREAD],
-                       int valid_items,
-                       Default oob_default)
+template <typename T, int ITEMS_PER_THREAD, typename InputIteratorT>
+HIPCUB_DEVICE inline void LoadDirectWarpStriped(int            linear_id,
+                                                InputIteratorT block_iter,
+                                                T (&items)[ITEMS_PER_THREAD],
+                                                int valid_items)
 {
-    ::rocprim::block_load_direct_striped<BLOCK_THREADS>(
-        linear_id, block_iter, items, valid_items, oob_default
-    );
+    ::rocprim::block_load_direct_warp_striped(linear_id, block_iter, items, valid_items);
 }
 
-template<
-    typename T,
-    int ITEMS_PER_THREAD,
-    typename InputIteratorT
->
-HIPCUB_DEVICE inline
-void LoadDirectWarpStriped(int linear_id,
-                           InputIteratorT block_iter,
-                           T (&items)[ITEMS_PER_THREAD])
+template <typename T, typename Default, int ITEMS_PER_THREAD, typename InputIteratorT>
+HIPCUB_DEVICE inline void LoadDirectWarpStriped(int            linear_id,
+                                                InputIteratorT block_iter,
+                                                T (&items)[ITEMS_PER_THREAD],
+                                                int     valid_items,
+                                                Default oob_default)
 {
     ::rocprim::block_load_direct_warp_striped(
-        linear_id, block_iter, items
-    );
-}
-
-template<
-    typename T,
-    int ITEMS_PER_THREAD,
-    typename InputIteratorT
->
-HIPCUB_DEVICE inline
-void LoadDirectWarpStriped(int linear_id,
-                           InputIteratorT block_iter,
-                           T (&items)[ITEMS_PER_THREAD],
-                           int valid_items)
-{
-    ::rocprim::block_load_direct_warp_striped(
-        linear_id, block_iter, items, valid_items
-    );
-}
-
-template<
-    typename T,
-    typename Default,
-    int ITEMS_PER_THREAD,
-    typename InputIteratorT
->
-HIPCUB_DEVICE inline
-void LoadDirectWarpStriped(int linear_id,
-                           InputIteratorT block_iter,
-                           T (&items)[ITEMS_PER_THREAD],
-                           int valid_items,
-                           Default oob_default)
-{
-    ::rocprim::block_load_direct_warp_striped(
-        linear_id, block_iter, items, valid_items, oob_default
-    );
+        linear_id, block_iter, items, valid_items, oob_default);
 }
 
 END_HIPCUB_NAMESPACE

--- a/hipcub/include/hipcub/rocprim/block/block_radix_sort.hpp
+++ b/hipcub/include/hipcub/rocprim/block/block_radix_sort.hpp
@@ -26,7 +26,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  ******************************************************************************/
- 
+
 #ifndef HIPCUB_ROCPRIM_BLOCK_BLOCK_RADIX_SORT_HPP_
 #define HIPCUB_ROCPRIM_BLOCK_BLOCK_RADIX_SORT_HPP_
 
@@ -38,39 +38,27 @@
 
 BEGIN_HIPCUB_NAMESPACE
 
-template<
-    typename KeyT,
-    int BLOCK_DIM_X,
-    int ITEMS_PER_THREAD,
-    typename ValueT = NullType,
-    int RADIX_BITS = 4, /* ignored */
-    bool MEMOIZE_OUTER_SCAN = true, /* ignored */
-    BlockScanAlgorithm INNER_SCAN_ALGORITHM = BLOCK_SCAN_WARP_SCANS, /* ignored */
-    hipSharedMemConfig SMEM_CONFIG = hipSharedMemBankSizeFourByte, /* ignored */
-    int BLOCK_DIM_Y = 1,
-    int BLOCK_DIM_Z = 1,
-    int PTX_ARCH = HIPCUB_ARCH /* ignored */
->
+template <typename KeyT,
+          int BLOCK_DIM_X,
+          int ITEMS_PER_THREAD,
+          typename ValueT                         = NullType,
+          int                RADIX_BITS           = 4, /* ignored */
+          bool               MEMOIZE_OUTER_SCAN   = true, /* ignored */
+          BlockScanAlgorithm INNER_SCAN_ALGORITHM = BLOCK_SCAN_WARP_SCANS, /* ignored */
+          hipSharedMemConfig SMEM_CONFIG          = hipSharedMemBankSizeFourByte, /* ignored */
+          int                BLOCK_DIM_Y          = 1,
+          int                BLOCK_DIM_Z          = 1,
+          int                PTX_ARCH             = HIPCUB_ARCH /* ignored */
+          >
 class BlockRadixSort
-    : private ::rocprim::block_radix_sort<
-        KeyT,
-        BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z,
-        ITEMS_PER_THREAD,
-        ValueT
-      >
+    : private ::rocprim::
+          block_radix_sort<KeyT, BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z, ITEMS_PER_THREAD, ValueT>
 {
-    static_assert(
-        BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z > 0,
-        "BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z must be greater than 0"
-    );
+    static_assert(BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z > 0,
+                  "BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z must be greater than 0");
 
-    using base_type =
-        typename ::rocprim::block_radix_sort<
-            KeyT,
-            BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z,
-            ITEMS_PER_THREAD,
-            ValueT
-        >;
+    using base_type = typename ::rocprim::
+        block_radix_sort<KeyT, BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z, ITEMS_PER_THREAD, ValueT>;
 
     // Reference to temporary storage (usually shared memory)
     typename base_type::storage_type& temp_storage_;
@@ -78,87 +66,77 @@ class BlockRadixSort
 public:
     using TempStorage = typename base_type::storage_type;
 
-    HIPCUB_DEVICE inline
-    BlockRadixSort() : temp_storage_(private_storage())
+    HIPCUB_DEVICE inline BlockRadixSort()
+        : temp_storage_(private_storage())
     {
     }
 
-    HIPCUB_DEVICE inline
-    BlockRadixSort(TempStorage& temp_storage) : temp_storage_(temp_storage)
+    HIPCUB_DEVICE inline BlockRadixSort(TempStorage& temp_storage)
+        : temp_storage_(temp_storage)
     {
     }
 
-    HIPCUB_DEVICE inline
-    void Sort(KeyT (&keys)[ITEMS_PER_THREAD],
-              int begin_bit = 0,
-              int end_bit = sizeof(KeyT) * 8)
+    HIPCUB_DEVICE inline void
+        Sort(KeyT (&keys)[ITEMS_PER_THREAD], int begin_bit = 0, int end_bit = sizeof(KeyT) * 8)
     {
         base_type::sort(keys, temp_storage_, begin_bit, end_bit);
     }
 
-    HIPCUB_DEVICE inline
-    void Sort(KeyT (&keys)[ITEMS_PER_THREAD],
-              ValueT (&values)[ITEMS_PER_THREAD],
-              int begin_bit = 0,
-              int end_bit = sizeof(KeyT) * 8)
+    HIPCUB_DEVICE inline void Sort(KeyT (&keys)[ITEMS_PER_THREAD],
+                                   ValueT (&values)[ITEMS_PER_THREAD],
+                                   int begin_bit = 0,
+                                   int end_bit   = sizeof(KeyT) * 8)
     {
         base_type::sort(keys, values, temp_storage_, begin_bit, end_bit);
     }
 
-    HIPCUB_DEVICE inline
-    void SortDescending(KeyT (&keys)[ITEMS_PER_THREAD],
-                        int begin_bit = 0,
-                        int end_bit = sizeof(KeyT) * 8)
+    HIPCUB_DEVICE inline void SortDescending(KeyT (&keys)[ITEMS_PER_THREAD],
+                                             int begin_bit = 0,
+                                             int end_bit   = sizeof(KeyT) * 8)
     {
         base_type::sort_desc(keys, temp_storage_, begin_bit, end_bit);
     }
 
-    HIPCUB_DEVICE inline
-    void SortDescending(KeyT (&keys)[ITEMS_PER_THREAD],
-                        ValueT (&values)[ITEMS_PER_THREAD],
-                        int begin_bit = 0,
-                        int end_bit = sizeof(KeyT) * 8)
+    HIPCUB_DEVICE inline void SortDescending(KeyT (&keys)[ITEMS_PER_THREAD],
+                                             ValueT (&values)[ITEMS_PER_THREAD],
+                                             int begin_bit = 0,
+                                             int end_bit   = sizeof(KeyT) * 8)
     {
         base_type::sort_desc(keys, values, temp_storage_, begin_bit, end_bit);
     }
 
-    HIPCUB_DEVICE inline
-    void SortBlockedToStriped(KeyT (&keys)[ITEMS_PER_THREAD],
-                              int begin_bit = 0,
-                              int end_bit = sizeof(KeyT) * 8)
+    HIPCUB_DEVICE inline void SortBlockedToStriped(KeyT (&keys)[ITEMS_PER_THREAD],
+                                                   int begin_bit = 0,
+                                                   int end_bit   = sizeof(KeyT) * 8)
     {
         base_type::sort_to_striped(keys, temp_storage_, begin_bit, end_bit);
     }
 
-    HIPCUB_DEVICE inline
-    void SortBlockedToStriped(KeyT (&keys)[ITEMS_PER_THREAD],
-                              ValueT (&values)[ITEMS_PER_THREAD],
-                              int begin_bit = 0,
-                              int end_bit = sizeof(KeyT) * 8)
+    HIPCUB_DEVICE inline void SortBlockedToStriped(KeyT (&keys)[ITEMS_PER_THREAD],
+                                                   ValueT (&values)[ITEMS_PER_THREAD],
+                                                   int begin_bit = 0,
+                                                   int end_bit   = sizeof(KeyT) * 8)
     {
         base_type::sort_to_striped(keys, values, temp_storage_, begin_bit, end_bit);
     }
 
-    HIPCUB_DEVICE inline
-    void SortDescendingBlockedToStriped(KeyT (&keys)[ITEMS_PER_THREAD],
-                                        int begin_bit = 0,
-                                        int end_bit = sizeof(KeyT) * 8)
+    HIPCUB_DEVICE inline void SortDescendingBlockedToStriped(KeyT (&keys)[ITEMS_PER_THREAD],
+                                                             int begin_bit = 0,
+                                                             int end_bit   = sizeof(KeyT) * 8)
     {
         base_type::sort_desc_to_striped(keys, temp_storage_, begin_bit, end_bit);
     }
 
-    HIPCUB_DEVICE inline
-    void SortDescendingBlockedToStriped(KeyT (&keys)[ITEMS_PER_THREAD],
-                                        ValueT (&values)[ITEMS_PER_THREAD],
-                                        int begin_bit = 0,
-                                        int end_bit = sizeof(KeyT) * 8)
+    HIPCUB_DEVICE inline void SortDescendingBlockedToStriped(KeyT (&keys)[ITEMS_PER_THREAD],
+                                                             ValueT (&values)[ITEMS_PER_THREAD],
+                                                             int begin_bit = 0,
+                                                             int end_bit   = sizeof(KeyT) * 8)
     {
         base_type::sort_desc_to_striped(keys, values, temp_storage_, begin_bit, end_bit);
     }
 
 private:
-    HIPCUB_DEVICE inline
-    TempStorage& private_storage()
+    HIPCUB_DEVICE inline TempStorage& private_storage()
     {
         HIPCUB_SHARED_MEMORY TempStorage private_storage;
         return private_storage;

--- a/hipcub/include/hipcub/rocprim/block/block_reduce.hpp
+++ b/hipcub/include/hipcub/rocprim/block/block_reduce.hpp
@@ -40,9 +40,8 @@ BEGIN_HIPCUB_NAMESPACE
 
 namespace detail
 {
-    inline constexpr
-    typename std::underlying_type<::rocprim::block_reduce_algorithm>::type
-    to_BlockReduceAlgorithm_enum(::rocprim::block_reduce_algorithm v)
+    inline constexpr typename std::underlying_type<::rocprim::block_reduce_algorithm>::type
+        to_BlockReduceAlgorithm_enum(::rocprim::block_reduce_algorithm v)
     {
         using utype = std::underlying_type<::rocprim::block_reduce_algorithm>::type;
         return static_cast<utype>(v);
@@ -52,39 +51,32 @@ namespace detail
 enum BlockReduceAlgorithm
 {
     BLOCK_REDUCE_RAKING_COMMUTATIVE_ONLY
-        = detail::to_BlockReduceAlgorithm_enum(::rocprim::block_reduce_algorithm::raking_reduce),
+    = detail::to_BlockReduceAlgorithm_enum(::rocprim::block_reduce_algorithm::raking_reduce),
     BLOCK_REDUCE_RAKING
-        = detail::to_BlockReduceAlgorithm_enum(::rocprim::block_reduce_algorithm::raking_reduce),
+    = detail::to_BlockReduceAlgorithm_enum(::rocprim::block_reduce_algorithm::raking_reduce),
     BLOCK_REDUCE_WARP_REDUCTIONS
-        = detail::to_BlockReduceAlgorithm_enum(::rocprim::block_reduce_algorithm::using_warp_reduce)
+    = detail::to_BlockReduceAlgorithm_enum(::rocprim::block_reduce_algorithm::using_warp_reduce)
 };
 
-template<
-    typename T,
-    int BLOCK_DIM_X,
-    BlockReduceAlgorithm ALGORITHM = BLOCK_REDUCE_WARP_REDUCTIONS,
-    int BLOCK_DIM_Y = 1,
-    int BLOCK_DIM_Z = 1,
-    int ARCH = HIPCUB_ARCH /* ignored */
->
+template <typename T,
+          int                  BLOCK_DIM_X,
+          BlockReduceAlgorithm ALGORITHM   = BLOCK_REDUCE_WARP_REDUCTIONS,
+          int                  BLOCK_DIM_Y = 1,
+          int                  BLOCK_DIM_Z = 1,
+          int                  ARCH        = HIPCUB_ARCH /* ignored */
+          >
 class BlockReduce
-    : private ::rocprim::block_reduce<
-        T,
-        BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z,
-        static_cast<::rocprim::block_reduce_algorithm>(ALGORITHM)
-      >
+    : private ::rocprim::block_reduce<T,
+                                      BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z,
+                                      static_cast<::rocprim::block_reduce_algorithm>(ALGORITHM)>
 {
-    static_assert(
-        BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z > 0,
-        "BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z must be greater than 0"
-    );
+    static_assert(BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z > 0,
+                  "BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z must be greater than 0");
 
     using base_type =
-        typename ::rocprim::block_reduce<
-            T,
-            BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z,
-            static_cast<::rocprim::block_reduce_algorithm>(ALGORITHM)
-        >;
+        typename ::rocprim::block_reduce<T,
+                                         BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z,
+                                         static_cast<::rocprim::block_reduce_algorithm>(ALGORITHM)>;
 
     // Reference to temporary storage (usually shared memory)
     typename base_type::storage_type& temp_storage_;
@@ -92,58 +84,52 @@ class BlockReduce
 public:
     using TempStorage = typename base_type::storage_type;
 
-    HIPCUB_DEVICE inline
-    BlockReduce() : temp_storage_(private_storage())
+    HIPCUB_DEVICE inline BlockReduce()
+        : temp_storage_(private_storage())
     {
     }
 
-    HIPCUB_DEVICE inline
-    BlockReduce(TempStorage& temp_storage) : temp_storage_(temp_storage)
+    HIPCUB_DEVICE inline BlockReduce(TempStorage& temp_storage)
+        : temp_storage_(temp_storage)
     {
     }
 
-    HIPCUB_DEVICE inline
-    T Sum(T input)
+    HIPCUB_DEVICE inline T Sum(T input)
     {
         base_type::reduce(input, input, temp_storage_);
         return input;
     }
 
-    HIPCUB_DEVICE inline
-    T Sum(T input, int valid_items)
+    HIPCUB_DEVICE inline T Sum(T input, int valid_items)
     {
         base_type::reduce(input, input, valid_items, temp_storage_);
         return input;
     }
 
-    template<int ITEMS_PER_THREAD>
-    HIPCUB_DEVICE inline
-    T Sum(T(&input)[ITEMS_PER_THREAD])
+    template <int ITEMS_PER_THREAD>
+    HIPCUB_DEVICE inline T Sum(T (&input)[ITEMS_PER_THREAD])
     {
         T output;
         base_type::reduce(input, output, temp_storage_);
         return output;
     }
 
-    template<typename ReduceOp>
-    HIPCUB_DEVICE inline
-    T Reduce(T input, ReduceOp reduce_op)
+    template <typename ReduceOp>
+    HIPCUB_DEVICE inline T Reduce(T input, ReduceOp reduce_op)
     {
         base_type::reduce(input, input, temp_storage_, reduce_op);
         return input;
     }
 
-    template<typename ReduceOp>
-    HIPCUB_DEVICE inline
-    T Reduce(T input, ReduceOp reduce_op, int valid_items)
+    template <typename ReduceOp>
+    HIPCUB_DEVICE inline T Reduce(T input, ReduceOp reduce_op, int valid_items)
     {
         base_type::reduce(input, input, valid_items, temp_storage_, reduce_op);
         return input;
     }
 
-    template<int ITEMS_PER_THREAD, typename ReduceOp>
-    HIPCUB_DEVICE inline
-    T Reduce(T(&input)[ITEMS_PER_THREAD], ReduceOp reduce_op)
+    template <int ITEMS_PER_THREAD, typename ReduceOp>
+    HIPCUB_DEVICE inline T Reduce(T (&input)[ITEMS_PER_THREAD], ReduceOp reduce_op)
     {
         T output;
         base_type::reduce(input, output, temp_storage_, reduce_op);
@@ -151,8 +137,7 @@ public:
     }
 
 private:
-    HIPCUB_DEVICE inline
-    TempStorage& private_storage()
+    HIPCUB_DEVICE inline TempStorage& private_storage()
     {
         HIPCUB_SHARED_MEMORY TempStorage private_storage;
         return private_storage;

--- a/hipcub/include/hipcub/rocprim/block/block_scan.hpp
+++ b/hipcub/include/hipcub/rocprim/block/block_scan.hpp
@@ -40,9 +40,8 @@ BEGIN_HIPCUB_NAMESPACE
 
 namespace detail
 {
-    inline constexpr
-    typename std::underlying_type<::rocprim::block_scan_algorithm>::type
-    to_BlockScanAlgorithm_enum(::rocprim::block_scan_algorithm v)
+    inline constexpr typename std::underlying_type<::rocprim::block_scan_algorithm>::type
+        to_BlockScanAlgorithm_enum(::rocprim::block_scan_algorithm v)
     {
         using utype = std::underlying_type<::rocprim::block_scan_algorithm>::type;
         return static_cast<utype>(v);
@@ -52,39 +51,32 @@ namespace detail
 enum BlockScanAlgorithm
 {
     BLOCK_SCAN_RAKING
-        = detail::to_BlockScanAlgorithm_enum(::rocprim::block_scan_algorithm::reduce_then_scan),
+    = detail::to_BlockScanAlgorithm_enum(::rocprim::block_scan_algorithm::reduce_then_scan),
     BLOCK_SCAN_RAKING_MEMOIZE
-        = detail::to_BlockScanAlgorithm_enum(::rocprim::block_scan_algorithm::reduce_then_scan),
+    = detail::to_BlockScanAlgorithm_enum(::rocprim::block_scan_algorithm::reduce_then_scan),
     BLOCK_SCAN_WARP_SCANS
-        = detail::to_BlockScanAlgorithm_enum(::rocprim::block_scan_algorithm::using_warp_scan)
+    = detail::to_BlockScanAlgorithm_enum(::rocprim::block_scan_algorithm::using_warp_scan)
 };
 
-template<
-    typename T,
-    int BLOCK_DIM_X,
-    BlockScanAlgorithm ALGORITHM = BLOCK_SCAN_RAKING,
-    int BLOCK_DIM_Y = 1,
-    int BLOCK_DIM_Z = 1,
-    int ARCH = HIPCUB_ARCH /* ignored */
->
+template <typename T,
+          int                BLOCK_DIM_X,
+          BlockScanAlgorithm ALGORITHM   = BLOCK_SCAN_RAKING,
+          int                BLOCK_DIM_Y = 1,
+          int                BLOCK_DIM_Z = 1,
+          int                ARCH        = HIPCUB_ARCH /* ignored */
+          >
 class BlockScan
-    : private ::rocprim::block_scan<
-        T,
-        BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z,
-        static_cast<::rocprim::block_scan_algorithm>(ALGORITHM)
-      >
+    : private ::rocprim::block_scan<T,
+                                    BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z,
+                                    static_cast<::rocprim::block_scan_algorithm>(ALGORITHM)>
 {
-    static_assert(
-        BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z > 0,
-        "BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z must be greater than 0"
-    );
+    static_assert(BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z > 0,
+                  "BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z must be greater than 0");
 
     using base_type =
-        typename ::rocprim::block_scan<
-            T,
-            BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z,
-            static_cast<::rocprim::block_scan_algorithm>(ALGORITHM)
-        >;
+        typename ::rocprim::block_scan<T,
+                                       BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z,
+                                       static_cast<::rocprim::block_scan_algorithm>(ALGORITHM)>;
 
     // Reference to temporary storage (usually shared memory)
     typename base_type::storage_type& temp_storage_;
@@ -92,214 +84,200 @@ class BlockScan
 public:
     using TempStorage = typename base_type::storage_type;
 
-    HIPCUB_DEVICE inline
-    BlockScan() : temp_storage_(private_storage())
+    HIPCUB_DEVICE inline BlockScan()
+        : temp_storage_(private_storage())
     {
     }
 
-    HIPCUB_DEVICE inline
-    BlockScan(TempStorage& temp_storage) : temp_storage_(temp_storage)
+    HIPCUB_DEVICE inline BlockScan(TempStorage& temp_storage)
+        : temp_storage_(temp_storage)
     {
     }
 
-    HIPCUB_DEVICE inline
-    void InclusiveSum(T input, T& output)
+    HIPCUB_DEVICE inline void InclusiveSum(T input, T& output)
     {
         base_type::inclusive_scan(input, output, temp_storage_);
     }
 
-    HIPCUB_DEVICE inline
-    void InclusiveSum(T input, T& output, T& block_aggregate)
+    HIPCUB_DEVICE inline void InclusiveSum(T input, T& output, T& block_aggregate)
     {
         base_type::inclusive_scan(input, output, block_aggregate, temp_storage_);
     }
 
-    template<typename BlockPrefixCallbackOp>
-    HIPCUB_DEVICE inline
-    void InclusiveSum(T input, T& output, BlockPrefixCallbackOp& block_prefix_callback_op)
+    template <typename BlockPrefixCallbackOp>
+    HIPCUB_DEVICE inline void
+        InclusiveSum(T input, T& output, BlockPrefixCallbackOp& block_prefix_callback_op)
     {
         base_type::inclusive_scan(
-            input, output, temp_storage_, block_prefix_callback_op, ::hipcub::Sum()
-        );
+            input, output, temp_storage_, block_prefix_callback_op, ::hipcub::Sum());
     }
 
-    template<int ITEMS_PER_THREAD>
-    HIPCUB_DEVICE inline
-    void InclusiveSum(T(&input)[ITEMS_PER_THREAD], T(&output)[ITEMS_PER_THREAD])
+    template <int ITEMS_PER_THREAD>
+    HIPCUB_DEVICE inline void InclusiveSum(T (&input)[ITEMS_PER_THREAD],
+                                           T (&output)[ITEMS_PER_THREAD])
     {
         base_type::inclusive_scan(input, output, temp_storage_);
     }
 
-    template<int ITEMS_PER_THREAD>
-    HIPCUB_DEVICE inline
-    void InclusiveSum(T(&input)[ITEMS_PER_THREAD], T(&output)[ITEMS_PER_THREAD],
-                      T& block_aggregate)
+    template <int ITEMS_PER_THREAD>
+    HIPCUB_DEVICE inline void InclusiveSum(T (&input)[ITEMS_PER_THREAD],
+                                           T (&output)[ITEMS_PER_THREAD],
+                                           T& block_aggregate)
     {
         base_type::inclusive_scan(input, output, block_aggregate, temp_storage_);
     }
 
-    template<int ITEMS_PER_THREAD, typename BlockPrefixCallbackOp>
-    HIPCUB_DEVICE inline
-    void InclusiveSum(T(&input)[ITEMS_PER_THREAD], T(&output)[ITEMS_PER_THREAD],
-                      BlockPrefixCallbackOp& block_prefix_callback_op)
+    template <int ITEMS_PER_THREAD, typename BlockPrefixCallbackOp>
+    HIPCUB_DEVICE inline void InclusiveSum(T (&input)[ITEMS_PER_THREAD],
+                                           T (&output)[ITEMS_PER_THREAD],
+                                           BlockPrefixCallbackOp& block_prefix_callback_op)
     {
         base_type::inclusive_scan(
-            input, output, temp_storage_, block_prefix_callback_op, ::hipcub::Sum()
-        );
+            input, output, temp_storage_, block_prefix_callback_op, ::hipcub::Sum());
     }
 
-    template<typename ScanOp>
-    HIPCUB_DEVICE inline
-    void InclusiveScan(T input, T& output, ScanOp scan_op)
+    template <typename ScanOp>
+    HIPCUB_DEVICE inline void InclusiveScan(T input, T& output, ScanOp scan_op)
     {
         base_type::inclusive_scan(input, output, temp_storage_, scan_op);
     }
 
-    template<typename ScanOp>
-    HIPCUB_DEVICE inline
-    void InclusiveScan(T input, T& output, ScanOp scan_op, T& block_aggregate)
+    template <typename ScanOp>
+    HIPCUB_DEVICE inline void InclusiveScan(T input, T& output, ScanOp scan_op, T& block_aggregate)
     {
         base_type::inclusive_scan(input, output, block_aggregate, temp_storage_, scan_op);
     }
 
-    template<typename ScanOp, typename BlockPrefixCallbackOp>
-    HIPCUB_DEVICE inline
-    void InclusiveScan(T input, T& output, ScanOp scan_op, BlockPrefixCallbackOp& block_prefix_callback_op)
+    template <typename ScanOp, typename BlockPrefixCallbackOp>
+    HIPCUB_DEVICE inline void InclusiveScan(T                      input,
+                                            T&                     output,
+                                            ScanOp                 scan_op,
+                                            BlockPrefixCallbackOp& block_prefix_callback_op)
     {
-        base_type::inclusive_scan(
-            input, output, temp_storage_, block_prefix_callback_op, scan_op
-        );
+        base_type::inclusive_scan(input, output, temp_storage_, block_prefix_callback_op, scan_op);
     }
 
-    template<int ITEMS_PER_THREAD, typename ScanOp>
-    HIPCUB_DEVICE inline
-    void InclusiveScan(T(&input)[ITEMS_PER_THREAD], T(&output)[ITEMS_PER_THREAD], ScanOp scan_op)
+    template <int ITEMS_PER_THREAD, typename ScanOp>
+    HIPCUB_DEVICE inline void
+        InclusiveScan(T (&input)[ITEMS_PER_THREAD], T (&output)[ITEMS_PER_THREAD], ScanOp scan_op)
     {
         base_type::inclusive_scan(input, output, temp_storage_, scan_op);
     }
 
-    template<int ITEMS_PER_THREAD, typename ScanOp>
-    HIPCUB_DEVICE inline
-    void InclusiveScan(T(&input)[ITEMS_PER_THREAD], T(&output)[ITEMS_PER_THREAD],
-                       ScanOp scan_op, T& block_aggregate)
+    template <int ITEMS_PER_THREAD, typename ScanOp>
+    HIPCUB_DEVICE inline void InclusiveScan(T (&input)[ITEMS_PER_THREAD],
+                                            T (&output)[ITEMS_PER_THREAD],
+                                            ScanOp scan_op,
+                                            T&     block_aggregate)
     {
         base_type::inclusive_scan(input, output, block_aggregate, temp_storage_, scan_op);
     }
 
-    template<int ITEMS_PER_THREAD, typename ScanOp, typename BlockPrefixCallbackOp>
-    HIPCUB_DEVICE inline
-    void InclusiveScan(T(&input)[ITEMS_PER_THREAD], T(&output)[ITEMS_PER_THREAD],
-                       ScanOp scan_op, BlockPrefixCallbackOp& block_prefix_callback_op)
+    template <int ITEMS_PER_THREAD, typename ScanOp, typename BlockPrefixCallbackOp>
+    HIPCUB_DEVICE inline void InclusiveScan(T (&input)[ITEMS_PER_THREAD],
+                                            T (&output)[ITEMS_PER_THREAD],
+                                            ScanOp                 scan_op,
+                                            BlockPrefixCallbackOp& block_prefix_callback_op)
     {
-        base_type::inclusive_scan(
-            input, output, temp_storage_, block_prefix_callback_op, scan_op
-        );
+        base_type::inclusive_scan(input, output, temp_storage_, block_prefix_callback_op, scan_op);
     }
 
-    HIPCUB_DEVICE inline
-    void ExclusiveSum(T input, T& output)
+    HIPCUB_DEVICE inline void ExclusiveSum(T input, T& output)
     {
         base_type::exclusive_scan(input, output, T(0), temp_storage_);
     }
 
-    HIPCUB_DEVICE inline
-    void ExclusiveSum(T input, T& output, T& block_aggregate)
+    HIPCUB_DEVICE inline void ExclusiveSum(T input, T& output, T& block_aggregate)
     {
         base_type::exclusive_scan(input, output, T(0), block_aggregate, temp_storage_);
     }
 
-    template<typename BlockPrefixCallbackOp>
-    HIPCUB_DEVICE inline
-    void ExclusiveSum(T input, T& output, BlockPrefixCallbackOp& block_prefix_callback_op)
+    template <typename BlockPrefixCallbackOp>
+    HIPCUB_DEVICE inline void
+        ExclusiveSum(T input, T& output, BlockPrefixCallbackOp& block_prefix_callback_op)
     {
         base_type::exclusive_scan(
-            input, output, temp_storage_, block_prefix_callback_op, ::hipcub::Sum()
-        );
+            input, output, temp_storage_, block_prefix_callback_op, ::hipcub::Sum());
     }
 
-    template<int ITEMS_PER_THREAD>
-    HIPCUB_DEVICE inline
-    void ExclusiveSum(T(&input)[ITEMS_PER_THREAD], T(&output)[ITEMS_PER_THREAD])
+    template <int ITEMS_PER_THREAD>
+    HIPCUB_DEVICE inline void ExclusiveSum(T (&input)[ITEMS_PER_THREAD],
+                                           T (&output)[ITEMS_PER_THREAD])
     {
         base_type::exclusive_scan(input, output, T(0), temp_storage_);
     }
 
-    template<int ITEMS_PER_THREAD>
-    HIPCUB_DEVICE inline
-    void ExclusiveSum(T(&input)[ITEMS_PER_THREAD], T(&output)[ITEMS_PER_THREAD],
-                      T& block_aggregate)
+    template <int ITEMS_PER_THREAD>
+    HIPCUB_DEVICE inline void ExclusiveSum(T (&input)[ITEMS_PER_THREAD],
+                                           T (&output)[ITEMS_PER_THREAD],
+                                           T& block_aggregate)
     {
         base_type::exclusive_scan(input, output, T(0), block_aggregate, temp_storage_);
     }
 
-    template<int ITEMS_PER_THREAD, typename BlockPrefixCallbackOp>
-    HIPCUB_DEVICE inline
-    void ExclusiveSum(T(&input)[ITEMS_PER_THREAD], T(&output)[ITEMS_PER_THREAD],
-                      BlockPrefixCallbackOp& block_prefix_callback_op)
+    template <int ITEMS_PER_THREAD, typename BlockPrefixCallbackOp>
+    HIPCUB_DEVICE inline void ExclusiveSum(T (&input)[ITEMS_PER_THREAD],
+                                           T (&output)[ITEMS_PER_THREAD],
+                                           BlockPrefixCallbackOp& block_prefix_callback_op)
     {
         base_type::exclusive_scan(
-            input, output, temp_storage_, block_prefix_callback_op, ::hipcub::Sum()
-        );
+            input, output, temp_storage_, block_prefix_callback_op, ::hipcub::Sum());
     }
 
-    template<typename ScanOp>
-    HIPCUB_DEVICE inline
-    void ExclusiveScan(T input, T& output, T initial_value, ScanOp scan_op)
+    template <typename ScanOp>
+    HIPCUB_DEVICE inline void ExclusiveScan(T input, T& output, T initial_value, ScanOp scan_op)
     {
         base_type::exclusive_scan(input, output, initial_value, temp_storage_, scan_op);
     }
 
-    template<typename ScanOp>
-    HIPCUB_DEVICE inline
-    void ExclusiveScan(T input, T& output, T initial_value,
-                       ScanOp scan_op, T& block_aggregate)
+    template <typename ScanOp>
+    HIPCUB_DEVICE inline void
+        ExclusiveScan(T input, T& output, T initial_value, ScanOp scan_op, T& block_aggregate)
     {
         base_type::exclusive_scan(
-            input, output, initial_value, block_aggregate, temp_storage_, scan_op
-        );
+            input, output, initial_value, block_aggregate, temp_storage_, scan_op);
     }
 
-    template<typename ScanOp, typename BlockPrefixCallbackOp>
-    HIPCUB_DEVICE inline
-    void ExclusiveScan(T input, T& output, ScanOp scan_op,
-                       BlockPrefixCallbackOp& block_prefix_callback_op)
+    template <typename ScanOp, typename BlockPrefixCallbackOp>
+    HIPCUB_DEVICE inline void ExclusiveScan(T                      input,
+                                            T&                     output,
+                                            ScanOp                 scan_op,
+                                            BlockPrefixCallbackOp& block_prefix_callback_op)
     {
-        base_type::exclusive_scan(
-            input, output, temp_storage_, block_prefix_callback_op, scan_op
-        );
+        base_type::exclusive_scan(input, output, temp_storage_, block_prefix_callback_op, scan_op);
     }
 
-    template<int ITEMS_PER_THREAD, typename ScanOp>
-    HIPCUB_DEVICE inline
-    void ExclusiveScan(T(&input)[ITEMS_PER_THREAD], T(&output)[ITEMS_PER_THREAD],
-                       T initial_value, ScanOp scan_op)
+    template <int ITEMS_PER_THREAD, typename ScanOp>
+    HIPCUB_DEVICE inline void ExclusiveScan(T (&input)[ITEMS_PER_THREAD],
+                                            T (&output)[ITEMS_PER_THREAD],
+                                            T      initial_value,
+                                            ScanOp scan_op)
     {
         base_type::exclusive_scan(input, output, initial_value, temp_storage_, scan_op);
     }
 
-    template<int ITEMS_PER_THREAD, typename ScanOp>
-    HIPCUB_DEVICE inline
-    void ExclusiveScan(T(&input)[ITEMS_PER_THREAD], T(&output)[ITEMS_PER_THREAD],
-                       T initial_value, ScanOp scan_op, T& block_aggregate)
+    template <int ITEMS_PER_THREAD, typename ScanOp>
+    HIPCUB_DEVICE inline void ExclusiveScan(T (&input)[ITEMS_PER_THREAD],
+                                            T (&output)[ITEMS_PER_THREAD],
+                                            T      initial_value,
+                                            ScanOp scan_op,
+                                            T&     block_aggregate)
     {
         base_type::exclusive_scan(
-            input, output, initial_value, block_aggregate, temp_storage_, scan_op
-        );
+            input, output, initial_value, block_aggregate, temp_storage_, scan_op);
     }
 
-    template<int ITEMS_PER_THREAD, typename ScanOp, typename BlockPrefixCallbackOp>
-    HIPCUB_DEVICE inline
-    void ExclusiveScan(T(&input)[ITEMS_PER_THREAD], T(&output)[ITEMS_PER_THREAD],
-                       ScanOp scan_op, BlockPrefixCallbackOp& block_prefix_callback_op)
+    template <int ITEMS_PER_THREAD, typename ScanOp, typename BlockPrefixCallbackOp>
+    HIPCUB_DEVICE inline void ExclusiveScan(T (&input)[ITEMS_PER_THREAD],
+                                            T (&output)[ITEMS_PER_THREAD],
+                                            ScanOp                 scan_op,
+                                            BlockPrefixCallbackOp& block_prefix_callback_op)
     {
-        base_type::exclusive_scan(
-            input, output, temp_storage_, block_prefix_callback_op, scan_op
-        );
+        base_type::exclusive_scan(input, output, temp_storage_, block_prefix_callback_op, scan_op);
     }
 
 private:
-    HIPCUB_DEVICE inline
-    TempStorage& private_storage()
+    HIPCUB_DEVICE inline TempStorage& private_storage()
     {
         HIPCUB_SHARED_MEMORY TempStorage private_storage;
         return private_storage;

--- a/hipcub/include/hipcub/rocprim/block/block_store.hpp
+++ b/hipcub/include/hipcub/rocprim/block/block_store.hpp
@@ -40,9 +40,8 @@ BEGIN_HIPCUB_NAMESPACE
 
 namespace detail
 {
-    inline constexpr
-    typename std::underlying_type<::rocprim::block_store_method>::type
-    to_BlockStoreAlgorithm_enum(::rocprim::block_store_method v)
+    inline constexpr typename std::underlying_type<::rocprim::block_store_method>::type
+        to_BlockStoreAlgorithm_enum(::rocprim::block_store_method v)
     {
         using utype = std::underlying_type<::rocprim::block_store_method>::type;
         return static_cast<utype>(v);
@@ -52,46 +51,39 @@ namespace detail
 enum BlockStoreAlgorithm
 {
     BLOCK_STORE_DIRECT
-        = detail::to_BlockStoreAlgorithm_enum(::rocprim::block_store_method::block_store_direct),
+    = detail::to_BlockStoreAlgorithm_enum(::rocprim::block_store_method::block_store_direct),
     BLOCK_STORE_VECTORIZE
-        = detail::to_BlockStoreAlgorithm_enum(::rocprim::block_store_method::block_store_vectorize),
+    = detail::to_BlockStoreAlgorithm_enum(::rocprim::block_store_method::block_store_vectorize),
     BLOCK_STORE_TRANSPOSE
-        = detail::to_BlockStoreAlgorithm_enum(::rocprim::block_store_method::block_store_transpose),
-    BLOCK_STORE_WARP_TRANSPOSE
-        = detail::to_BlockStoreAlgorithm_enum(::rocprim::block_store_method::block_store_warp_transpose),
+    = detail::to_BlockStoreAlgorithm_enum(::rocprim::block_store_method::block_store_transpose),
+    BLOCK_STORE_WARP_TRANSPOSE = detail::to_BlockStoreAlgorithm_enum(
+        ::rocprim::block_store_method::block_store_warp_transpose),
     BLOCK_STORE_WARP_TRANSPOSE_TIMESLICED
-        = detail::to_BlockStoreAlgorithm_enum(::rocprim::block_store_method::block_store_warp_transpose)
+    = detail::to_BlockStoreAlgorithm_enum(::rocprim::block_store_method::block_store_warp_transpose)
 };
 
-template<
-    typename T,
-    int BLOCK_DIM_X,
-    int ITEMS_PER_THREAD,
-    BlockStoreAlgorithm ALGORITHM = BLOCK_STORE_DIRECT,
-    int BLOCK_DIM_Y = 1,
-    int BLOCK_DIM_Z = 1,
-    int ARCH = HIPCUB_ARCH /* ignored */
->
+template <typename T,
+          int                 BLOCK_DIM_X,
+          int                 ITEMS_PER_THREAD,
+          BlockStoreAlgorithm ALGORITHM   = BLOCK_STORE_DIRECT,
+          int                 BLOCK_DIM_Y = 1,
+          int                 BLOCK_DIM_Z = 1,
+          int                 ARCH        = HIPCUB_ARCH /* ignored */
+          >
 class BlockStore
-    : private ::rocprim::block_store<
-        T,
-        BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z,
-        ITEMS_PER_THREAD,
-        static_cast<::rocprim::block_store_method>(ALGORITHM)
-      >
+    : private ::rocprim::block_store<T,
+                                     BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z,
+                                     ITEMS_PER_THREAD,
+                                     static_cast<::rocprim::block_store_method>(ALGORITHM)>
 {
-    static_assert(
-        BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z > 0,
-        "BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z must be greater than 0"
-    );
+    static_assert(BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z > 0,
+                  "BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z must be greater than 0");
 
     using base_type =
-        typename ::rocprim::block_store<
-            T,
-            BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z,
-            ITEMS_PER_THREAD,
-            static_cast<::rocprim::block_store_method>(ALGORITHM)
-        >;
+        typename ::rocprim::block_store<T,
+                                        BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z,
+                                        ITEMS_PER_THREAD,
+                                        static_cast<::rocprim::block_store_method>(ALGORITHM)>;
 
     // Reference to temporary storage (usually shared memory)
     typename base_type::storage_type& temp_storage_;
@@ -99,36 +91,31 @@ class BlockStore
 public:
     using TempStorage = typename base_type::storage_type;
 
-    HIPCUB_DEVICE inline
-    BlockStore() : temp_storage_(private_storage())
+    HIPCUB_DEVICE inline BlockStore()
+        : temp_storage_(private_storage())
     {
     }
 
-    HIPCUB_DEVICE inline
-    BlockStore(TempStorage& temp_storage) : temp_storage_(temp_storage)
+    HIPCUB_DEVICE inline BlockStore(TempStorage& temp_storage)
+        : temp_storage_(temp_storage)
     {
     }
 
-    template<class OutputIteratorT>
-    HIPCUB_DEVICE inline
-    void Store(OutputIteratorT block_iter,
-               T (&items)[ITEMS_PER_THREAD])
+    template <class OutputIteratorT>
+    HIPCUB_DEVICE inline void Store(OutputIteratorT block_iter, T (&items)[ITEMS_PER_THREAD])
     {
         base_type::store(block_iter, items, temp_storage_);
     }
 
-    template<class OutputIteratorT>
-    HIPCUB_DEVICE inline
-    void Store(OutputIteratorT block_iter,
-               T (&items)[ITEMS_PER_THREAD],
-               int valid_items)
+    template <class OutputIteratorT>
+    HIPCUB_DEVICE inline void
+        Store(OutputIteratorT block_iter, T (&items)[ITEMS_PER_THREAD], int valid_items)
     {
         base_type::store(block_iter, items, valid_items, temp_storage_);
     }
 
 private:
-    HIPCUB_DEVICE inline
-    TempStorage& private_storage()
+    HIPCUB_DEVICE inline TempStorage& private_storage()
     {
         HIPCUB_SHARED_MEMORY TempStorage private_storage;
         return private_storage;

--- a/hipcub/include/hipcub/rocprim/block/block_store_func.hpp
+++ b/hipcub/include/hipcub/rocprim/block/block_store_func.hpp
@@ -34,113 +34,59 @@
 
 BEGIN_HIPCUB_NAMESPACE
 
-template<
-    typename T,
-    int ITEMS_PER_THREAD,
-    typename OutputIteratorT
->
-HIPCUB_DEVICE inline
-void StoreDirectBlocked(int linear_id,
-                        OutputIteratorT block_iter,
-                        T (&items)[ITEMS_PER_THREAD])
+template <typename T, int ITEMS_PER_THREAD, typename OutputIteratorT>
+HIPCUB_DEVICE inline void
+    StoreDirectBlocked(int linear_id, OutputIteratorT block_iter, T (&items)[ITEMS_PER_THREAD])
 {
-    ::rocprim::block_store_direct_blocked(
-        linear_id, block_iter, items
-    );
+    ::rocprim::block_store_direct_blocked(linear_id, block_iter, items);
 }
 
-template<
-    typename T,
-    int ITEMS_PER_THREAD,
-    typename OutputIteratorT
->
-HIPCUB_DEVICE inline
-void StoreDirectBlocked(int linear_id,
-                        OutputIteratorT block_iter,
-                        T (&items)[ITEMS_PER_THREAD],
-                        int valid_items)
+template <typename T, int ITEMS_PER_THREAD, typename OutputIteratorT>
+HIPCUB_DEVICE inline void StoreDirectBlocked(int             linear_id,
+                                             OutputIteratorT block_iter,
+                                             T (&items)[ITEMS_PER_THREAD],
+                                             int valid_items)
 {
-    ::rocprim::block_store_direct_blocked(
-        linear_id, block_iter, items, valid_items
-    );
+    ::rocprim::block_store_direct_blocked(linear_id, block_iter, items, valid_items);
 }
 
-template <
-    typename T,
-    int ITEMS_PER_THREAD
->
-HIPCUB_DEVICE inline
-void StoreDirectBlockedVectorized(int linear_id,
-                                  T* block_iter,
-                                  T (&items)[ITEMS_PER_THREAD])
+template <typename T, int ITEMS_PER_THREAD>
+HIPCUB_DEVICE inline void
+    StoreDirectBlockedVectorized(int linear_id, T* block_iter, T (&items)[ITEMS_PER_THREAD])
 {
-    ::rocprim::block_store_direct_blocked_vectorized(
-        linear_id, block_iter, items
-    );
+    ::rocprim::block_store_direct_blocked_vectorized(linear_id, block_iter, items);
 }
 
-template<
-    int BLOCK_THREADS,
-    typename T,
-    int ITEMS_PER_THREAD,
-    typename OutputIteratorT
->
-HIPCUB_DEVICE inline
-void StoreDirectStriped(int linear_id,
-                        OutputIteratorT block_iter,
-                        T (&items)[ITEMS_PER_THREAD])
+template <int BLOCK_THREADS, typename T, int ITEMS_PER_THREAD, typename OutputIteratorT>
+HIPCUB_DEVICE inline void
+    StoreDirectStriped(int linear_id, OutputIteratorT block_iter, T (&items)[ITEMS_PER_THREAD])
 {
-    ::rocprim::block_store_direct_striped<BLOCK_THREADS>(
-        linear_id, block_iter, items
-    );
+    ::rocprim::block_store_direct_striped<BLOCK_THREADS>(linear_id, block_iter, items);
 }
 
-template<
-    int BLOCK_THREADS,
-    typename T,
-    int ITEMS_PER_THREAD,
-    typename OutputIteratorT
->
-HIPCUB_DEVICE inline
-void StoreDirectStriped(int linear_id,
-                        OutputIteratorT block_iter,
-                        T (&items)[ITEMS_PER_THREAD],
-                        int valid_items)
+template <int BLOCK_THREADS, typename T, int ITEMS_PER_THREAD, typename OutputIteratorT>
+HIPCUB_DEVICE inline void StoreDirectStriped(int             linear_id,
+                                             OutputIteratorT block_iter,
+                                             T (&items)[ITEMS_PER_THREAD],
+                                             int valid_items)
 {
-    ::rocprim::block_store_direct_striped<BLOCK_THREADS>(
-        linear_id, block_iter, items, valid_items
-    );
+    ::rocprim::block_store_direct_striped<BLOCK_THREADS>(linear_id, block_iter, items, valid_items);
 }
 
-template<
-    typename T,
-    int ITEMS_PER_THREAD,
-    typename OutputIteratorT
->
-HIPCUB_DEVICE inline
-void StoreDirectWarpStriped(int linear_id,
-                            OutputIteratorT block_iter,
-                            T (&items)[ITEMS_PER_THREAD])
+template <typename T, int ITEMS_PER_THREAD, typename OutputIteratorT>
+HIPCUB_DEVICE inline void
+    StoreDirectWarpStriped(int linear_id, OutputIteratorT block_iter, T (&items)[ITEMS_PER_THREAD])
 {
-    ::rocprim::block_store_direct_warp_striped(
-        linear_id, block_iter, items
-    );
+    ::rocprim::block_store_direct_warp_striped(linear_id, block_iter, items);
 }
 
-template<
-    typename T,
-    int ITEMS_PER_THREAD,
-    typename OutputIteratorT
->
-HIPCUB_DEVICE inline
-void StoreDirectWarpStriped(int linear_id,
-                            OutputIteratorT block_iter,
-                            T (&items)[ITEMS_PER_THREAD],
-                            int valid_items)
+template <typename T, int ITEMS_PER_THREAD, typename OutputIteratorT>
+HIPCUB_DEVICE inline void StoreDirectWarpStriped(int             linear_id,
+                                                 OutputIteratorT block_iter,
+                                                 T (&items)[ITEMS_PER_THREAD],
+                                                 int valid_items)
 {
-    ::rocprim::block_store_direct_warp_striped(
-        linear_id, block_iter, items, valid_items
-    );
+    ::rocprim::block_store_direct_warp_striped(linear_id, block_iter, items, valid_items);
 }
 
 END_HIPCUB_NAMESPACE

--- a/hipcub/include/hipcub/rocprim/device/device_histogram.hpp
+++ b/hipcub/include/hipcub/rocprim/device/device_histogram.hpp
@@ -38,81 +38,75 @@ BEGIN_HIPCUB_NAMESPACE
 
 struct DeviceHistogram
 {
-    template<
-        typename SampleIteratorT,
-        typename CounterT,
-        typename LevelT,
-        typename OffsetT
-    >
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t HistogramEven(void * d_temp_storage,
-                             size_t& temp_storage_bytes,
-                             SampleIteratorT d_samples,
-                             CounterT * d_histogram,
-                             int num_levels,
-                             LevelT lower_level,
-                             LevelT upper_level,
-                             OffsetT num_samples,
-                             hipStream_t stream = 0,
-                             bool debug_synchronous = false)
+    template <typename SampleIteratorT, typename CounterT, typename LevelT, typename OffsetT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t HistogramEven(void*           d_temp_storage,
+                                                            size_t&         temp_storage_bytes,
+                                                            SampleIteratorT d_samples,
+                                                            CounterT*       d_histogram,
+                                                            int             num_levels,
+                                                            LevelT          lower_level,
+                                                            LevelT          upper_level,
+                                                            OffsetT         num_samples,
+                                                            hipStream_t     stream = 0,
+                                                            bool debug_synchronous = false)
     {
-        return ::rocprim::histogram_even(
-            d_temp_storage, temp_storage_bytes,
-            d_samples, num_samples,
-            d_histogram,
-            num_levels, lower_level, upper_level,
-            stream, debug_synchronous
-        );
+        return ::rocprim::histogram_even(d_temp_storage,
+                                         temp_storage_bytes,
+                                         d_samples,
+                                         num_samples,
+                                         d_histogram,
+                                         num_levels,
+                                         lower_level,
+                                         upper_level,
+                                         stream,
+                                         debug_synchronous);
     }
 
-    template<
-        typename SampleIteratorT,
-        typename CounterT,
-        typename LevelT,
-        typename OffsetT
-    >
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t HistogramEven(void * d_temp_storage,
-                             size_t& temp_storage_bytes,
-                             SampleIteratorT d_samples,
-                             CounterT * d_histogram,
-                             int num_levels,
-                             LevelT lower_level,
-                             LevelT upper_level,
-                             OffsetT num_row_samples,
-                             OffsetT num_rows,
-                             size_t row_stride_bytes,
-                             hipStream_t stream = 0,
-                             bool debug_synchronous = false)
+    template <typename SampleIteratorT, typename CounterT, typename LevelT, typename OffsetT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t HistogramEven(void*           d_temp_storage,
+                                                            size_t&         temp_storage_bytes,
+                                                            SampleIteratorT d_samples,
+                                                            CounterT*       d_histogram,
+                                                            int             num_levels,
+                                                            LevelT          lower_level,
+                                                            LevelT          upper_level,
+                                                            OffsetT         num_row_samples,
+                                                            OffsetT         num_rows,
+                                                            size_t          row_stride_bytes,
+                                                            hipStream_t     stream = 0,
+                                                            bool debug_synchronous = false)
     {
-        return ::rocprim::histogram_even(
-            d_temp_storage, temp_storage_bytes,
-            d_samples, num_row_samples, num_rows, row_stride_bytes,
-            d_histogram,
-            num_levels, lower_level, upper_level,
-            stream, debug_synchronous
-        );
+        return ::rocprim::histogram_even(d_temp_storage,
+                                         temp_storage_bytes,
+                                         d_samples,
+                                         num_row_samples,
+                                         num_rows,
+                                         row_stride_bytes,
+                                         d_histogram,
+                                         num_levels,
+                                         lower_level,
+                                         upper_level,
+                                         stream,
+                                         debug_synchronous);
     }
 
-    template<
-        int NUM_CHANNELS,
-        int NUM_ACTIVE_CHANNELS,
-        typename SampleIteratorT,
-        typename CounterT,
-        typename LevelT,
-        typename OffsetT
-    >
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t MultiHistogramEven(void * d_temp_storage,
-                                  size_t& temp_storage_bytes,
-                                  SampleIteratorT d_samples,
-                                  CounterT * d_histogram[NUM_ACTIVE_CHANNELS],
-                                  int num_levels[NUM_ACTIVE_CHANNELS],
-                                  LevelT lower_level[NUM_ACTIVE_CHANNELS],
-                                  LevelT upper_level[NUM_ACTIVE_CHANNELS],
-                                  OffsetT num_pixels,
-                                  hipStream_t stream = 0,
-                                  bool debug_synchronous = false)
+    template <int NUM_CHANNELS,
+              int NUM_ACTIVE_CHANNELS,
+              typename SampleIteratorT,
+              typename CounterT,
+              typename LevelT,
+              typename OffsetT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t
+        MultiHistogramEven(void*           d_temp_storage,
+                           size_t&         temp_storage_bytes,
+                           SampleIteratorT d_samples,
+                           CounterT*       d_histogram[NUM_ACTIVE_CHANNELS],
+                           int             num_levels[NUM_ACTIVE_CHANNELS],
+                           LevelT          lower_level[NUM_ACTIVE_CHANNELS],
+                           LevelT          upper_level[NUM_ACTIVE_CHANNELS],
+                           OffsetT         num_pixels,
+                           hipStream_t     stream            = 0,
+                           bool            debug_synchronous = false)
     {
         unsigned int levels[NUM_ACTIVE_CHANNELS];
         for(unsigned int channel = 0; channel < NUM_ACTIVE_CHANNELS; channel++)
@@ -120,35 +114,37 @@ struct DeviceHistogram
             levels[channel] = num_levels[channel];
         }
         return ::rocprim::multi_histogram_even<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
-            d_temp_storage, temp_storage_bytes,
-            d_samples, num_pixels,
+            d_temp_storage,
+            temp_storage_bytes,
+            d_samples,
+            num_pixels,
             d_histogram,
-            levels, lower_level, upper_level,
-            stream, debug_synchronous
-        );
+            levels,
+            lower_level,
+            upper_level,
+            stream,
+            debug_synchronous);
     }
 
-    template<
-        int NUM_CHANNELS,
-        int NUM_ACTIVE_CHANNELS,
-        typename SampleIteratorT,
-        typename CounterT,
-        typename LevelT,
-        typename OffsetT
-    >
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t MultiHistogramEven(void * d_temp_storage,
-                                  size_t& temp_storage_bytes,
-                                  SampleIteratorT d_samples,
-                                  CounterT * d_histogram[NUM_ACTIVE_CHANNELS],
-                                  int num_levels[NUM_ACTIVE_CHANNELS],
-                                  LevelT lower_level[NUM_ACTIVE_CHANNELS],
-                                  LevelT upper_level[NUM_ACTIVE_CHANNELS],
-                                  OffsetT num_row_pixels,
-                                  OffsetT num_rows,
-                                  size_t row_stride_bytes,
-                                  hipStream_t stream = 0,
-                                  bool debug_synchronous = false)
+    template <int NUM_CHANNELS,
+              int NUM_ACTIVE_CHANNELS,
+              typename SampleIteratorT,
+              typename CounterT,
+              typename LevelT,
+              typename OffsetT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t
+        MultiHistogramEven(void*           d_temp_storage,
+                           size_t&         temp_storage_bytes,
+                           SampleIteratorT d_samples,
+                           CounterT*       d_histogram[NUM_ACTIVE_CHANNELS],
+                           int             num_levels[NUM_ACTIVE_CHANNELS],
+                           LevelT          lower_level[NUM_ACTIVE_CHANNELS],
+                           LevelT          upper_level[NUM_ACTIVE_CHANNELS],
+                           OffsetT         num_row_pixels,
+                           OffsetT         num_rows,
+                           size_t          row_stride_bytes,
+                           hipStream_t     stream            = 0,
+                           bool            debug_synchronous = false)
     {
         unsigned int levels[NUM_ACTIVE_CHANNELS];
         for(unsigned int channel = 0; channel < NUM_ACTIVE_CHANNELS; channel++)
@@ -156,86 +152,84 @@ struct DeviceHistogram
             levels[channel] = num_levels[channel];
         }
         return ::rocprim::multi_histogram_even<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
-            d_temp_storage, temp_storage_bytes,
-            d_samples, num_row_pixels, num_rows, row_stride_bytes,
+            d_temp_storage,
+            temp_storage_bytes,
+            d_samples,
+            num_row_pixels,
+            num_rows,
+            row_stride_bytes,
             d_histogram,
-            levels, lower_level, upper_level,
-            stream, debug_synchronous
-        );
+            levels,
+            lower_level,
+            upper_level,
+            stream,
+            debug_synchronous);
     }
 
-    template<
-        typename SampleIteratorT,
-        typename CounterT,
-        typename LevelT,
-        typename OffsetT
-    >
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t HistogramRange(void * d_temp_storage,
-                              size_t& temp_storage_bytes,
-                              SampleIteratorT d_samples,
-                              CounterT * d_histogram,
-                              int num_levels,
-                              LevelT * d_levels,
-                              OffsetT num_samples,
-                              hipStream_t stream = 0,
-                              bool debug_synchronous = false)
+    template <typename SampleIteratorT, typename CounterT, typename LevelT, typename OffsetT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t HistogramRange(void*           d_temp_storage,
+                                                             size_t&         temp_storage_bytes,
+                                                             SampleIteratorT d_samples,
+                                                             CounterT*       d_histogram,
+                                                             int             num_levels,
+                                                             LevelT*         d_levels,
+                                                             OffsetT         num_samples,
+                                                             hipStream_t     stream = 0,
+                                                             bool debug_synchronous = false)
     {
-        return ::rocprim::histogram_range(
-            d_temp_storage, temp_storage_bytes,
-            d_samples, num_samples,
-            d_histogram,
-            num_levels, d_levels,
-            stream, debug_synchronous
-        );
+        return ::rocprim::histogram_range(d_temp_storage,
+                                          temp_storage_bytes,
+                                          d_samples,
+                                          num_samples,
+                                          d_histogram,
+                                          num_levels,
+                                          d_levels,
+                                          stream,
+                                          debug_synchronous);
     }
 
-    template<
-        typename SampleIteratorT,
-        typename CounterT,
-        typename LevelT,
-        typename OffsetT
-    >
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t HistogramRange(void * d_temp_storage,
-                              size_t& temp_storage_bytes,
-                              SampleIteratorT d_samples,
-                              CounterT * d_histogram,
-                              int num_levels,
-                              LevelT * d_levels,
-                              OffsetT num_row_samples,
-                              OffsetT num_rows,
-                              size_t row_stride_bytes,
-                              hipStream_t stream = 0,
-                              bool debug_synchronous = false)
+    template <typename SampleIteratorT, typename CounterT, typename LevelT, typename OffsetT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t HistogramRange(void*           d_temp_storage,
+                                                             size_t&         temp_storage_bytes,
+                                                             SampleIteratorT d_samples,
+                                                             CounterT*       d_histogram,
+                                                             int             num_levels,
+                                                             LevelT*         d_levels,
+                                                             OffsetT         num_row_samples,
+                                                             OffsetT         num_rows,
+                                                             size_t          row_stride_bytes,
+                                                             hipStream_t     stream = 0,
+                                                             bool debug_synchronous = false)
     {
-        return ::rocprim::histogram_range(
-            d_temp_storage, temp_storage_bytes,
-            d_samples, num_row_samples, num_rows, row_stride_bytes,
-            d_histogram,
-            num_levels, d_levels,
-            stream, debug_synchronous
-        );
+        return ::rocprim::histogram_range(d_temp_storage,
+                                          temp_storage_bytes,
+                                          d_samples,
+                                          num_row_samples,
+                                          num_rows,
+                                          row_stride_bytes,
+                                          d_histogram,
+                                          num_levels,
+                                          d_levels,
+                                          stream,
+                                          debug_synchronous);
     }
 
-    template<
-        int NUM_CHANNELS,
-        int NUM_ACTIVE_CHANNELS,
-        typename SampleIteratorT,
-        typename CounterT,
-        typename LevelT,
-        typename OffsetT
-    >
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t MultiHistogramRange(void * d_temp_storage,
-                                   size_t& temp_storage_bytes,
-                                   SampleIteratorT d_samples,
-                                   CounterT * d_histogram[NUM_ACTIVE_CHANNELS],
-                                   int num_levels[NUM_ACTIVE_CHANNELS],
-                                   LevelT * d_levels[NUM_ACTIVE_CHANNELS],
-                                   OffsetT num_pixels,
-                                   hipStream_t stream = 0,
-                                   bool debug_synchronous = false)
+    template <int NUM_CHANNELS,
+              int NUM_ACTIVE_CHANNELS,
+              typename SampleIteratorT,
+              typename CounterT,
+              typename LevelT,
+              typename OffsetT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t
+        MultiHistogramRange(void*           d_temp_storage,
+                            size_t&         temp_storage_bytes,
+                            SampleIteratorT d_samples,
+                            CounterT*       d_histogram[NUM_ACTIVE_CHANNELS],
+                            int             num_levels[NUM_ACTIVE_CHANNELS],
+                            LevelT*         d_levels[NUM_ACTIVE_CHANNELS],
+                            OffsetT         num_pixels,
+                            hipStream_t     stream            = 0,
+                            bool            debug_synchronous = false)
     {
         unsigned int levels[NUM_ACTIVE_CHANNELS];
         for(unsigned int channel = 0; channel < NUM_ACTIVE_CHANNELS; channel++)
@@ -243,34 +237,35 @@ struct DeviceHistogram
             levels[channel] = num_levels[channel];
         }
         return ::rocprim::multi_histogram_range<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
-            d_temp_storage, temp_storage_bytes,
-            d_samples, num_pixels,
+            d_temp_storage,
+            temp_storage_bytes,
+            d_samples,
+            num_pixels,
             d_histogram,
-            levels, d_levels,
-            stream, debug_synchronous
-        );
+            levels,
+            d_levels,
+            stream,
+            debug_synchronous);
     }
 
-    template<
-        int NUM_CHANNELS,
-        int NUM_ACTIVE_CHANNELS,
-        typename SampleIteratorT,
-        typename CounterT,
-        typename LevelT,
-        typename OffsetT
-    >
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t MultiHistogramRange(void * d_temp_storage,
-                                   size_t& temp_storage_bytes,
-                                   SampleIteratorT d_samples,
-                                   CounterT * d_histogram[NUM_ACTIVE_CHANNELS],
-                                   int num_levels[NUM_ACTIVE_CHANNELS],
-                                   LevelT * d_levels[NUM_ACTIVE_CHANNELS],
-                                   OffsetT num_row_pixels,
-                                   OffsetT num_rows,
-                                   size_t row_stride_bytes,
-                                   hipStream_t stream = 0,
-                                   bool debug_synchronous = false)
+    template <int NUM_CHANNELS,
+              int NUM_ACTIVE_CHANNELS,
+              typename SampleIteratorT,
+              typename CounterT,
+              typename LevelT,
+              typename OffsetT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t
+        MultiHistogramRange(void*           d_temp_storage,
+                            size_t&         temp_storage_bytes,
+                            SampleIteratorT d_samples,
+                            CounterT*       d_histogram[NUM_ACTIVE_CHANNELS],
+                            int             num_levels[NUM_ACTIVE_CHANNELS],
+                            LevelT*         d_levels[NUM_ACTIVE_CHANNELS],
+                            OffsetT         num_row_pixels,
+                            OffsetT         num_rows,
+                            size_t          row_stride_bytes,
+                            hipStream_t     stream            = 0,
+                            bool            debug_synchronous = false)
     {
         unsigned int levels[NUM_ACTIVE_CHANNELS];
         for(unsigned int channel = 0; channel < NUM_ACTIVE_CHANNELS; channel++)
@@ -278,12 +273,17 @@ struct DeviceHistogram
             levels[channel] = num_levels[channel];
         }
         return ::rocprim::multi_histogram_range<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
-            d_temp_storage, temp_storage_bytes,
-            d_samples, num_row_pixels, num_rows, row_stride_bytes,
+            d_temp_storage,
+            temp_storage_bytes,
+            d_samples,
+            num_row_pixels,
+            num_rows,
+            row_stride_bytes,
             d_histogram,
-            levels, d_levels,
-            stream, debug_synchronous
-        );
+            levels,
+            d_levels,
+            stream,
+            debug_synchronous);
     }
 };
 

--- a/hipcub/include/hipcub/rocprim/device/device_radix_sort.hpp
+++ b/hipcub/include/hipcub/rocprim/device/device_radix_sort.hpp
@@ -38,180 +38,198 @@ BEGIN_HIPCUB_NAMESPACE
 
 struct DeviceRadixSort
 {
-    template<typename KeyT, typename ValueT>
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t SortPairs(void * d_temp_storage,
-                         size_t& temp_storage_bytes,
-                         const KeyT * d_keys_in,
-                         KeyT * d_keys_out,
-                         const ValueT * d_values_in,
-                         ValueT * d_values_out,
-                         int num_items,
-                         int begin_bit = 0,
-                         int end_bit = sizeof(KeyT) * 8,
-                         hipStream_t stream = 0,
-                         bool debug_synchronous = false)
+    template <typename KeyT, typename ValueT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t SortPairs(void*         d_temp_storage,
+                                                        size_t&       temp_storage_bytes,
+                                                        const KeyT*   d_keys_in,
+                                                        KeyT*         d_keys_out,
+                                                        const ValueT* d_values_in,
+                                                        ValueT*       d_values_out,
+                                                        int           num_items,
+                                                        int           begin_bit = 0,
+                                                        int           end_bit   = sizeof(KeyT) * 8,
+                                                        hipStream_t   stream    = 0,
+                                                        bool          debug_synchronous = false)
     {
-        return ::rocprim::radix_sort_pairs(
-            d_temp_storage, temp_storage_bytes,
-            d_keys_in, d_keys_out, d_values_in, d_values_out, num_items,
-            begin_bit, end_bit,
-            stream, debug_synchronous
-        );
+        return ::rocprim::radix_sort_pairs(d_temp_storage,
+                                           temp_storage_bytes,
+                                           d_keys_in,
+                                           d_keys_out,
+                                           d_values_in,
+                                           d_values_out,
+                                           num_items,
+                                           begin_bit,
+                                           end_bit,
+                                           stream,
+                                           debug_synchronous);
     }
 
-    template<typename KeyT, typename ValueT>
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t SortPairs(void * d_temp_storage,
-                         size_t& temp_storage_bytes,
-                         DoubleBuffer<KeyT>& d_keys,
-                         DoubleBuffer<ValueT>& d_values,
-                         int num_items,
-                         int begin_bit = 0,
-                         int end_bit = sizeof(KeyT) * 8,
-                         hipStream_t stream = 0,
-                         bool debug_synchronous = false)
+    template <typename KeyT, typename ValueT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t SortPairs(void*                 d_temp_storage,
+                                                        size_t&               temp_storage_bytes,
+                                                        DoubleBuffer<KeyT>&   d_keys,
+                                                        DoubleBuffer<ValueT>& d_values,
+                                                        int                   num_items,
+                                                        int                   begin_bit = 0,
+                                                        int         end_bit = sizeof(KeyT) * 8,
+                                                        hipStream_t stream  = 0,
+                                                        bool        debug_synchronous = false)
     {
-        ::rocprim::double_buffer<KeyT> d_keys_db = detail::to_double_buffer(d_keys);
+        ::rocprim::double_buffer<KeyT>   d_keys_db   = detail::to_double_buffer(d_keys);
         ::rocprim::double_buffer<ValueT> d_values_db = detail::to_double_buffer(d_values);
-        hipError_t error = ::rocprim::radix_sort_pairs(
-            d_temp_storage, temp_storage_bytes,
-            d_keys_db, d_values_db, num_items,
-            begin_bit, end_bit,
-            stream, debug_synchronous
-        );
+        hipError_t                       error       = ::rocprim::radix_sort_pairs(d_temp_storage,
+                                                       temp_storage_bytes,
+                                                       d_keys_db,
+                                                       d_values_db,
+                                                       num_items,
+                                                       begin_bit,
+                                                       end_bit,
+                                                       stream,
+                                                       debug_synchronous);
         detail::update_double_buffer(d_keys, d_keys_db);
         detail::update_double_buffer(d_values, d_values_db);
         return error;
     }
 
-    template<typename KeyT, typename ValueT>
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t SortPairsDescending(void * d_temp_storage,
-                                   size_t& temp_storage_bytes,
-                                   const KeyT * d_keys_in,
-                                   KeyT * d_keys_out,
-                                   const ValueT * d_values_in,
-                                   ValueT * d_values_out,
-                                   int num_items,
-                                   int begin_bit = 0,
-                                   int end_bit = sizeof(KeyT) * 8,
-                                   hipStream_t stream = 0,
-                                   bool debug_synchronous = false)
+    template <typename KeyT, typename ValueT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t SortPairsDescending(void*         d_temp_storage,
+                                                                  size_t&       temp_storage_bytes,
+                                                                  const KeyT*   d_keys_in,
+                                                                  KeyT*         d_keys_out,
+                                                                  const ValueT* d_values_in,
+                                                                  ValueT*       d_values_out,
+                                                                  int           num_items,
+                                                                  int           begin_bit = 0,
+                                                                  int end_bit = sizeof(KeyT) * 8,
+                                                                  hipStream_t stream     = 0,
+                                                                  bool debug_synchronous = false)
     {
-        return ::rocprim::radix_sort_pairs_desc(
-            d_temp_storage, temp_storage_bytes,
-            d_keys_in, d_keys_out, d_values_in, d_values_out, num_items,
-            begin_bit, end_bit,
-            stream, debug_synchronous
-        );
+        return ::rocprim::radix_sort_pairs_desc(d_temp_storage,
+                                                temp_storage_bytes,
+                                                d_keys_in,
+                                                d_keys_out,
+                                                d_values_in,
+                                                d_values_out,
+                                                num_items,
+                                                begin_bit,
+                                                end_bit,
+                                                stream,
+                                                debug_synchronous);
     }
 
-    template<typename KeyT, typename ValueT>
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t SortPairsDescending(void * d_temp_storage,
-                                   size_t& temp_storage_bytes,
-                                   DoubleBuffer<KeyT>& d_keys,
-                                   DoubleBuffer<ValueT>& d_values,
-                                   int num_items,
-                                   int begin_bit = 0,
-                                   int end_bit = sizeof(KeyT) * 8,
-                                   hipStream_t stream = 0,
-                                   bool debug_synchronous = false)
+    template <typename KeyT, typename ValueT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t SortPairsDescending(void*   d_temp_storage,
+                                                                  size_t& temp_storage_bytes,
+                                                                  DoubleBuffer<KeyT>&   d_keys,
+                                                                  DoubleBuffer<ValueT>& d_values,
+                                                                  int                   num_items,
+                                                                  int begin_bit = 0,
+                                                                  int end_bit   = sizeof(KeyT) * 8,
+                                                                  hipStream_t stream     = 0,
+                                                                  bool debug_synchronous = false)
     {
-        ::rocprim::double_buffer<KeyT> d_keys_db = detail::to_double_buffer(d_keys);
+        ::rocprim::double_buffer<KeyT>   d_keys_db   = detail::to_double_buffer(d_keys);
         ::rocprim::double_buffer<ValueT> d_values_db = detail::to_double_buffer(d_values);
-        hipError_t error = ::rocprim::radix_sort_pairs_desc(
-            d_temp_storage, temp_storage_bytes,
-            d_keys_db, d_values_db, num_items,
-            begin_bit, end_bit,
-            stream, debug_synchronous
-        );
+        hipError_t                       error = ::rocprim::radix_sort_pairs_desc(d_temp_storage,
+                                                            temp_storage_bytes,
+                                                            d_keys_db,
+                                                            d_values_db,
+                                                            num_items,
+                                                            begin_bit,
+                                                            end_bit,
+                                                            stream,
+                                                            debug_synchronous);
         detail::update_double_buffer(d_keys, d_keys_db);
         detail::update_double_buffer(d_values, d_values_db);
         return error;
     }
 
-    template<typename KeyT>
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t SortKeys(void * d_temp_storage,
-                        size_t& temp_storage_bytes,
-                        const KeyT * d_keys_in,
-                        KeyT * d_keys_out,
-                        int num_items,
-                        int begin_bit = 0,
-                        int end_bit = sizeof(KeyT) * 8,
-                        hipStream_t stream = 0,
-                        bool debug_synchronous = false)
+    template <typename KeyT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t SortKeys(void*       d_temp_storage,
+                                                       size_t&     temp_storage_bytes,
+                                                       const KeyT* d_keys_in,
+                                                       KeyT*       d_keys_out,
+                                                       int         num_items,
+                                                       int         begin_bit = 0,
+                                                       int         end_bit   = sizeof(KeyT) * 8,
+                                                       hipStream_t stream    = 0,
+                                                       bool        debug_synchronous = false)
     {
-        return ::rocprim::radix_sort_keys(
-            d_temp_storage, temp_storage_bytes,
-            d_keys_in, d_keys_out, num_items,
-            begin_bit, end_bit,
-            stream, debug_synchronous
-        );
+        return ::rocprim::radix_sort_keys(d_temp_storage,
+                                          temp_storage_bytes,
+                                          d_keys_in,
+                                          d_keys_out,
+                                          num_items,
+                                          begin_bit,
+                                          end_bit,
+                                          stream,
+                                          debug_synchronous);
     }
 
-    template<typename KeyT>
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t SortKeys(void * d_temp_storage,
-                        size_t& temp_storage_bytes,
-                        DoubleBuffer<KeyT>& d_keys,
-                        int num_items,
-                        int begin_bit = 0,
-                        int end_bit = sizeof(KeyT) * 8,
-                        hipStream_t stream = 0,
-                        bool debug_synchronous = false)
+    template <typename KeyT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t SortKeys(void*               d_temp_storage,
+                                                       size_t&             temp_storage_bytes,
+                                                       DoubleBuffer<KeyT>& d_keys,
+                                                       int                 num_items,
+                                                       int                 begin_bit = 0,
+                                                       int         end_bit = sizeof(KeyT) * 8,
+                                                       hipStream_t stream  = 0,
+                                                       bool        debug_synchronous = false)
     {
         ::rocprim::double_buffer<KeyT> d_keys_db = detail::to_double_buffer(d_keys);
-        hipError_t error = ::rocprim::radix_sort_keys(
-            d_temp_storage, temp_storage_bytes,
-            d_keys_db, num_items,
-            begin_bit, end_bit,
-            stream, debug_synchronous
-        );
+        hipError_t                     error     = ::rocprim::radix_sort_keys(d_temp_storage,
+                                                      temp_storage_bytes,
+                                                      d_keys_db,
+                                                      num_items,
+                                                      begin_bit,
+                                                      end_bit,
+                                                      stream,
+                                                      debug_synchronous);
         detail::update_double_buffer(d_keys, d_keys_db);
         return error;
     }
 
-    template<typename KeyT>
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t SortKeysDescending(void * d_temp_storage,
-                                  size_t& temp_storage_bytes,
-                                  const KeyT * d_keys_in,
-                                  KeyT * d_keys_out,
-                                  int num_items,
-                                  int begin_bit = 0,
-                                  int end_bit = sizeof(KeyT) * 8,
-                                  hipStream_t stream = 0,
-                                  bool debug_synchronous = false)
+    template <typename KeyT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t SortKeysDescending(void*       d_temp_storage,
+                                                                 size_t&     temp_storage_bytes,
+                                                                 const KeyT* d_keys_in,
+                                                                 KeyT*       d_keys_out,
+                                                                 int         num_items,
+                                                                 int         begin_bit = 0,
+                                                                 int end_bit = sizeof(KeyT) * 8,
+                                                                 hipStream_t stream     = 0,
+                                                                 bool debug_synchronous = false)
     {
-        return ::rocprim::radix_sort_keys_desc(
-            d_temp_storage, temp_storage_bytes,
-            d_keys_in, d_keys_out, num_items,
-            begin_bit, end_bit,
-            stream, debug_synchronous
-        );
+        return ::rocprim::radix_sort_keys_desc(d_temp_storage,
+                                               temp_storage_bytes,
+                                               d_keys_in,
+                                               d_keys_out,
+                                               num_items,
+                                               begin_bit,
+                                               end_bit,
+                                               stream,
+                                               debug_synchronous);
     }
 
-    template<typename KeyT>
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t SortKeysDescending(void * d_temp_storage,
-                                  size_t& temp_storage_bytes,
-                                  DoubleBuffer<KeyT>& d_keys,
-                                  int num_items,
-                                  int begin_bit = 0,
-                                  int end_bit = sizeof(KeyT) * 8,
-                                  hipStream_t stream = 0,
-                                  bool debug_synchronous = false)
+    template <typename KeyT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t SortKeysDescending(void*   d_temp_storage,
+                                                                 size_t& temp_storage_bytes,
+                                                                 DoubleBuffer<KeyT>& d_keys,
+                                                                 int                 num_items,
+                                                                 int                 begin_bit = 0,
+                                                                 int end_bit = sizeof(KeyT) * 8,
+                                                                 hipStream_t stream     = 0,
+                                                                 bool debug_synchronous = false)
     {
         ::rocprim::double_buffer<KeyT> d_keys_db = detail::to_double_buffer(d_keys);
-        hipError_t error = ::rocprim::radix_sort_keys_desc(
-            d_temp_storage, temp_storage_bytes,
-            d_keys_db, num_items,
-            begin_bit, end_bit,
-            stream, debug_synchronous
-        );
+        hipError_t                     error     = ::rocprim::radix_sort_keys_desc(d_temp_storage,
+                                                           temp_storage_bytes,
+                                                           d_keys_db,
+                                                           num_items,
+                                                           begin_bit,
+                                                           end_bit,
+                                                           stream,
+                                                           debug_synchronous);
         detail::update_double_buffer(d_keys, d_keys_db);
         return error;
     }

--- a/hipcub/include/hipcub/rocprim/device/device_reduce.hpp
+++ b/hipcub/include/hipcub/rocprim/device/device_reduce.hpp
@@ -30,8 +30,8 @@
 #ifndef HIPCUB_ROCPRIM_DEVICE_DEVICE_REDUCE_HPP_
 #define HIPCUB_ROCPRIM_DEVICE_DEVICE_REDUCE_HPP_
 
-#include <limits>
 #include <iterator>
+#include <limits>
 
 #include <hip/hip_fp16.h> // __half
 
@@ -43,234 +43,224 @@ BEGIN_HIPCUB_NAMESPACE
 namespace detail
 {
 
-template<class T>
-inline
-T get_lowest_value()
-{
-    return std::numeric_limits<T>::lowest();
-}
+    template <class T>
+    inline T get_lowest_value()
+    {
+        return std::numeric_limits<T>::lowest();
+    }
 
-template<>
-inline
-__half get_lowest_value<__half>()
-{
-    unsigned short lowest_half = 0xfbff;
-    __half lowest_value = *reinterpret_cast<__half*>(&lowest_half);
-    return lowest_value;
-}
+    template <>
+    inline __half get_lowest_value<__half>()
+    {
+        unsigned short lowest_half  = 0xfbff;
+        __half         lowest_value = *reinterpret_cast<__half*>(&lowest_half);
+        return lowest_value;
+    }
 
-template<class T>
-inline
-T get_max_value()
-{
-    return std::numeric_limits<T>::max();
-}
+    template <class T>
+    inline T get_max_value()
+    {
+        return std::numeric_limits<T>::max();
+    }
 
-template<>
-inline
-__half get_max_value<__half>()
-{
-    unsigned short max_half = 0x7bff;
-    __half max_value = *reinterpret_cast<__half*>(&max_half);
-    return max_value;
-}
+    template <>
+    inline __half get_max_value<__half>()
+    {
+        unsigned short max_half  = 0x7bff;
+        __half         max_value = *reinterpret_cast<__half*>(&max_half);
+        return max_value;
+    }
 
 } // end detail namespace
 
 class DeviceReduce
 {
 public:
-    template <
-        typename InputIteratorT,
-        typename OutputIteratorT,
-        typename ReduceOpT,
-        typename T
-    >
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t Reduce(void *d_temp_storage,
-                      size_t &temp_storage_bytes,
-                      InputIteratorT d_in,
-                      OutputIteratorT d_out,
-                      int num_items,
-                      ReduceOpT reduction_op,
-                      T init,
-                      hipStream_t stream = 0,
-                      bool debug_synchronous = false)
+    template <typename InputIteratorT, typename OutputIteratorT, typename ReduceOpT, typename T>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t Reduce(void*           d_temp_storage,
+                                                     size_t&         temp_storage_bytes,
+                                                     InputIteratorT  d_in,
+                                                     OutputIteratorT d_out,
+                                                     int             num_items,
+                                                     ReduceOpT       reduction_op,
+                                                     T               init,
+                                                     hipStream_t     stream            = 0,
+                                                     bool            debug_synchronous = false)
     {
         return ::rocprim::reduce(
-            d_temp_storage, temp_storage_bytes,
-            d_in, d_out, init, num_items,
+            d_temp_storage,
+            temp_storage_bytes,
+            d_in,
+            d_out,
+            init,
+            num_items,
             ::hipcub::detail::convert_result_type<InputIteratorT, OutputIteratorT>(reduction_op),
-            stream, debug_synchronous
-        );
+            stream,
+            debug_synchronous);
     }
 
-    template <
-        typename InputIteratorT,
-        typename OutputIteratorT
-    >
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t Sum(void *d_temp_storage,
-                   size_t &temp_storage_bytes,
-                   InputIteratorT d_in,
-                   OutputIteratorT d_out,
-                   int num_items,
-                   hipStream_t stream = 0,
-                   bool debug_synchronous = false)
+    template <typename InputIteratorT, typename OutputIteratorT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t Sum(void*           d_temp_storage,
+                                                  size_t&         temp_storage_bytes,
+                                                  InputIteratorT  d_in,
+                                                  OutputIteratorT d_out,
+                                                  int             num_items,
+                                                  hipStream_t     stream            = 0,
+                                                  bool            debug_synchronous = false)
     {
         using T = typename std::iterator_traits<InputIteratorT>::value_type;
-        return Reduce(
-            d_temp_storage, temp_storage_bytes,
-            d_in, d_out, num_items, ::hipcub::Sum(), T(0),
-            stream, debug_synchronous
-        );
+        return Reduce(d_temp_storage,
+                      temp_storage_bytes,
+                      d_in,
+                      d_out,
+                      num_items,
+                      ::hipcub::Sum(),
+                      T(0),
+                      stream,
+                      debug_synchronous);
     }
 
-    template <
-        typename InputIteratorT,
-        typename OutputIteratorT
-    >
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t Min(void *d_temp_storage,
-                   size_t &temp_storage_bytes,
-                   InputIteratorT d_in,
-                   OutputIteratorT d_out,
-                   int num_items,
-                   hipStream_t stream = 0,
-                   bool debug_synchronous = false)
+    template <typename InputIteratorT, typename OutputIteratorT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t Min(void*           d_temp_storage,
+                                                  size_t&         temp_storage_bytes,
+                                                  InputIteratorT  d_in,
+                                                  OutputIteratorT d_out,
+                                                  int             num_items,
+                                                  hipStream_t     stream            = 0,
+                                                  bool            debug_synchronous = false)
     {
         using T = typename std::iterator_traits<InputIteratorT>::value_type;
-        return Reduce(
-            d_temp_storage, temp_storage_bytes,
-            d_in, d_out, num_items, ::hipcub::Min(), detail::get_max_value<T>(),
-            stream, debug_synchronous
-        );
+        return Reduce(d_temp_storage,
+                      temp_storage_bytes,
+                      d_in,
+                      d_out,
+                      num_items,
+                      ::hipcub::Min(),
+                      detail::get_max_value<T>(),
+                      stream,
+                      debug_synchronous);
     }
 
-    template <
-        typename InputIteratorT,
-        typename OutputIteratorT
-    >
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t ArgMin(void *d_temp_storage,
-                      size_t &temp_storage_bytes,
-                      InputIteratorT d_in,
-                      OutputIteratorT d_out,
-                      int num_items,
-                      hipStream_t stream = 0,
-                      bool debug_synchronous = false)
+    template <typename InputIteratorT, typename OutputIteratorT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t ArgMin(void*           d_temp_storage,
+                                                     size_t&         temp_storage_bytes,
+                                                     InputIteratorT  d_in,
+                                                     OutputIteratorT d_out,
+                                                     int             num_items,
+                                                     hipStream_t     stream            = 0,
+                                                     bool            debug_synchronous = false)
     {
-        using OffsetT = int;
-        using T = typename std::iterator_traits<InputIteratorT>::value_type;
-        using O = typename std::iterator_traits<OutputIteratorT>::value_type;
-        using OutputTupleT =
-            typename std::conditional<
-                std::is_same<O, void>::value,
-                KeyValuePair<OffsetT, T>,
-                O
-            >::type;
+        using OffsetT      = int;
+        using T            = typename std::iterator_traits<InputIteratorT>::value_type;
+        using O            = typename std::iterator_traits<OutputIteratorT>::value_type;
+        using OutputTupleT = typename std::
+            conditional<std::is_same<O, void>::value, KeyValuePair<OffsetT, T>, O>::type;
 
         using OutputValueT = typename OutputTupleT::Value;
-        using IteratorT = ArgIndexInputIterator<InputIteratorT, OffsetT, OutputValueT>;
+        using IteratorT    = ArgIndexInputIterator<InputIteratorT, OffsetT, OutputValueT>;
 
-        IteratorT d_indexed_in(d_in);
+        IteratorT    d_indexed_in(d_in);
         OutputTupleT init(1, detail::get_max_value<T>());
 
-        return Reduce(
-            d_temp_storage, temp_storage_bytes,
-            d_indexed_in, d_out, num_items, ::hipcub::ArgMin(), init,
-            stream, debug_synchronous
-        );
+        return Reduce(d_temp_storage,
+                      temp_storage_bytes,
+                      d_indexed_in,
+                      d_out,
+                      num_items,
+                      ::hipcub::ArgMin(),
+                      init,
+                      stream,
+                      debug_synchronous);
     }
 
-    template <
-        typename InputIteratorT,
-        typename OutputIteratorT
-    >
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t Max(void *d_temp_storage,
-                   size_t &temp_storage_bytes,
-                   InputIteratorT d_in,
-                   OutputIteratorT d_out,
-                   int num_items,
-                   hipStream_t stream = 0,
-                   bool debug_synchronous = false)
+    template <typename InputIteratorT, typename OutputIteratorT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t Max(void*           d_temp_storage,
+                                                  size_t&         temp_storage_bytes,
+                                                  InputIteratorT  d_in,
+                                                  OutputIteratorT d_out,
+                                                  int             num_items,
+                                                  hipStream_t     stream            = 0,
+                                                  bool            debug_synchronous = false)
     {
         using T = typename std::iterator_traits<InputIteratorT>::value_type;
-        return Reduce(
-            d_temp_storage, temp_storage_bytes,
-            d_in, d_out, num_items, ::hipcub::Max(), detail::get_lowest_value<T>(),
-            stream, debug_synchronous
-        );
+        return Reduce(d_temp_storage,
+                      temp_storage_bytes,
+                      d_in,
+                      d_out,
+                      num_items,
+                      ::hipcub::Max(),
+                      detail::get_lowest_value<T>(),
+                      stream,
+                      debug_synchronous);
     }
 
-    template <
-        typename InputIteratorT,
-        typename OutputIteratorT
-    >
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t ArgMax(void *d_temp_storage,
-                      size_t &temp_storage_bytes,
-                      InputIteratorT d_in,
-                      OutputIteratorT d_out,
-                      int num_items,
-                      hipStream_t stream = 0,
-                      bool debug_synchronous = false)
+    template <typename InputIteratorT, typename OutputIteratorT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t ArgMax(void*           d_temp_storage,
+                                                     size_t&         temp_storage_bytes,
+                                                     InputIteratorT  d_in,
+                                                     OutputIteratorT d_out,
+                                                     int             num_items,
+                                                     hipStream_t     stream            = 0,
+                                                     bool            debug_synchronous = false)
     {
-        using OffsetT = int;
-        using T = typename std::iterator_traits<InputIteratorT>::value_type;
-        using O = typename std::iterator_traits<OutputIteratorT>::value_type;
-        using OutputTupleT =
-            typename std::conditional<
-                std::is_same<O, void>::value,
-                KeyValuePair<OffsetT, T>,
-                O
-            >::type;
+        using OffsetT      = int;
+        using T            = typename std::iterator_traits<InputIteratorT>::value_type;
+        using O            = typename std::iterator_traits<OutputIteratorT>::value_type;
+        using OutputTupleT = typename std::
+            conditional<std::is_same<O, void>::value, KeyValuePair<OffsetT, T>, O>::type;
 
         using OutputValueT = typename OutputTupleT::Value;
-        using IteratorT = ArgIndexInputIterator<InputIteratorT, OffsetT, OutputValueT>;
+        using IteratorT    = ArgIndexInputIterator<InputIteratorT, OffsetT, OutputValueT>;
 
-        IteratorT d_indexed_in(d_in);
+        IteratorT    d_indexed_in(d_in);
         OutputTupleT init(1, detail::get_lowest_value<T>());
 
-        return Reduce(
-            d_temp_storage, temp_storage_bytes,
-            d_indexed_in, d_out, num_items, ::hipcub::ArgMax(), init,
-            stream, debug_synchronous
-        );
+        return Reduce(d_temp_storage,
+                      temp_storage_bytes,
+                      d_indexed_in,
+                      d_out,
+                      num_items,
+                      ::hipcub::ArgMax(),
+                      init,
+                      stream,
+                      debug_synchronous);
     }
 
-    template<
-        typename KeysInputIteratorT,
-        typename UniqueOutputIteratorT,
-        typename ValuesInputIteratorT,
-        typename AggregatesOutputIteratorT,
-        typename NumRunsOutputIteratorT,
-        typename ReductionOpT
-    >
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t ReduceByKey(void * d_temp_storage,
-                           size_t& temp_storage_bytes,
-                           KeysInputIteratorT d_keys_in,
-                           UniqueOutputIteratorT d_unique_out,
-                           ValuesInputIteratorT d_values_in,
-                           AggregatesOutputIteratorT d_aggregates_out,
-                           NumRunsOutputIteratorT d_num_runs_out,
-                           ReductionOpT reduction_op,
-                           int num_items,
-                           hipStream_t stream = 0,
-                           bool debug_synchronous = false)
+    template <typename KeysInputIteratorT,
+              typename UniqueOutputIteratorT,
+              typename ValuesInputIteratorT,
+              typename AggregatesOutputIteratorT,
+              typename NumRunsOutputIteratorT,
+              typename ReductionOpT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t
+        ReduceByKey(void*                     d_temp_storage,
+                    size_t&                   temp_storage_bytes,
+                    KeysInputIteratorT        d_keys_in,
+                    UniqueOutputIteratorT     d_unique_out,
+                    ValuesInputIteratorT      d_values_in,
+                    AggregatesOutputIteratorT d_aggregates_out,
+                    NumRunsOutputIteratorT    d_num_runs_out,
+                    ReductionOpT              reduction_op,
+                    int                       num_items,
+                    hipStream_t               stream            = 0,
+                    bool                      debug_synchronous = false)
     {
-        using key_compare_op =
-            ::rocprim::equal_to<typename std::iterator_traits<KeysInputIteratorT>::value_type>;
+        using key_compare_op
+            = ::rocprim::equal_to<typename std::iterator_traits<KeysInputIteratorT>::value_type>;
         return ::rocprim::reduce_by_key(
-            d_temp_storage, temp_storage_bytes,
-            d_keys_in, d_values_in, num_items,
-            d_unique_out, d_aggregates_out, d_num_runs_out,
-            ::hipcub::detail::convert_result_type<ValuesInputIteratorT, AggregatesOutputIteratorT>(reduction_op),
+            d_temp_storage,
+            temp_storage_bytes,
+            d_keys_in,
+            d_values_in,
+            num_items,
+            d_unique_out,
+            d_aggregates_out,
+            d_num_runs_out,
+            ::hipcub::detail::convert_result_type<ValuesInputIteratorT, AggregatesOutputIteratorT>(
+                reduction_op),
             key_compare_op(),
-            stream, debug_synchronous
-        );
+            stream,
+            debug_synchronous);
     }
 };
 

--- a/hipcub/include/hipcub/rocprim/device/device_run_length_encode.hpp
+++ b/hipcub/include/hipcub/rocprim/device/device_run_length_encode.hpp
@@ -37,54 +37,54 @@ BEGIN_HIPCUB_NAMESPACE
 class DeviceRunLengthEncode
 {
 public:
-    template<
-        typename InputIteratorT,
-        typename UniqueOutputIteratorT,
-        typename LengthsOutputIteratorT,
-        typename NumRunsOutputIteratorT
-    >
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t Encode(void * d_temp_storage,
-                      size_t& temp_storage_bytes,
-                      InputIteratorT d_in,
-                      UniqueOutputIteratorT d_unique_out,
-                      LengthsOutputIteratorT d_counts_out,
-                      NumRunsOutputIteratorT d_num_runs_out,
-                      int num_items,
-                      hipStream_t stream = 0,
-                      bool debug_synchronous = false)
+    template <typename InputIteratorT,
+              typename UniqueOutputIteratorT,
+              typename LengthsOutputIteratorT,
+              typename NumRunsOutputIteratorT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t Encode(void*                  d_temp_storage,
+                                                     size_t&                temp_storage_bytes,
+                                                     InputIteratorT         d_in,
+                                                     UniqueOutputIteratorT  d_unique_out,
+                                                     LengthsOutputIteratorT d_counts_out,
+                                                     NumRunsOutputIteratorT d_num_runs_out,
+                                                     int                    num_items,
+                                                     hipStream_t            stream = 0,
+                                                     bool debug_synchronous        = false)
     {
-        return ::rocprim::run_length_encode(
-            d_temp_storage, temp_storage_bytes,
-            d_in, num_items,
-            d_unique_out, d_counts_out, d_num_runs_out,
-            stream, debug_synchronous
-        );
+        return ::rocprim::run_length_encode(d_temp_storage,
+                                            temp_storage_bytes,
+                                            d_in,
+                                            num_items,
+                                            d_unique_out,
+                                            d_counts_out,
+                                            d_num_runs_out,
+                                            stream,
+                                            debug_synchronous);
     }
 
-    template<
-        typename InputIteratorT,
-        typename OffsetsOutputIteratorT,
-        typename LengthsOutputIteratorT,
-        typename NumRunsOutputIteratorT
-    >
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t NonTrivialRuns(void * d_temp_storage,
-                              size_t& temp_storage_bytes,
-                              InputIteratorT d_in,
-                              OffsetsOutputIteratorT d_offsets_out,
-                              LengthsOutputIteratorT d_lengths_out,
-                              NumRunsOutputIteratorT d_num_runs_out,
-                              int num_items,
-                              hipStream_t stream = 0,
-                              bool debug_synchronous = false)
+    template <typename InputIteratorT,
+              typename OffsetsOutputIteratorT,
+              typename LengthsOutputIteratorT,
+              typename NumRunsOutputIteratorT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t NonTrivialRuns(void*          d_temp_storage,
+                                                             size_t&        temp_storage_bytes,
+                                                             InputIteratorT d_in,
+                                                             OffsetsOutputIteratorT d_offsets_out,
+                                                             LengthsOutputIteratorT d_lengths_out,
+                                                             NumRunsOutputIteratorT d_num_runs_out,
+                                                             int                    num_items,
+                                                             hipStream_t            stream = 0,
+                                                             bool debug_synchronous        = false)
     {
-        return ::rocprim::run_length_encode_non_trivial_runs(
-            d_temp_storage, temp_storage_bytes,
-            d_in, num_items,
-            d_offsets_out, d_lengths_out, d_num_runs_out,
-            stream, debug_synchronous
-        );
+        return ::rocprim::run_length_encode_non_trivial_runs(d_temp_storage,
+                                                             temp_storage_bytes,
+                                                             d_in,
+                                                             num_items,
+                                                             d_offsets_out,
+                                                             d_lengths_out,
+                                                             d_num_runs_out,
+                                                             stream,
+                                                             debug_synchronous);
     }
 };
 

--- a/hipcub/include/hipcub/rocprim/device/device_scan.hpp
+++ b/hipcub/include/hipcub/rocprim/device/device_scan.hpp
@@ -39,93 +39,91 @@ BEGIN_HIPCUB_NAMESPACE
 class DeviceScan
 {
 public:
-    template <
-        typename InputIteratorT,
-        typename OutputIteratorT
-    >
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t InclusiveSum(void *d_temp_storage,
-                            size_t &temp_storage_bytes,
-                            InputIteratorT d_in,
-                            OutputIteratorT d_out,
-                            int num_items,
-                            hipStream_t stream = 0,
-                            bool debug_synchronous = false)
+    template <typename InputIteratorT, typename OutputIteratorT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t InclusiveSum(void*           d_temp_storage,
+                                                           size_t&         temp_storage_bytes,
+                                                           InputIteratorT  d_in,
+                                                           OutputIteratorT d_out,
+                                                           int             num_items,
+                                                           hipStream_t     stream = 0,
+                                                           bool debug_synchronous = false)
     {
-        return InclusiveScan(
-            d_temp_storage, temp_storage_bytes,
-            d_in, d_out, ::hipcub::Sum(), num_items, 
-            stream, debug_synchronous
-        );
+        return InclusiveScan(d_temp_storage,
+                             temp_storage_bytes,
+                             d_in,
+                             d_out,
+                             ::hipcub::Sum(),
+                             num_items,
+                             stream,
+                             debug_synchronous);
     }
 
-    template <
-        typename InputIteratorT,
-        typename OutputIteratorT,
-        typename ScanOpT
-    >
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t InclusiveScan(void *d_temp_storage,
-                             size_t &temp_storage_bytes,
-                             InputIteratorT d_in,
-                             OutputIteratorT d_out,
-                             ScanOpT scan_op,
-                             int num_items,
-                             hipStream_t stream = 0,
-                             bool debug_synchronous = false)
+    template <typename InputIteratorT, typename OutputIteratorT, typename ScanOpT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t InclusiveScan(void*           d_temp_storage,
+                                                            size_t&         temp_storage_bytes,
+                                                            InputIteratorT  d_in,
+                                                            OutputIteratorT d_out,
+                                                            ScanOpT         scan_op,
+                                                            int             num_items,
+                                                            hipStream_t     stream = 0,
+                                                            bool debug_synchronous = false)
     {
         return ::rocprim::inclusive_scan(
-            d_temp_storage, temp_storage_bytes,
-            d_in, d_out, num_items,
+            d_temp_storage,
+            temp_storage_bytes,
+            d_in,
+            d_out,
+            num_items,
             ::hipcub::detail::convert_result_type<InputIteratorT, OutputIteratorT>(scan_op),
-            stream, debug_synchronous
-        );
+            stream,
+            debug_synchronous);
     }
 
-    template <
-        typename InputIteratorT,
-        typename OutputIteratorT
-    >
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t ExclusiveSum(void *d_temp_storage,
-                            size_t &temp_storage_bytes,
-                            InputIteratorT d_in,
-                            OutputIteratorT d_out,
-                            int num_items,
-                            hipStream_t stream = 0,
-                            bool debug_synchronous = false)
+    template <typename InputIteratorT, typename OutputIteratorT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t ExclusiveSum(void*           d_temp_storage,
+                                                           size_t&         temp_storage_bytes,
+                                                           InputIteratorT  d_in,
+                                                           OutputIteratorT d_out,
+                                                           int             num_items,
+                                                           hipStream_t     stream = 0,
+                                                           bool debug_synchronous = false)
     {
         using T = typename std::iterator_traits<InputIteratorT>::value_type;
-        return ExclusiveScan(
-            d_temp_storage, temp_storage_bytes,
-            d_in, d_out, ::hipcub::Sum(), T(0), num_items,
-            stream, debug_synchronous
-        );
+        return ExclusiveScan(d_temp_storage,
+                             temp_storage_bytes,
+                             d_in,
+                             d_out,
+                             ::hipcub::Sum(),
+                             T(0),
+                             num_items,
+                             stream,
+                             debug_synchronous);
     }
 
-    template <
-        typename InputIteratorT,
-        typename OutputIteratorT,
-        typename ScanOpT,
-        typename InitValueT
-    >
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t ExclusiveScan(void *d_temp_storage,
-                             size_t &temp_storage_bytes,
-                             InputIteratorT d_in,
-                             OutputIteratorT d_out,
-                             ScanOpT scan_op,
-                             InitValueT init_value,
-                             int num_items,
-                             hipStream_t stream = 0,
-                             bool debug_synchronous = false)
+    template <typename InputIteratorT,
+              typename OutputIteratorT,
+              typename ScanOpT,
+              typename InitValueT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t ExclusiveScan(void*           d_temp_storage,
+                                                            size_t&         temp_storage_bytes,
+                                                            InputIteratorT  d_in,
+                                                            OutputIteratorT d_out,
+                                                            ScanOpT         scan_op,
+                                                            InitValueT      init_value,
+                                                            int             num_items,
+                                                            hipStream_t     stream = 0,
+                                                            bool debug_synchronous = false)
     {
         return ::rocprim::exclusive_scan(
-            d_temp_storage, temp_storage_bytes,
-            d_in, d_out, init_value, num_items,
+            d_temp_storage,
+            temp_storage_bytes,
+            d_in,
+            d_out,
+            init_value,
+            num_items,
             ::hipcub::detail::convert_result_type<InputIteratorT, OutputIteratorT>(scan_op),
-            stream, debug_synchronous
-        );
+            stream,
+            debug_synchronous);
     }
 };
 

--- a/hipcub/include/hipcub/rocprim/device/device_segmented_radix_sort.hpp
+++ b/hipcub/include/hipcub/rocprim/device/device_segmented_radix_sort.hpp
@@ -38,212 +38,246 @@ BEGIN_HIPCUB_NAMESPACE
 
 struct DeviceSegmentedRadixSort
 {
-    template<typename KeyT, typename ValueT, typename OffsetIteratorT>
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t SortPairs(void * d_temp_storage,
-                         size_t& temp_storage_bytes,
-                         const KeyT * d_keys_in,
-                         KeyT * d_keys_out,
-                         const ValueT * d_values_in,
-                         ValueT * d_values_out,
-                         int num_items,
-                         int num_segments,
-                         OffsetIteratorT d_begin_offsets,
-                         OffsetIteratorT d_end_offsets,
-                         int begin_bit = 0,
-                         int end_bit = sizeof(KeyT) * 8,
-                         hipStream_t stream = 0,
-                         bool debug_synchronous = false)
+    template <typename KeyT, typename ValueT, typename OffsetIteratorT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t SortPairs(void*           d_temp_storage,
+                                                        size_t&         temp_storage_bytes,
+                                                        const KeyT*     d_keys_in,
+                                                        KeyT*           d_keys_out,
+                                                        const ValueT*   d_values_in,
+                                                        ValueT*         d_values_out,
+                                                        int             num_items,
+                                                        int             num_segments,
+                                                        OffsetIteratorT d_begin_offsets,
+                                                        OffsetIteratorT d_end_offsets,
+                                                        int             begin_bit = 0,
+                                                        int             end_bit = sizeof(KeyT) * 8,
+                                                        hipStream_t     stream  = 0,
+                                                        bool            debug_synchronous = false)
     {
-        return ::rocprim::segmented_radix_sort_pairs(
-            d_temp_storage, temp_storage_bytes,
-            d_keys_in, d_keys_out, d_values_in, d_values_out, num_items,
-            num_segments, d_begin_offsets, d_end_offsets,
-            begin_bit, end_bit,
-            stream, debug_synchronous
-        );
+        return ::rocprim::segmented_radix_sort_pairs(d_temp_storage,
+                                                     temp_storage_bytes,
+                                                     d_keys_in,
+                                                     d_keys_out,
+                                                     d_values_in,
+                                                     d_values_out,
+                                                     num_items,
+                                                     num_segments,
+                                                     d_begin_offsets,
+                                                     d_end_offsets,
+                                                     begin_bit,
+                                                     end_bit,
+                                                     stream,
+                                                     debug_synchronous);
     }
 
-    template<typename KeyT, typename ValueT, typename OffsetIteratorT>
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t SortPairs(void * d_temp_storage,
-                         size_t& temp_storage_bytes,
-                         DoubleBuffer<KeyT>& d_keys,
-                         DoubleBuffer<ValueT>& d_values,
-                         int num_items,
-                         int num_segments,
-                         OffsetIteratorT d_begin_offsets,
-                         OffsetIteratorT d_end_offsets,
-                         int begin_bit = 0,
-                         int end_bit = sizeof(KeyT) * 8,
-                         hipStream_t stream = 0,
-                         bool debug_synchronous = false)
+    template <typename KeyT, typename ValueT, typename OffsetIteratorT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t SortPairs(void*                 d_temp_storage,
+                                                        size_t&               temp_storage_bytes,
+                                                        DoubleBuffer<KeyT>&   d_keys,
+                                                        DoubleBuffer<ValueT>& d_values,
+                                                        int                   num_items,
+                                                        int                   num_segments,
+                                                        OffsetIteratorT       d_begin_offsets,
+                                                        OffsetIteratorT       d_end_offsets,
+                                                        int                   begin_bit = 0,
+                                                        int         end_bit = sizeof(KeyT) * 8,
+                                                        hipStream_t stream  = 0,
+                                                        bool        debug_synchronous = false)
     {
-        ::rocprim::double_buffer<KeyT> d_keys_db = detail::to_double_buffer(d_keys);
+        ::rocprim::double_buffer<KeyT>   d_keys_db   = detail::to_double_buffer(d_keys);
         ::rocprim::double_buffer<ValueT> d_values_db = detail::to_double_buffer(d_values);
-        hipError_t error = ::rocprim::segmented_radix_sort_pairs(
-            d_temp_storage, temp_storage_bytes,
-            d_keys_db, d_values_db, num_items,
-            num_segments, d_begin_offsets, d_end_offsets,
-            begin_bit, end_bit,
-            stream, debug_synchronous
-        );
+        hipError_t error = ::rocprim::segmented_radix_sort_pairs(d_temp_storage,
+                                                                 temp_storage_bytes,
+                                                                 d_keys_db,
+                                                                 d_values_db,
+                                                                 num_items,
+                                                                 num_segments,
+                                                                 d_begin_offsets,
+                                                                 d_end_offsets,
+                                                                 begin_bit,
+                                                                 end_bit,
+                                                                 stream,
+                                                                 debug_synchronous);
         detail::update_double_buffer(d_keys, d_keys_db);
         detail::update_double_buffer(d_values, d_values_db);
         return error;
     }
 
-    template<typename KeyT, typename ValueT, typename OffsetIteratorT>
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t SortPairsDescending(void * d_temp_storage,
-                                   size_t& temp_storage_bytes,
-                                   const KeyT * d_keys_in,
-                                   KeyT * d_keys_out,
-                                   const ValueT * d_values_in,
-                                   ValueT * d_values_out,
-                                   int num_items,
-                                   int num_segments,
-                                   OffsetIteratorT d_begin_offsets,
-                                   OffsetIteratorT d_end_offsets,
-                                   int begin_bit = 0,
-                                   int end_bit = sizeof(KeyT) * 8,
-                                   hipStream_t stream = 0,
-                                   bool debug_synchronous = false)
+    template <typename KeyT, typename ValueT, typename OffsetIteratorT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t SortPairsDescending(void*         d_temp_storage,
+                                                                  size_t&       temp_storage_bytes,
+                                                                  const KeyT*   d_keys_in,
+                                                                  KeyT*         d_keys_out,
+                                                                  const ValueT* d_values_in,
+                                                                  ValueT*       d_values_out,
+                                                                  int           num_items,
+                                                                  int           num_segments,
+                                                                  OffsetIteratorT d_begin_offsets,
+                                                                  OffsetIteratorT d_end_offsets,
+                                                                  int             begin_bit = 0,
+                                                                  int end_bit = sizeof(KeyT) * 8,
+                                                                  hipStream_t stream     = 0,
+                                                                  bool debug_synchronous = false)
     {
-        return ::rocprim::segmented_radix_sort_pairs_desc(
-            d_temp_storage, temp_storage_bytes,
-            d_keys_in, d_keys_out, d_values_in, d_values_out, num_items,
-            num_segments, d_begin_offsets, d_end_offsets,
-            begin_bit, end_bit,
-            stream, debug_synchronous
-        );
+        return ::rocprim::segmented_radix_sort_pairs_desc(d_temp_storage,
+                                                          temp_storage_bytes,
+                                                          d_keys_in,
+                                                          d_keys_out,
+                                                          d_values_in,
+                                                          d_values_out,
+                                                          num_items,
+                                                          num_segments,
+                                                          d_begin_offsets,
+                                                          d_end_offsets,
+                                                          begin_bit,
+                                                          end_bit,
+                                                          stream,
+                                                          debug_synchronous);
     }
 
-    template<typename KeyT, typename ValueT, typename OffsetIteratorT>
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t SortPairsDescending(void * d_temp_storage,
-                                   size_t& temp_storage_bytes,
-                                   DoubleBuffer<KeyT>& d_keys,
-                                   DoubleBuffer<ValueT>& d_values,
-                                   int num_items,
-                                   int num_segments,
-                                   OffsetIteratorT d_begin_offsets,
-                                   OffsetIteratorT d_end_offsets,
-                                   int begin_bit = 0,
-                                   int end_bit = sizeof(KeyT) * 8,
-                                   hipStream_t stream = 0,
-                                   bool debug_synchronous = false)
+    template <typename KeyT, typename ValueT, typename OffsetIteratorT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t SortPairsDescending(void*   d_temp_storage,
+                                                                  size_t& temp_storage_bytes,
+                                                                  DoubleBuffer<KeyT>&   d_keys,
+                                                                  DoubleBuffer<ValueT>& d_values,
+                                                                  int                   num_items,
+                                                                  int             num_segments,
+                                                                  OffsetIteratorT d_begin_offsets,
+                                                                  OffsetIteratorT d_end_offsets,
+                                                                  int             begin_bit = 0,
+                                                                  int end_bit = sizeof(KeyT) * 8,
+                                                                  hipStream_t stream     = 0,
+                                                                  bool debug_synchronous = false)
     {
-        ::rocprim::double_buffer<KeyT> d_keys_db = detail::to_double_buffer(d_keys);
+        ::rocprim::double_buffer<KeyT>   d_keys_db   = detail::to_double_buffer(d_keys);
         ::rocprim::double_buffer<ValueT> d_values_db = detail::to_double_buffer(d_values);
-        hipError_t error = ::rocprim::segmented_radix_sort_pairs_desc(
-            d_temp_storage, temp_storage_bytes,
-            d_keys_db, d_values_db, num_items,
-            num_segments, d_begin_offsets, d_end_offsets,
-            begin_bit, end_bit,
-            stream, debug_synchronous
-        );
+        hipError_t error = ::rocprim::segmented_radix_sort_pairs_desc(d_temp_storage,
+                                                                      temp_storage_bytes,
+                                                                      d_keys_db,
+                                                                      d_values_db,
+                                                                      num_items,
+                                                                      num_segments,
+                                                                      d_begin_offsets,
+                                                                      d_end_offsets,
+                                                                      begin_bit,
+                                                                      end_bit,
+                                                                      stream,
+                                                                      debug_synchronous);
         detail::update_double_buffer(d_keys, d_keys_db);
         detail::update_double_buffer(d_values, d_values_db);
         return error;
     }
 
-    template<typename KeyT, typename OffsetIteratorT>
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t SortKeys(void * d_temp_storage,
-                        size_t& temp_storage_bytes,
-                        const KeyT * d_keys_in,
-                        KeyT * d_keys_out,
-                        int num_items,
-                        int num_segments,
-                        OffsetIteratorT d_begin_offsets,
-                        OffsetIteratorT d_end_offsets,
-                        int begin_bit = 0,
-                        int end_bit = sizeof(KeyT) * 8,
-                        hipStream_t stream = 0,
-                        bool debug_synchronous = false)
+    template <typename KeyT, typename OffsetIteratorT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t SortKeys(void*           d_temp_storage,
+                                                       size_t&         temp_storage_bytes,
+                                                       const KeyT*     d_keys_in,
+                                                       KeyT*           d_keys_out,
+                                                       int             num_items,
+                                                       int             num_segments,
+                                                       OffsetIteratorT d_begin_offsets,
+                                                       OffsetIteratorT d_end_offsets,
+                                                       int             begin_bit = 0,
+                                                       int             end_bit   = sizeof(KeyT) * 8,
+                                                       hipStream_t     stream    = 0,
+                                                       bool            debug_synchronous = false)
     {
-        return ::rocprim::segmented_radix_sort_keys(
-            d_temp_storage, temp_storage_bytes,
-            d_keys_in, d_keys_out, num_items,
-            num_segments, d_begin_offsets, d_end_offsets,
-            begin_bit, end_bit,
-            stream, debug_synchronous
-        );
+        return ::rocprim::segmented_radix_sort_keys(d_temp_storage,
+                                                    temp_storage_bytes,
+                                                    d_keys_in,
+                                                    d_keys_out,
+                                                    num_items,
+                                                    num_segments,
+                                                    d_begin_offsets,
+                                                    d_end_offsets,
+                                                    begin_bit,
+                                                    end_bit,
+                                                    stream,
+                                                    debug_synchronous);
     }
 
-    template<typename KeyT, typename OffsetIteratorT>
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t SortKeys(void * d_temp_storage,
-                        size_t& temp_storage_bytes,
-                        DoubleBuffer<KeyT>& d_keys,
-                        int num_items,
-                        int num_segments,
-                        OffsetIteratorT d_begin_offsets,
-                        OffsetIteratorT d_end_offsets,
-                        int begin_bit = 0,
-                        int end_bit = sizeof(KeyT) * 8,
-                        hipStream_t stream = 0,
-                        bool debug_synchronous = false)
+    template <typename KeyT, typename OffsetIteratorT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t SortKeys(void*               d_temp_storage,
+                                                       size_t&             temp_storage_bytes,
+                                                       DoubleBuffer<KeyT>& d_keys,
+                                                       int                 num_items,
+                                                       int                 num_segments,
+                                                       OffsetIteratorT     d_begin_offsets,
+                                                       OffsetIteratorT     d_end_offsets,
+                                                       int                 begin_bit = 0,
+                                                       int         end_bit = sizeof(KeyT) * 8,
+                                                       hipStream_t stream  = 0,
+                                                       bool        debug_synchronous = false)
     {
         ::rocprim::double_buffer<KeyT> d_keys_db = detail::to_double_buffer(d_keys);
-        hipError_t error = ::rocprim::segmented_radix_sort_keys(
-            d_temp_storage, temp_storage_bytes,
-            d_keys_db, num_items,
-            num_segments, d_begin_offsets, d_end_offsets,
-            begin_bit, end_bit,
-            stream, debug_synchronous
-        );
+        hipError_t                     error = ::rocprim::segmented_radix_sort_keys(d_temp_storage,
+                                                                temp_storage_bytes,
+                                                                d_keys_db,
+                                                                num_items,
+                                                                num_segments,
+                                                                d_begin_offsets,
+                                                                d_end_offsets,
+                                                                begin_bit,
+                                                                end_bit,
+                                                                stream,
+                                                                debug_synchronous);
         detail::update_double_buffer(d_keys, d_keys_db);
         return error;
     }
 
-    template<typename KeyT, typename OffsetIteratorT>
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t SortKeysDescending(void * d_temp_storage,
-                                  size_t& temp_storage_bytes,
-                                  const KeyT * d_keys_in,
-                                  KeyT * d_keys_out,
-                                  int num_items,
-                                  int num_segments,
-                                  OffsetIteratorT d_begin_offsets,
-                                  OffsetIteratorT d_end_offsets,
-                                  int begin_bit = 0,
-                                  int end_bit = sizeof(KeyT) * 8,
-                                  hipStream_t stream = 0,
-                                  bool debug_synchronous = false)
+    template <typename KeyT, typename OffsetIteratorT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t SortKeysDescending(void*           d_temp_storage,
+                                                                 size_t&         temp_storage_bytes,
+                                                                 const KeyT*     d_keys_in,
+                                                                 KeyT*           d_keys_out,
+                                                                 int             num_items,
+                                                                 int             num_segments,
+                                                                 OffsetIteratorT d_begin_offsets,
+                                                                 OffsetIteratorT d_end_offsets,
+                                                                 int             begin_bit = 0,
+                                                                 int end_bit = sizeof(KeyT) * 8,
+                                                                 hipStream_t stream     = 0,
+                                                                 bool debug_synchronous = false)
     {
-        return ::rocprim::segmented_radix_sort_keys_desc(
-            d_temp_storage, temp_storage_bytes,
-            d_keys_in, d_keys_out, num_items,
-            num_segments, d_begin_offsets, d_end_offsets,
-            begin_bit, end_bit,
-            stream, debug_synchronous
-        );
+        return ::rocprim::segmented_radix_sort_keys_desc(d_temp_storage,
+                                                         temp_storage_bytes,
+                                                         d_keys_in,
+                                                         d_keys_out,
+                                                         num_items,
+                                                         num_segments,
+                                                         d_begin_offsets,
+                                                         d_end_offsets,
+                                                         begin_bit,
+                                                         end_bit,
+                                                         stream,
+                                                         debug_synchronous);
     }
 
-    template<typename KeyT, typename OffsetIteratorT>
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t SortKeysDescending(void * d_temp_storage,
-                                  size_t& temp_storage_bytes,
-                                  DoubleBuffer<KeyT>& d_keys,
-                                  int num_items,
-                                  int num_segments,
-                                  OffsetIteratorT d_begin_offsets,
-                                  OffsetIteratorT d_end_offsets,
-                                  int begin_bit = 0,
-                                  int end_bit = sizeof(KeyT) * 8,
-                                  hipStream_t stream = 0,
-                                  bool debug_synchronous = false)
+    template <typename KeyT, typename OffsetIteratorT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t SortKeysDescending(void*   d_temp_storage,
+                                                                 size_t& temp_storage_bytes,
+                                                                 DoubleBuffer<KeyT>& d_keys,
+                                                                 int                 num_items,
+                                                                 int                 num_segments,
+                                                                 OffsetIteratorT d_begin_offsets,
+                                                                 OffsetIteratorT d_end_offsets,
+                                                                 int             begin_bit = 0,
+                                                                 int end_bit = sizeof(KeyT) * 8,
+                                                                 hipStream_t stream     = 0,
+                                                                 bool debug_synchronous = false)
     {
         ::rocprim::double_buffer<KeyT> d_keys_db = detail::to_double_buffer(d_keys);
-        hipError_t error = ::rocprim::segmented_radix_sort_keys_desc(
-            d_temp_storage, temp_storage_bytes,
-            d_keys_db, num_items,
-            num_segments, d_begin_offsets, d_end_offsets,
-            begin_bit, end_bit,
-            stream, debug_synchronous
-        );
+        hipError_t error = ::rocprim::segmented_radix_sort_keys_desc(d_temp_storage,
+                                                                     temp_storage_bytes,
+                                                                     d_keys_db,
+                                                                     num_items,
+                                                                     num_segments,
+                                                                     d_begin_offsets,
+                                                                     d_end_offsets,
+                                                                     begin_bit,
+                                                                     end_bit,
+                                                                     stream,
+                                                                     debug_synchronous);
         detail::update_double_buffer(d_keys, d_keys_db);
         return error;
     }

--- a/hipcub/include/hipcub/rocprim/device/device_segmented_reduce.hpp
+++ b/hipcub/include/hipcub/rocprim/device/device_segmented_reduce.hpp
@@ -30,8 +30,8 @@
 #ifndef HIPCUB_ROCPRIM_DEVICE_DEVICE_SEGMENTED_REDUCE_HPP_
 #define HIPCUB_ROCPRIM_DEVICE_DEVICE_SEGMENTED_REDUCE_HPP_
 
-#include <limits>
 #include <iterator>
+#include <limits>
 
 #include "../../config.hpp"
 
@@ -41,195 +41,185 @@ BEGIN_HIPCUB_NAMESPACE
 
 struct DeviceSegmentedReduce
 {
-    template<
-        typename InputIteratorT,
-        typename OutputIteratorT,
-        typename OffsetIteratorT,
-        typename ReductionOp,
-        typename T
-    >
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t Reduce(void * d_temp_storage,
-                      size_t& temp_storage_bytes,
-                      InputIteratorT d_in,
-                      OutputIteratorT d_out,
-                      int num_segments,
-                      OffsetIteratorT d_begin_offsets,
-                      OffsetIteratorT d_end_offsets,
-                      ReductionOp reduction_op,
-                      T initial_value,
-                      hipStream_t stream = 0,
-                      bool debug_synchronous = false)
+    template <typename InputIteratorT,
+              typename OutputIteratorT,
+              typename OffsetIteratorT,
+              typename ReductionOp,
+              typename T>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t Reduce(void*           d_temp_storage,
+                                                     size_t&         temp_storage_bytes,
+                                                     InputIteratorT  d_in,
+                                                     OutputIteratorT d_out,
+                                                     int             num_segments,
+                                                     OffsetIteratorT d_begin_offsets,
+                                                     OffsetIteratorT d_end_offsets,
+                                                     ReductionOp     reduction_op,
+                                                     T               initial_value,
+                                                     hipStream_t     stream            = 0,
+                                                     bool            debug_synchronous = false)
     {
         return ::rocprim::segmented_reduce(
-            d_temp_storage, temp_storage_bytes,
-            d_in, d_out,
-            num_segments, d_begin_offsets, d_end_offsets,
+            d_temp_storage,
+            temp_storage_bytes,
+            d_in,
+            d_out,
+            num_segments,
+            d_begin_offsets,
+            d_end_offsets,
             ::hipcub::detail::convert_result_type<InputIteratorT, OutputIteratorT>(reduction_op),
             initial_value,
-            stream, debug_synchronous
-        );
+            stream,
+            debug_synchronous);
     }
 
-    template<
-        typename InputIteratorT,
-        typename OutputIteratorT,
-        typename OffsetIteratorT
-    >
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t Sum(void * d_temp_storage,
-                   size_t& temp_storage_bytes,
-                   InputIteratorT d_in,
-                   OutputIteratorT d_out,
-                   int num_segments,
-                   OffsetIteratorT d_begin_offsets,
-                   OffsetIteratorT d_end_offsets,
-                   hipStream_t stream = 0,
-                   bool debug_synchronous = false)
+    template <typename InputIteratorT, typename OutputIteratorT, typename OffsetIteratorT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t Sum(void*           d_temp_storage,
+                                                  size_t&         temp_storage_bytes,
+                                                  InputIteratorT  d_in,
+                                                  OutputIteratorT d_out,
+                                                  int             num_segments,
+                                                  OffsetIteratorT d_begin_offsets,
+                                                  OffsetIteratorT d_end_offsets,
+                                                  hipStream_t     stream            = 0,
+                                                  bool            debug_synchronous = false)
     {
         using input_type = typename std::iterator_traits<InputIteratorT>::value_type;
 
-        return Reduce(
-            d_temp_storage, temp_storage_bytes,
-            d_in, d_out,
-            num_segments, d_begin_offsets, d_end_offsets,
-            ::hipcub::Sum(), input_type(),
-            stream, debug_synchronous
-        );
+        return Reduce(d_temp_storage,
+                      temp_storage_bytes,
+                      d_in,
+                      d_out,
+                      num_segments,
+                      d_begin_offsets,
+                      d_end_offsets,
+                      ::hipcub::Sum(),
+                      input_type(),
+                      stream,
+                      debug_synchronous);
     }
 
-    template<
-        typename InputIteratorT,
-        typename OutputIteratorT,
-        typename OffsetIteratorT
-    >
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t Min(void * d_temp_storage,
-                   size_t& temp_storage_bytes,
-                   InputIteratorT d_in,
-                   OutputIteratorT d_out,
-                   int num_segments,
-                   OffsetIteratorT d_begin_offsets,
-                   OffsetIteratorT d_end_offsets,
-                   hipStream_t stream = 0,
-                   bool debug_synchronous = false)
+    template <typename InputIteratorT, typename OutputIteratorT, typename OffsetIteratorT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t Min(void*           d_temp_storage,
+                                                  size_t&         temp_storage_bytes,
+                                                  InputIteratorT  d_in,
+                                                  OutputIteratorT d_out,
+                                                  int             num_segments,
+                                                  OffsetIteratorT d_begin_offsets,
+                                                  OffsetIteratorT d_end_offsets,
+                                                  hipStream_t     stream            = 0,
+                                                  bool            debug_synchronous = false)
     {
         using input_type = typename std::iterator_traits<InputIteratorT>::value_type;
 
-        return Reduce(
-            d_temp_storage, temp_storage_bytes,
-            d_in, d_out,
-            num_segments, d_begin_offsets, d_end_offsets,
-            ::hipcub::Min(), std::numeric_limits<input_type>::max(),
-            stream, debug_synchronous
-        );
+        return Reduce(d_temp_storage,
+                      temp_storage_bytes,
+                      d_in,
+                      d_out,
+                      num_segments,
+                      d_begin_offsets,
+                      d_end_offsets,
+                      ::hipcub::Min(),
+                      std::numeric_limits<input_type>::max(),
+                      stream,
+                      debug_synchronous);
     }
 
-    template<
-        typename InputIteratorT,
-        typename OutputIteratorT,
-        typename OffsetIteratorT
-    >
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t ArgMin(void * d_temp_storage,
-                      size_t& temp_storage_bytes,
-                      InputIteratorT d_in,
-                      OutputIteratorT d_out,
-                      int num_segments,
-                      OffsetIteratorT d_begin_offsets,
-                      OffsetIteratorT d_end_offsets,
-                      hipStream_t stream = 0,
-                      bool debug_synchronous = false)
+    template <typename InputIteratorT, typename OutputIteratorT, typename OffsetIteratorT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t ArgMin(void*           d_temp_storage,
+                                                     size_t&         temp_storage_bytes,
+                                                     InputIteratorT  d_in,
+                                                     OutputIteratorT d_out,
+                                                     int             num_segments,
+                                                     OffsetIteratorT d_begin_offsets,
+                                                     OffsetIteratorT d_end_offsets,
+                                                     hipStream_t     stream            = 0,
+                                                     bool            debug_synchronous = false)
     {
-        using OffsetT = int;
-        using T = typename std::iterator_traits<InputIteratorT>::value_type;
-        using O = typename std::iterator_traits<OutputIteratorT>::value_type;
-        using OutputTupleT = typename std::conditional<
-                                 std::is_same<O, void>::value,
-                                 KeyValuePair<OffsetT, T>,
-                                 O
-                             >::type;
+        using OffsetT      = int;
+        using T            = typename std::iterator_traits<InputIteratorT>::value_type;
+        using O            = typename std::iterator_traits<OutputIteratorT>::value_type;
+        using OutputTupleT = typename std::
+            conditional<std::is_same<O, void>::value, KeyValuePair<OffsetT, T>, O>::type;
 
         using OutputValueT = typename OutputTupleT::Value;
-        using IteratorT = ArgIndexInputIterator<InputIteratorT, OffsetT, OutputValueT>;
+        using IteratorT    = ArgIndexInputIterator<InputIteratorT, OffsetT, OutputValueT>;
 
-        IteratorT d_indexed_in(d_in);
+        IteratorT          d_indexed_in(d_in);
         const OutputTupleT init(1, std::numeric_limits<T>::max());
 
-        return Reduce(
-            d_temp_storage, temp_storage_bytes,
-            d_indexed_in, d_out,
-            num_segments, d_begin_offsets, d_end_offsets,
-            ::hipcub::ArgMin(), init,
-            stream, debug_synchronous
-        );
+        return Reduce(d_temp_storage,
+                      temp_storage_bytes,
+                      d_indexed_in,
+                      d_out,
+                      num_segments,
+                      d_begin_offsets,
+                      d_end_offsets,
+                      ::hipcub::ArgMin(),
+                      init,
+                      stream,
+                      debug_synchronous);
     }
 
-    template<
-        typename InputIteratorT,
-        typename OutputIteratorT,
-        typename OffsetIteratorT
-    >
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t Max(void * d_temp_storage,
-                   size_t& temp_storage_bytes,
-                   InputIteratorT d_in,
-                   OutputIteratorT d_out,
-                   int num_segments,
-                   OffsetIteratorT d_begin_offsets,
-                   OffsetIteratorT d_end_offsets,
-                   hipStream_t stream = 0,
-                   bool debug_synchronous = false)
+    template <typename InputIteratorT, typename OutputIteratorT, typename OffsetIteratorT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t Max(void*           d_temp_storage,
+                                                  size_t&         temp_storage_bytes,
+                                                  InputIteratorT  d_in,
+                                                  OutputIteratorT d_out,
+                                                  int             num_segments,
+                                                  OffsetIteratorT d_begin_offsets,
+                                                  OffsetIteratorT d_end_offsets,
+                                                  hipStream_t     stream            = 0,
+                                                  bool            debug_synchronous = false)
     {
         using input_type = typename std::iterator_traits<InputIteratorT>::value_type;
 
-        return Reduce(
-            d_temp_storage, temp_storage_bytes,
-            d_in, d_out,
-            num_segments, d_begin_offsets, d_end_offsets,
-            ::hipcub::Max(), std::numeric_limits<input_type>::lowest(),
-            stream, debug_synchronous
-        );
+        return Reduce(d_temp_storage,
+                      temp_storage_bytes,
+                      d_in,
+                      d_out,
+                      num_segments,
+                      d_begin_offsets,
+                      d_end_offsets,
+                      ::hipcub::Max(),
+                      std::numeric_limits<input_type>::lowest(),
+                      stream,
+                      debug_synchronous);
     }
 
-    template<
-        typename InputIteratorT,
-        typename OutputIteratorT,
-        typename OffsetIteratorT
-    >
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t ArgMax(void * d_temp_storage,
-                      size_t& temp_storage_bytes,
-                      InputIteratorT d_in,
-                      OutputIteratorT d_out,
-                      int num_segments,
-                      OffsetIteratorT d_begin_offsets,
-                      OffsetIteratorT d_end_offsets,
-                      hipStream_t stream = 0,
-                      bool debug_synchronous = false)
+    template <typename InputIteratorT, typename OutputIteratorT, typename OffsetIteratorT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t ArgMax(void*           d_temp_storage,
+                                                     size_t&         temp_storage_bytes,
+                                                     InputIteratorT  d_in,
+                                                     OutputIteratorT d_out,
+                                                     int             num_segments,
+                                                     OffsetIteratorT d_begin_offsets,
+                                                     OffsetIteratorT d_end_offsets,
+                                                     hipStream_t     stream            = 0,
+                                                     bool            debug_synchronous = false)
     {
-        using OffsetT = int;
-        using T = typename std::iterator_traits<InputIteratorT>::value_type;
-        using O = typename std::iterator_traits<OutputIteratorT>::value_type;
-        using OutputTupleT = typename std::conditional<
-                                 std::is_same<O, void>::value,
-                                 KeyValuePair<OffsetT, T>,
-                                 O
-                             >::type;
+        using OffsetT      = int;
+        using T            = typename std::iterator_traits<InputIteratorT>::value_type;
+        using O            = typename std::iterator_traits<OutputIteratorT>::value_type;
+        using OutputTupleT = typename std::
+            conditional<std::is_same<O, void>::value, KeyValuePair<OffsetT, T>, O>::type;
 
         using OutputValueT = typename OutputTupleT::Value;
-        using IteratorT = ArgIndexInputIterator<InputIteratorT, OffsetT, OutputValueT>;
+        using IteratorT    = ArgIndexInputIterator<InputIteratorT, OffsetT, OutputValueT>;
 
-        IteratorT d_indexed_in(d_in);
+        IteratorT          d_indexed_in(d_in);
         const OutputTupleT init(1, std::numeric_limits<T>::lowest());
 
-        return Reduce(
-            d_temp_storage, temp_storage_bytes,
-            d_indexed_in, d_out,
-            num_segments, d_begin_offsets, d_end_offsets,
-            ::hipcub::ArgMax(), init,
-            stream, debug_synchronous
-        );
+        return Reduce(d_temp_storage,
+                      temp_storage_bytes,
+                      d_indexed_in,
+                      d_out,
+                      num_segments,
+                      d_begin_offsets,
+                      d_end_offsets,
+                      ::hipcub::ArgMax(),
+                      init,
+                      stream,
+                      debug_synchronous);
     }
 };
 

--- a/hipcub/include/hipcub/rocprim/device/device_select.hpp
+++ b/hipcub/include/hipcub/rocprim/device/device_select.hpp
@@ -37,74 +37,75 @@ BEGIN_HIPCUB_NAMESPACE
 class DeviceSelect
 {
 public:
-    template <
-        typename InputIteratorT,
-        typename FlagIterator,
-        typename OutputIteratorT,
-        typename NumSelectedIteratorT
-    >
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t Flagged(void *d_temp_storage,
-                       size_t &temp_storage_bytes,
-                       InputIteratorT d_in,
-                       FlagIterator d_flags,
-                       OutputIteratorT d_out,
-                       NumSelectedIteratorT d_num_selected_out,
-                       int num_items,
-                       hipStream_t stream = 0,
-                       bool debug_synchronous = false)
+    template <typename InputIteratorT,
+              typename FlagIterator,
+              typename OutputIteratorT,
+              typename NumSelectedIteratorT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t Flagged(void*                d_temp_storage,
+                                                      size_t&              temp_storage_bytes,
+                                                      InputIteratorT       d_in,
+                                                      FlagIterator         d_flags,
+                                                      OutputIteratorT      d_out,
+                                                      NumSelectedIteratorT d_num_selected_out,
+                                                      int                  num_items,
+                                                      hipStream_t          stream = 0,
+                                                      bool debug_synchronous      = false)
     {
-        return ::rocprim::select(
-            d_temp_storage, temp_storage_bytes,
-            d_in, d_flags, d_out, d_num_selected_out, num_items,
-            stream, debug_synchronous
-        );
+        return ::rocprim::select(d_temp_storage,
+                                 temp_storage_bytes,
+                                 d_in,
+                                 d_flags,
+                                 d_out,
+                                 d_num_selected_out,
+                                 num_items,
+                                 stream,
+                                 debug_synchronous);
     }
 
-    template <
-        typename InputIteratorT,
-        typename OutputIteratorT,
-        typename NumSelectedIteratorT,
-        typename SelectOp
-    >
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t If(void *d_temp_storage,
-                  size_t &temp_storage_bytes,
-                  InputIteratorT d_in,
-                  OutputIteratorT d_out,
-                  NumSelectedIteratorT d_num_selected_out,
-                  int num_items,
-                  SelectOp select_op,
-                  hipStream_t stream = 0,
-                  bool debug_synchronous = false)
+    template <typename InputIteratorT,
+              typename OutputIteratorT,
+              typename NumSelectedIteratorT,
+              typename SelectOp>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t If(void*                d_temp_storage,
+                                                 size_t&              temp_storage_bytes,
+                                                 InputIteratorT       d_in,
+                                                 OutputIteratorT      d_out,
+                                                 NumSelectedIteratorT d_num_selected_out,
+                                                 int                  num_items,
+                                                 SelectOp             select_op,
+                                                 hipStream_t          stream            = 0,
+                                                 bool                 debug_synchronous = false)
     {
-        return ::rocprim::select(
-            d_temp_storage, temp_storage_bytes,
-            d_in, d_out, d_num_selected_out, num_items, select_op,
-            stream, debug_synchronous
-        );
+        return ::rocprim::select(d_temp_storage,
+                                 temp_storage_bytes,
+                                 d_in,
+                                 d_out,
+                                 d_num_selected_out,
+                                 num_items,
+                                 select_op,
+                                 stream,
+                                 debug_synchronous);
     }
 
-    template <
-        typename InputIteratorT,
-        typename OutputIteratorT,
-        typename NumSelectedIteratorT
-    >
-    HIPCUB_RUNTIME_FUNCTION static
-    hipError_t Unique(void *d_temp_storage,
-                      size_t &temp_storage_bytes,
-                      InputIteratorT d_in,
-                      OutputIteratorT d_out,
-                      NumSelectedIteratorT d_num_selected_out,
-                      int num_items,
-                      hipStream_t stream = 0,
-                      bool debug_synchronous = false)
+    template <typename InputIteratorT, typename OutputIteratorT, typename NumSelectedIteratorT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t Unique(void*                d_temp_storage,
+                                                     size_t&              temp_storage_bytes,
+                                                     InputIteratorT       d_in,
+                                                     OutputIteratorT      d_out,
+                                                     NumSelectedIteratorT d_num_selected_out,
+                                                     int                  num_items,
+                                                     hipStream_t          stream            = 0,
+                                                     bool                 debug_synchronous = false)
     {
-        return ::rocprim::unique(
-            d_temp_storage, temp_storage_bytes,
-            d_in, d_out, d_num_selected_out, num_items, hipcub::Equality(),
-            stream, debug_synchronous
-        );
+        return ::rocprim::unique(d_temp_storage,
+                                 temp_storage_bytes,
+                                 d_in,
+                                 d_out,
+                                 d_num_selected_out,
+                                 num_items,
+                                 hipcub::Equality(),
+                                 stream,
+                                 debug_synchronous);
     }
 };
 

--- a/hipcub/include/hipcub/rocprim/hipcub.hpp
+++ b/hipcub/include/hipcub/rocprim/hipcub.hpp
@@ -32,10 +32,10 @@
 
 #include "../config.hpp"
 
-#include "util_allocator.hpp"
-#include "util_type.hpp"
-#include "util_ptx.hpp"
 #include "thread/thread_operators.hpp"
+#include "util_allocator.hpp"
+#include "util_ptx.hpp"
+#include "util_type.hpp"
 
 // Iterator
 #include "iterator/arg_index_input_iterator.hpp"

--- a/hipcub/include/hipcub/rocprim/iterator/arg_index_input_iterator.hpp
+++ b/hipcub/include/hipcub/rocprim/iterator/arg_index_input_iterator.hpp
@@ -34,11 +34,9 @@
 
 BEGIN_HIPCUB_NAMESPACE
 
-template<
-    typename InputIterator,
-    typename Difference = std::ptrdiff_t,
-    typename Value = typename std::iterator_traits<InputIterator>::value_type
->
+template <typename InputIterator,
+          typename Difference = std::ptrdiff_t,
+          typename Value      = typename std::iterator_traits<InputIterator>::value_type>
 using ArgIndexInputIterator = ::rocprim::arg_index_iterator<InputIterator, Difference, Value>;
 
 END_HIPCUB_NAMESPACE

--- a/hipcub/include/hipcub/rocprim/iterator/constant_input_iterator.hpp
+++ b/hipcub/include/hipcub/rocprim/iterator/constant_input_iterator.hpp
@@ -26,7 +26,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  ******************************************************************************/
- 
+
 #ifndef HIPCUB_ROCPRIM_ITERATOR_CONSTANT_INPUT_ITERATOR_HPP_
 #define HIPCUB_ROCPRIM_ITERATOR_CONSTANT_INPUT_ITERATOR_HPP_
 
@@ -34,10 +34,7 @@
 
 BEGIN_HIPCUB_NAMESPACE
 
-template<
-    typename ValueType,
-    typename OffsetT = std::ptrdiff_t
->
+template <typename ValueType, typename OffsetT = std::ptrdiff_t>
 using ConstantInputIterator = ::rocprim::constant_iterator<ValueType, OffsetT>;
 
 END_HIPCUB_NAMESPACE

--- a/hipcub/include/hipcub/rocprim/iterator/counting_input_iterator.hpp
+++ b/hipcub/include/hipcub/rocprim/iterator/counting_input_iterator.hpp
@@ -34,10 +34,7 @@
 
 BEGIN_HIPCUB_NAMESPACE
 
-template<
-    typename ValueType,
-    typename OffsetT = std::ptrdiff_t
->
+template <typename ValueType, typename OffsetT = std::ptrdiff_t>
 using CountingInputIterator = ::rocprim::counting_iterator<ValueType, OffsetT>;
 
 END_HIPCUB_NAMESPACE

--- a/hipcub/include/hipcub/rocprim/iterator/tex_obj_input_iterator.hpp
+++ b/hipcub/include/hipcub/rocprim/iterator/tex_obj_input_iterator.hpp
@@ -34,10 +34,7 @@
 
 BEGIN_HIPCUB_NAMESPACE
 
-template<
-    typename T,
-    typename OffsetT = std::ptrdiff_t
->
+template <typename T, typename OffsetT = std::ptrdiff_t>
 using TexObjInputIterator = ::rocprim::texture_cache_iterator<T, OffsetT>;
 
 END_HIPCUB_NAMESPACE

--- a/hipcub/include/hipcub/rocprim/iterator/transform_input_iterator.hpp
+++ b/hipcub/include/hipcub/rocprim/iterator/transform_input_iterator.hpp
@@ -34,13 +34,13 @@
 
 BEGIN_HIPCUB_NAMESPACE
 
-template<
-    typename ValueType,
-    typename ConversionOp,
-    typename InputIteratorT,
-    typename OffsetT = std::ptrdiff_t // ignored
->
-using TransformInputIterator = ::rocprim::transform_iterator<InputIteratorT, ConversionOp, ValueType>;
+template <typename ValueType,
+          typename ConversionOp,
+          typename InputIteratorT,
+          typename OffsetT = std::ptrdiff_t // ignored
+          >
+using TransformInputIterator
+    = ::rocprim::transform_iterator<InputIteratorT, ConversionOp, ValueType>;
 
 END_HIPCUB_NAMESPACE
 

--- a/hipcub/include/hipcub/rocprim/util_allocator.hpp
+++ b/hipcub/include/hipcub/rocprim/util_allocator.hpp
@@ -32,9 +32,9 @@
 
 #include "../config.hpp"
 
-#include <set>
 #include <map>
 #include <mutex>
+#include <set>
 
 #include <math.h>
 #include <stdio.h>
@@ -44,22 +44,19 @@ BEGIN_HIPCUB_NAMESPACE
 #define _HipcubLog(format, ...) printf(format, __VA_ARGS__);
 
 /// hipCUB error reporting macro (prints error messages to stderr)
-#if (defined(DEBUG) || defined(_DEBUG)) && !defined(HIPCUB_STDERR)
-    #define HIPCUB_STDERR
+#if(defined(DEBUG) || defined(_DEBUG)) && !defined(HIPCUB_STDERR)
+#define HIPCUB_STDERR
 #endif
 
-inline
-hipError_t Debug(
-    hipError_t      error,
-    const char*     filename,
-    int             line)
+inline hipError_t Debug(hipError_t error, const char* filename, int line)
 {
     (void)filename;
     (void)line;
 #ifdef HIPCUB_STDERR
-    if (error)
+    if(error)
     {
-        fprintf(stderr, "HIP error %d [%s, %d]: %s\n", error, filename, line, hipGetErrorString(error));
+        fprintf(
+            stderr, "HIP error %d [%s, %d]: %s\n", error, filename, line, hipGetErrorString(error));
         fflush(stderr);
     }
 #endif
@@ -67,7 +64,7 @@ hipError_t Debug(
 }
 
 #ifndef HipcubDebug
-    #define HipcubDebug(e) hipcub::Debug((hipError_t) (e), __FILE__, __LINE__)
+#define HipcubDebug(e) hipcub::Debug((hipError_t)(e), __FILE__, __LINE__)
 #endif
 
 // Hipified version of cub/util_allocator.cuh
@@ -79,10 +76,10 @@ struct CachingDeviceAllocator
     //---------------------------------------------------------------------
 
     /// Out-of-bounds bin
-    static const unsigned int INVALID_BIN = (unsigned int) -1;
+    static const unsigned int INVALID_BIN = (unsigned int)-1;
 
     /// Invalid size
-    static const size_t INVALID_SIZE = (size_t) -1;
+    static const size_t INVALID_SIZE = (size_t)-1;
 
     /// Invalid device ordinal
     static const int INVALID_DEVICE_ORDINAL = -1;
@@ -96,46 +93,49 @@ struct CachingDeviceAllocator
      */
     struct BlockDescriptor
     {
-        void*           d_ptr;              // Device pointer
-        size_t          bytes;              // Size of allocation in bytes
-        unsigned int    bin;                // Bin enumeration
-        int             device;             // device ordinal
-        hipStream_t     associated_stream;  // Associated associated_stream
-        hipEvent_t      ready_event;        // Signal when associated stream has run to the point at which this block was freed
+        void*        d_ptr; // Device pointer
+        size_t       bytes; // Size of allocation in bytes
+        unsigned int bin; // Bin enumeration
+        int          device; // device ordinal
+        hipStream_t  associated_stream; // Associated associated_stream
+        hipEvent_t
+            ready_event; // Signal when associated stream has run to the point at which this block was freed
 
         // Constructor (suitable for searching maps for a specific block, given its pointer and device)
-        BlockDescriptor(void *d_ptr, int device) :
-            d_ptr(d_ptr),
-            bytes(0),
-            bin(INVALID_BIN),
-            device(device),
-            associated_stream(0),
-            ready_event(0)
-        {}
+        BlockDescriptor(void* d_ptr, int device)
+            : d_ptr(d_ptr)
+            , bytes(0)
+            , bin(INVALID_BIN)
+            , device(device)
+            , associated_stream(0)
+            , ready_event(0)
+        {
+        }
 
         // Constructor (suitable for searching maps for a range of suitable blocks, given a device)
-        BlockDescriptor(int device) :
-            d_ptr(NULL),
-            bytes(0),
-            bin(INVALID_BIN),
-            device(device),
-            associated_stream(0),
-            ready_event(0)
-        {}
+        BlockDescriptor(int device)
+            : d_ptr(NULL)
+            , bytes(0)
+            , bin(INVALID_BIN)
+            , device(device)
+            , associated_stream(0)
+            , ready_event(0)
+        {
+        }
 
         // Comparison functor for comparing device pointers
-        static bool PtrCompare(const BlockDescriptor &a, const BlockDescriptor &b)
+        static bool PtrCompare(const BlockDescriptor& a, const BlockDescriptor& b)
         {
-            if (a.device == b.device)
+            if(a.device == b.device)
                 return (a.d_ptr < b.d_ptr);
             else
                 return (a.device < b.device);
         }
 
         // Comparison functor for comparing allocation sizes
-        static bool SizeCompare(const BlockDescriptor &a, const BlockDescriptor &b)
+        static bool SizeCompare(const BlockDescriptor& a, const BlockDescriptor& b)
         {
-            if (a.device == b.device)
+            if(a.device == b.device)
                 return (a.bytes < b.bytes);
             else
                 return (a.device < b.device);
@@ -143,13 +143,17 @@ struct CachingDeviceAllocator
     };
 
     /// BlockDescriptor comparator function interface
-    typedef bool (*Compare)(const BlockDescriptor &, const BlockDescriptor &);
+    typedef bool (*Compare)(const BlockDescriptor&, const BlockDescriptor&);
 
-    class TotalBytes {
+    class TotalBytes
+    {
     public:
         size_t free;
         size_t live;
-        TotalBytes() { free = live = 0; }
+        TotalBytes()
+        {
+            free = live = 0;
+        }
     };
 
     /// Set type for cached blocks (ordered by size)
@@ -161,7 +165,6 @@ struct CachingDeviceAllocator
     /// Map type of device ordinals to the number of cached bytes cached by each device
     typedef std::map<int, TotalBytes> GpuCachedBytes;
 
-
     //---------------------------------------------------------------------
     // Utility functions
     //---------------------------------------------------------------------
@@ -169,71 +172,65 @@ struct CachingDeviceAllocator
     /**
      * Integer pow function for unsigned base and exponent
      */
-    static unsigned int IntPow(
-        unsigned int base,
-        unsigned int exp)
+    static unsigned int IntPow(unsigned int base, unsigned int exp)
     {
         unsigned int retval = 1;
-        while (exp > 0)
+        while(exp > 0)
         {
-            if (exp & 1) {
-                retval = retval * base;        // multiply the result by the current base
+            if(exp & 1)
+            {
+                retval = retval * base; // multiply the result by the current base
             }
-            base = base * base;                // square the base
-            exp = exp >> 1;                    // divide the exponent in half
+            base = base * base; // square the base
+            exp  = exp >> 1; // divide the exponent in half
         }
         return retval;
     }
 
-
     /**
      * Round up to the nearest power-of
      */
-    void NearestPowerOf(
-        unsigned int    &power,
-        size_t          &rounded_bytes,
-        unsigned int    base,
-        size_t          value)
+    void NearestPowerOf(unsigned int& power, size_t& rounded_bytes, unsigned int base, size_t value)
     {
-        power = 0;
+        power         = 0;
         rounded_bytes = 1;
 
-        if (value * base < value)
+        if(value * base < value)
         {
             // Overflow
-            power = sizeof(size_t) * 8;
+            power         = sizeof(size_t) * 8;
             rounded_bytes = size_t(0) - 1;
             return;
         }
 
-        while (rounded_bytes < value)
+        while(rounded_bytes < value)
         {
             rounded_bytes *= base;
             power++;
         }
     }
 
-
     //---------------------------------------------------------------------
     // Fields
     //---------------------------------------------------------------------
 
-    std::mutex      mutex;              /// Mutex for thread-safety
+    std::mutex mutex; /// Mutex for thread-safety
 
-    unsigned int    bin_growth;         /// Geometric growth factor for bin-sizes
-    unsigned int    min_bin;            /// Minimum bin enumeration
-    unsigned int    max_bin;            /// Maximum bin enumeration
+    unsigned int bin_growth; /// Geometric growth factor for bin-sizes
+    unsigned int min_bin; /// Minimum bin enumeration
+    unsigned int max_bin; /// Maximum bin enumeration
 
-    size_t          min_bin_bytes;      /// Minimum bin size
-    size_t          max_bin_bytes;      /// Maximum bin size
-    size_t          max_cached_bytes;   /// Maximum aggregate cached bytes per device
+    size_t min_bin_bytes; /// Minimum bin size
+    size_t max_bin_bytes; /// Maximum bin size
+    size_t max_cached_bytes; /// Maximum aggregate cached bytes per device
 
-    const bool      skip_cleanup;       /// Whether or not to skip a call to FreeAllCached() when destructor is called.  (The CUDA runtime may have already shut down for statically declared allocators)
-    bool            debug;              /// Whether or not to print (de)allocation events to stdout
+    const bool
+         skip_cleanup; /// Whether or not to skip a call to FreeAllCached() when destructor is called.  (The CUDA runtime may have already shut down for statically declared allocators)
+    bool debug; /// Whether or not to print (de)allocation events to stdout
 
-    GpuCachedBytes  cached_bytes;       /// Map of device ordinal to aggregate cached bytes on that device
-    CachedBlocks    cached_blocks;      /// Set of cached device allocations available for reuse
-    BusyBlocks      live_blocks;        /// Set of live device allocations currently in use
+    GpuCachedBytes cached_bytes; /// Map of device ordinal to aggregate cached bytes on that device
+    CachedBlocks   cached_blocks; /// Set of cached device allocations available for reuse
+    BusyBlocks     live_blocks; /// Set of live device allocations currently in use
 
     //---------------------------------------------------------------------
     // Methods
@@ -243,25 +240,27 @@ struct CachingDeviceAllocator
      * \brief Constructor.
      */
     CachingDeviceAllocator(
-        unsigned int    bin_growth,                             ///< Geometric growth factor for bin-sizes
-        unsigned int    min_bin             = 1,                ///< Minimum bin (default is bin_growth ^ 1)
-        unsigned int    max_bin             = INVALID_BIN,      ///< Maximum bin (default is no max bin)
-        size_t          max_cached_bytes    = INVALID_SIZE,     ///< Maximum aggregate cached bytes per device (default is no limit)
-        bool            skip_cleanup        = false,            ///< Whether or not to skip a call to \p FreeAllCached() when the destructor is called (default is to deallocate)
-        bool            debug               = false)            ///< Whether or not to print (de)allocation events to stdout (default is no stderr output)
-    :
-        bin_growth(bin_growth),
-        min_bin(min_bin),
-        max_bin(max_bin),
-        min_bin_bytes(IntPow(bin_growth, min_bin)),
-        max_bin_bytes(IntPow(bin_growth, max_bin)),
-        max_cached_bytes(max_cached_bytes),
-        skip_cleanup(skip_cleanup),
-        debug(debug),
-        cached_blocks(BlockDescriptor::SizeCompare),
-        live_blocks(BlockDescriptor::PtrCompare)
-    {}
-
+        unsigned int bin_growth, ///< Geometric growth factor for bin-sizes
+        unsigned int min_bin = 1, ///< Minimum bin (default is bin_growth ^ 1)
+        unsigned int max_bin = INVALID_BIN, ///< Maximum bin (default is no max bin)
+        size_t       max_cached_bytes
+        = INVALID_SIZE, ///< Maximum aggregate cached bytes per device (default is no limit)
+        bool skip_cleanup
+        = false, ///< Whether or not to skip a call to \p FreeAllCached() when the destructor is called (default is to deallocate)
+        bool debug
+        = false) ///< Whether or not to print (de)allocation events to stdout (default is no stderr output)
+        : bin_growth(bin_growth)
+        , min_bin(min_bin)
+        , max_bin(max_bin)
+        , min_bin_bytes(IntPow(bin_growth, min_bin))
+        , max_bin_bytes(IntPow(bin_growth, max_bin))
+        , max_cached_bytes(max_cached_bytes)
+        , skip_cleanup(skip_cleanup)
+        , debug(debug)
+        , cached_blocks(BlockDescriptor::SizeCompare)
+        , live_blocks(BlockDescriptor::PtrCompare)
+    {
+    }
 
     /**
      * \brief Default constructor.
@@ -276,22 +275,19 @@ struct CachingDeviceAllocator
      * which delineates five bin-sizes: 512B, 4KB, 32KB, 256KB, and 2MB and
      * sets a maximum of 6,291,455 cached bytes per device
      */
-    CachingDeviceAllocator(
-        bool skip_cleanup = false,
-        bool debug = false)
-    :
-        bin_growth(8),
-        min_bin(3),
-        max_bin(7),
-        min_bin_bytes(IntPow(bin_growth, min_bin)),
-        max_bin_bytes(IntPow(bin_growth, max_bin)),
-        max_cached_bytes((max_bin_bytes * 3) - 1),
-        skip_cleanup(skip_cleanup),
-        debug(debug),
-        cached_blocks(BlockDescriptor::SizeCompare),
-        live_blocks(BlockDescriptor::PtrCompare)
-    {}
-
+    CachingDeviceAllocator(bool skip_cleanup = false, bool debug = false)
+        : bin_growth(8)
+        , min_bin(3)
+        , max_bin(7)
+        , min_bin_bytes(IntPow(bin_growth, min_bin))
+        , max_bin_bytes(IntPow(bin_growth, max_bin))
+        , max_cached_bytes((max_bin_bytes * 3) - 1)
+        , skip_cleanup(skip_cleanup)
+        , debug(debug)
+        , cached_blocks(BlockDescriptor::SizeCompare)
+        , live_blocks(BlockDescriptor::PtrCompare)
+    {
+    }
 
     /**
      * \brief Sets the limit on the number bytes this allocator is allowed to cache per device.
@@ -299,13 +295,15 @@ struct CachingDeviceAllocator
      * Changing the ceiling of cached bytes does not cause any allocations (in-use or
      * cached-in-reserve) to be freed.  See \p FreeAllCached().
      */
-    hipError_t SetMaxCachedBytes(
-        size_t max_cached_bytes)
+    hipError_t SetMaxCachedBytes(size_t max_cached_bytes)
     {
         // Lock
         mutex.lock();
 
-        if (debug) _HipcubLog("Changing max_cached_bytes (%lld -> %lld)\n", (long long) this->max_cached_bytes, (long long) max_cached_bytes);
+        if(debug)
+            _HipcubLog("Changing max_cached_bytes (%lld -> %lld)\n",
+                       (long long)this->max_cached_bytes,
+                       (long long)max_cached_bytes);
 
         this->max_cached_bytes = max_cached_bytes;
 
@@ -315,7 +313,6 @@ struct CachingDeviceAllocator
         return hipSuccess;
     }
 
-
     /**
      * \brief Provides a suitable allocation of device memory for the given size on the specified device.
      *
@@ -323,63 +320,63 @@ struct CachingDeviceAllocator
      * with which it was associated with during allocation, and it becomes available for reuse within other
      * streams when all prior work submitted to \p active_stream has completed.
      */
-    hipError_t DeviceAllocate(
-        int             device,             ///< [in] Device on which to place the allocation
-        void            **d_ptr,            ///< [out] Reference to pointer to the allocation
-        size_t          bytes,              ///< [in] Minimum number of bytes for the allocation
-        hipStream_t     active_stream = 0)  ///< [in] The stream to be associated with this allocation
+    hipError_t DeviceAllocate(int    device, ///< [in] Device on which to place the allocation
+                              void** d_ptr, ///< [out] Reference to pointer to the allocation
+                              size_t bytes, ///< [in] Minimum number of bytes for the allocation
+                              hipStream_t active_stream
+                              = 0) ///< [in] The stream to be associated with this allocation
     {
-        *d_ptr                          = NULL;
-        int entrypoint_device           = INVALID_DEVICE_ORDINAL;
-        hipError_t error                = hipSuccess;
+        *d_ptr                       = NULL;
+        int        entrypoint_device = INVALID_DEVICE_ORDINAL;
+        hipError_t error             = hipSuccess;
 
-        if (device == INVALID_DEVICE_ORDINAL)
+        if(device == INVALID_DEVICE_ORDINAL)
         {
-            if (HipcubDebug(error = hipGetDevice(&entrypoint_device))) return error;
+            if(HipcubDebug(error = hipGetDevice(&entrypoint_device)))
+                return error;
             device = entrypoint_device;
         }
 
         // Create a block descriptor for the requested allocation
-        bool found = false;
+        bool            found = false;
         BlockDescriptor search_key(device);
         search_key.associated_stream = active_stream;
         NearestPowerOf(search_key.bin, search_key.bytes, bin_growth, bytes);
 
-        if (search_key.bin > max_bin)
+        if(search_key.bin > max_bin)
         {
             // Bin is greater than our maximum bin: allocate the request
             // exactly and give out-of-bounds bin.  It will not be cached
             // for reuse when returned.
-            search_key.bin      = INVALID_BIN;
-            search_key.bytes    = bytes;
+            search_key.bin   = INVALID_BIN;
+            search_key.bytes = bytes;
         }
         else
         {
             // Search for a suitable cached allocation: lock
             mutex.lock();
 
-            if (search_key.bin < min_bin)
+            if(search_key.bin < min_bin)
             {
                 // Bin is less than minimum bin: round up
-                search_key.bin      = min_bin;
-                search_key.bytes    = min_bin_bytes;
+                search_key.bin   = min_bin;
+                search_key.bytes = min_bin_bytes;
             }
 
             // Iterate through the range of cached blocks on the same device in the same bin
             CachedBlocks::iterator block_itr = cached_blocks.lower_bound(search_key);
-            while ((block_itr != cached_blocks.end())
-                    && (block_itr->device == device)
-                    && (block_itr->bin == search_key.bin))
+            while((block_itr != cached_blocks.end()) && (block_itr->device == device)
+                  && (block_itr->bin == search_key.bin))
             {
                 // To prevent races with reusing blocks returned by the host but still
                 // in use by the device, only consider cached blocks that are
                 // either (from the active stream) or (from an idle stream)
-                if ((active_stream == block_itr->associated_stream) ||
-                    (hipEventQuery(block_itr->ready_event) != hipErrorNotReady))
+                if((active_stream == block_itr->associated_stream)
+                   || (hipEventQuery(block_itr->ready_event) != hipErrorNotReady))
                 {
                     // Reuse existing cache block.  Insert into live blocks.
-                    found = true;
-                    search_key = *block_itr;
+                    found                        = true;
+                    search_key                   = *block_itr;
                     search_key.associated_stream = active_stream;
                     live_blocks.insert(search_key);
 
@@ -387,8 +384,14 @@ struct CachingDeviceAllocator
                     cached_bytes[device].free -= search_key.bytes;
                     cached_bytes[device].live += search_key.bytes;
 
-                    if (debug) _HipcubLog("\tDevice %d reused cached block at %p (%lld bytes) for stream %lld (previously associated with stream %lld).\n",
-                        device, search_key.d_ptr, (long long) search_key.bytes, (long long) search_key.associated_stream, (long long)  block_itr->associated_stream);
+                    if(debug)
+                        _HipcubLog("\tDevice %d reused cached block at %p (%lld bytes) for stream "
+                                   "%lld (previously associated with stream %lld).\n",
+                                   device,
+                                   search_key.d_ptr,
+                                   (long long)search_key.bytes,
+                                   (long long)search_key.associated_stream,
+                                   (long long)block_itr->associated_stream);
 
                     cached_blocks.erase(block_itr);
 
@@ -402,47 +405,64 @@ struct CachingDeviceAllocator
         }
 
         // Allocate the block if necessary
-        if (!found)
+        if(!found)
         {
             // Set runtime's current device to specified device (entrypoint may not be set)
-            if (device != entrypoint_device)
+            if(device != entrypoint_device)
             {
-                if (HipcubDebug(error = hipGetDevice(&entrypoint_device))) return error;
-                if (HipcubDebug(error = hipSetDevice(device))) return error;
+                if(HipcubDebug(error = hipGetDevice(&entrypoint_device)))
+                    return error;
+                if(HipcubDebug(error = hipSetDevice(device)))
+                    return error;
             }
 
             // Attempt to allocate
-            if (HipcubDebug(error = hipMalloc(&search_key.d_ptr, search_key.bytes)) == hipErrorMemoryAllocation)
+            if(HipcubDebug(error = hipMalloc(&search_key.d_ptr, search_key.bytes))
+               == hipErrorMemoryAllocation)
             {
                 // The allocation attempt failed: free all cached blocks on device and retry
-                if (debug) _HipcubLog("\tDevice %d failed to allocate %lld bytes for stream %lld, retrying after freeing cached allocations",
-                      device, (long long) search_key.bytes, (long long) search_key.associated_stream);
+                if(debug)
+                    _HipcubLog("\tDevice %d failed to allocate %lld bytes for stream %lld, "
+                               "retrying after freeing cached allocations",
+                               device,
+                               (long long)search_key.bytes,
+                               (long long)search_key.associated_stream);
 
-                error = hipSuccess;    // Reset the error we will return
-                hipGetLastError();     // Reset error
+                error = hipSuccess; // Reset the error we will return
+                hipGetLastError(); // Reset error
 
                 // Lock
                 mutex.lock();
 
                 // Iterate the range of free blocks on the same device
-                BlockDescriptor free_key(device);
+                BlockDescriptor        free_key(device);
                 CachedBlocks::iterator block_itr = cached_blocks.lower_bound(free_key);
 
-                while ((block_itr != cached_blocks.end()) && (block_itr->device == device))
+                while((block_itr != cached_blocks.end()) && (block_itr->device == device))
                 {
                     // No need to worry about synchronization with the device: hipFree is
                     // blocking and will synchronize across all kernels executing
                     // on the current device
 
                     // Free device memory and destroy stream event.
-                    if (HipcubDebug(error = hipFree(block_itr->d_ptr))) break;
-                    if (HipcubDebug(error = hipEventDestroy(block_itr->ready_event))) break;
+                    if(HipcubDebug(error = hipFree(block_itr->d_ptr)))
+                        break;
+                    if(HipcubDebug(error = hipEventDestroy(block_itr->ready_event)))
+                        break;
 
                     // Reduce balance and erase entry
                     cached_bytes[device].free -= block_itr->bytes;
 
-                    if (debug) _HipcubLog("\tDevice %d freed %lld bytes.\n\t\t  %lld available blocks cached (%lld bytes), %lld live blocks (%lld bytes) outstanding.\n",
-                        device, (long long) block_itr->bytes, (long long) cached_blocks.size(), (long long) cached_bytes[device].free, (long long) live_blocks.size(), (long long) cached_bytes[device].live);
+                    if(debug)
+                        _HipcubLog(
+                            "\tDevice %d freed %lld bytes.\n\t\t  %lld available blocks cached "
+                            "(%lld bytes), %lld live blocks (%lld bytes) outstanding.\n",
+                            device,
+                            (long long)block_itr->bytes,
+                            (long long)cached_blocks.size(),
+                            (long long)cached_bytes[device].free,
+                            (long long)live_blocks.size(),
+                            (long long)cached_bytes[device].live);
 
                     cached_blocks.erase(block_itr);
 
@@ -453,14 +473,17 @@ struct CachingDeviceAllocator
                 mutex.unlock();
 
                 // Return under error
-                if (error) return error;
+                if(error)
+                    return error;
 
                 // Try to allocate again
-                if (HipcubDebug(error = hipMalloc(&search_key.d_ptr, search_key.bytes))) return error;
+                if(HipcubDebug(error = hipMalloc(&search_key.d_ptr, search_key.bytes)))
+                    return error;
             }
 
             // Create ready event
-            if (HipcubDebug(error = hipEventCreateWithFlags(&search_key.ready_event, hipEventDisableTiming)))
+            if(HipcubDebug(
+                   error = hipEventCreateWithFlags(&search_key.ready_event, hipEventDisableTiming)))
                 return error;
 
             // Insert into live blocks
@@ -469,25 +492,35 @@ struct CachingDeviceAllocator
             cached_bytes[device].live += search_key.bytes;
             mutex.unlock();
 
-            if (debug) _HipcubLog("\tDevice %d allocated new device block at %p (%lld bytes associated with stream %lld).\n",
-                      device, search_key.d_ptr, (long long) search_key.bytes, (long long) search_key.associated_stream);
+            if(debug)
+                _HipcubLog("\tDevice %d allocated new device block at %p (%lld bytes associated "
+                           "with stream %lld).\n",
+                           device,
+                           search_key.d_ptr,
+                           (long long)search_key.bytes,
+                           (long long)search_key.associated_stream);
 
             // Attempt to revert back to previous device if necessary
-            if ((entrypoint_device != INVALID_DEVICE_ORDINAL) && (entrypoint_device != device))
+            if((entrypoint_device != INVALID_DEVICE_ORDINAL) && (entrypoint_device != device))
             {
-                if (HipcubDebug(error = hipSetDevice(entrypoint_device))) return error;
+                if(HipcubDebug(error = hipSetDevice(entrypoint_device)))
+                    return error;
             }
         }
 
         // Copy device pointer to output parameter
         *d_ptr = search_key.d_ptr;
 
-        if (debug) _HipcubLog("\t\t%lld available blocks cached (%lld bytes), %lld live blocks outstanding(%lld bytes).\n",
-            (long long) cached_blocks.size(), (long long) cached_bytes[device].free, (long long) live_blocks.size(), (long long) cached_bytes[device].live);
+        if(debug)
+            _HipcubLog("\t\t%lld available blocks cached (%lld bytes), %lld live blocks "
+                       "outstanding(%lld bytes).\n",
+                       (long long)cached_blocks.size(),
+                       (long long)cached_bytes[device].free,
+                       (long long)live_blocks.size(),
+                       (long long)cached_bytes[device].live);
 
         return error;
     }
-
 
     /**
      * \brief Provides a suitable allocation of device memory for the given size on the current device.
@@ -496,14 +529,13 @@ struct CachingDeviceAllocator
      * with which it was associated with during allocation, and it becomes available for reuse within other
      * streams when all prior work submitted to \p active_stream has completed.
      */
-    hipError_t DeviceAllocate(
-        void            **d_ptr,            ///< [out] Reference to pointer to the allocation
-        size_t          bytes,              ///< [in] Minimum number of bytes for the allocation
-        hipStream_t     active_stream = 0)  ///< [in] The stream to be associated with this allocation
+    hipError_t DeviceAllocate(void** d_ptr, ///< [out] Reference to pointer to the allocation
+                              size_t bytes, ///< [in] Minimum number of bytes for the allocation
+                              hipStream_t active_stream
+                              = 0) ///< [in] The stream to be associated with this allocation
     {
         return DeviceAllocate(INVALID_DEVICE_ORDINAL, d_ptr, bytes, active_stream);
     }
-
 
     /**
      * \brief Frees a live allocation of device memory on the specified device, returning it to the allocator.
@@ -512,16 +544,14 @@ struct CachingDeviceAllocator
      * with which it was associated with during allocation, and it becomes available for reuse within other
      * streams when all prior work submitted to \p active_stream has completed.
      */
-    hipError_t DeviceFree(
-        int             device,
-        void*           d_ptr)
+    hipError_t DeviceFree(int device, void* d_ptr)
     {
-        int entrypoint_device           = INVALID_DEVICE_ORDINAL;
-        hipError_t error                = hipSuccess;
+        int        entrypoint_device = INVALID_DEVICE_ORDINAL;
+        hipError_t error             = hipSuccess;
 
-        if (device == INVALID_DEVICE_ORDINAL)
+        if(device == INVALID_DEVICE_ORDINAL)
         {
-            if (HipcubDebug(error = hipGetDevice(&entrypoint_device)))
+            if(HipcubDebug(error = hipGetDevice(&entrypoint_device)))
                 return error;
             device = entrypoint_device;
         }
@@ -530,10 +560,10 @@ struct CachingDeviceAllocator
         mutex.lock();
 
         // Find corresponding block descriptor
-        bool recached = false;
-        BlockDescriptor search_key(d_ptr, device);
+        bool                 recached = false;
+        BlockDescriptor      search_key(d_ptr, device);
         BusyBlocks::iterator block_itr = live_blocks.find(search_key);
-        if (block_itr != live_blocks.end())
+        if(block_itr != live_blocks.end())
         {
             // Remove from live blocks
             search_key = *block_itr;
@@ -541,54 +571,78 @@ struct CachingDeviceAllocator
             cached_bytes[device].live -= search_key.bytes;
 
             // Keep the returned allocation if bin is valid and we won't exceed the max cached threshold
-            if ((search_key.bin != INVALID_BIN) && (cached_bytes[device].free + search_key.bytes <= max_cached_bytes))
+            if((search_key.bin != INVALID_BIN)
+               && (cached_bytes[device].free + search_key.bytes <= max_cached_bytes))
             {
                 // Insert returned allocation into free blocks
                 recached = true;
                 cached_blocks.insert(search_key);
                 cached_bytes[device].free += search_key.bytes;
 
-                if (debug) _HipcubLog("\tDevice %d returned %lld bytes from associated stream %lld.\n\t\t %lld available blocks cached (%lld bytes), %lld live blocks outstanding. (%lld bytes)\n",
-                    device, (long long) search_key.bytes, (long long) search_key.associated_stream, (long long) cached_blocks.size(),
-                    (long long) cached_bytes[device].free, (long long) live_blocks.size(), (long long) cached_bytes[device].live);
+                if(debug)
+                    _HipcubLog("\tDevice %d returned %lld bytes from associated stream %lld.\n\t\t "
+                               "%lld available blocks cached (%lld bytes), %lld live blocks "
+                               "outstanding. (%lld bytes)\n",
+                               device,
+                               (long long)search_key.bytes,
+                               (long long)search_key.associated_stream,
+                               (long long)cached_blocks.size(),
+                               (long long)cached_bytes[device].free,
+                               (long long)live_blocks.size(),
+                               (long long)cached_bytes[device].live);
             }
         }
 
         // First set to specified device (entrypoint may not be set)
-        if (device != entrypoint_device)
+        if(device != entrypoint_device)
         {
-            if (HipcubDebug(error = hipGetDevice(&entrypoint_device))) return error;
-            if (HipcubDebug(error = hipSetDevice(device))) return error;
+            if(HipcubDebug(error = hipGetDevice(&entrypoint_device)))
+                return error;
+            if(HipcubDebug(error = hipSetDevice(device)))
+                return error;
         }
 
-        if (recached)
+        if(recached)
         {
             // Insert the ready event in the associated stream (must have current device set properly)
-            if (HipcubDebug(error = hipEventRecord(search_key.ready_event, search_key.associated_stream))) return error;
+            if(HipcubDebug(error
+                           = hipEventRecord(search_key.ready_event, search_key.associated_stream)))
+                return error;
         }
 
         // Unlock
         mutex.unlock();
 
-        if (!recached)
+        if(!recached)
         {
             // Free the allocation from the runtime and cleanup the event.
-            if (HipcubDebug(error = hipFree(d_ptr))) return error;
-            if (HipcubDebug(error = hipEventDestroy(search_key.ready_event))) return error;
+            if(HipcubDebug(error = hipFree(d_ptr)))
+                return error;
+            if(HipcubDebug(error = hipEventDestroy(search_key.ready_event)))
+                return error;
 
-            if (debug) _HipcubLog("\tDevice %d freed %lld bytes from associated stream %lld.\n\t\t  %lld available blocks cached (%lld bytes), %lld live blocks (%lld bytes) outstanding.\n",
-                device, (long long) search_key.bytes, (long long) search_key.associated_stream, (long long) cached_blocks.size(), (long long) cached_bytes[device].free, (long long) live_blocks.size(), (long long) cached_bytes[device].live);
+            if(debug)
+                _HipcubLog("\tDevice %d freed %lld bytes from associated stream %lld.\n\t\t  %lld "
+                           "available blocks cached (%lld bytes), %lld live blocks (%lld bytes) "
+                           "outstanding.\n",
+                           device,
+                           (long long)search_key.bytes,
+                           (long long)search_key.associated_stream,
+                           (long long)cached_blocks.size(),
+                           (long long)cached_bytes[device].free,
+                           (long long)live_blocks.size(),
+                           (long long)cached_bytes[device].live);
         }
 
         // Reset device
-        if ((entrypoint_device != INVALID_DEVICE_ORDINAL) && (entrypoint_device != device))
+        if((entrypoint_device != INVALID_DEVICE_ORDINAL) && (entrypoint_device != device))
         {
-            if (HipcubDebug(error = hipSetDevice(entrypoint_device))) return error;
+            if(HipcubDebug(error = hipSetDevice(entrypoint_device)))
+                return error;
         }
 
         return error;
     }
-
 
     /**
      * \brief Frees a live allocation of device memory on the current device, returning it to the allocator.
@@ -597,51 +651,60 @@ struct CachingDeviceAllocator
      * with which it was associated with during allocation, and it becomes available for reuse within other
      * streams when all prior work submitted to \p active_stream has completed.
      */
-    hipError_t DeviceFree(
-        void*           d_ptr)
+    hipError_t DeviceFree(void* d_ptr)
     {
         return DeviceFree(INVALID_DEVICE_ORDINAL, d_ptr);
     }
-
 
     /**
      * \brief Frees all cached device allocations on all devices
      */
     hipError_t FreeAllCached()
     {
-        hipError_t error          = hipSuccess;
-        int entrypoint_device     = INVALID_DEVICE_ORDINAL;
-        int current_device        = INVALID_DEVICE_ORDINAL;
+        hipError_t error             = hipSuccess;
+        int        entrypoint_device = INVALID_DEVICE_ORDINAL;
+        int        current_device    = INVALID_DEVICE_ORDINAL;
 
         mutex.lock();
 
-        while (!cached_blocks.empty())
+        while(!cached_blocks.empty())
         {
             // Get first block
             CachedBlocks::iterator begin = cached_blocks.begin();
 
             // Get entry-point device ordinal if necessary
-            if (entrypoint_device == INVALID_DEVICE_ORDINAL)
+            if(entrypoint_device == INVALID_DEVICE_ORDINAL)
             {
-                if (HipcubDebug(error = hipGetDevice(&entrypoint_device))) break;
+                if(HipcubDebug(error = hipGetDevice(&entrypoint_device)))
+                    break;
             }
 
             // Set current device ordinal if necessary
-            if (begin->device != current_device)
+            if(begin->device != current_device)
             {
-                if (HipcubDebug(error = hipSetDevice(begin->device))) break;
+                if(HipcubDebug(error = hipSetDevice(begin->device)))
+                    break;
                 current_device = begin->device;
             }
 
             // Free device memory
-            if (HipcubDebug(error = hipFree(begin->d_ptr))) break;
-            if (HipcubDebug(error = hipEventDestroy(begin->ready_event))) break;
+            if(HipcubDebug(error = hipFree(begin->d_ptr)))
+                break;
+            if(HipcubDebug(error = hipEventDestroy(begin->ready_event)))
+                break;
 
             // Reduce balance and erase entry
             cached_bytes[current_device].free -= begin->bytes;
 
-            if (debug) _HipcubLog("\tDevice %d freed %lld bytes.\n\t\t  %lld available blocks cached (%lld bytes), %lld live blocks (%lld bytes) outstanding.\n",
-                current_device, (long long) begin->bytes, (long long) cached_blocks.size(), (long long) cached_bytes[current_device].free, (long long) live_blocks.size(), (long long) cached_bytes[current_device].live);
+            if(debug)
+                _HipcubLog("\tDevice %d freed %lld bytes.\n\t\t  %lld available blocks cached "
+                           "(%lld bytes), %lld live blocks (%lld bytes) outstanding.\n",
+                           current_device,
+                           (long long)begin->bytes,
+                           (long long)cached_blocks.size(),
+                           (long long)cached_bytes[current_device].free,
+                           (long long)live_blocks.size(),
+                           (long long)cached_bytes[current_device].live);
 
             cached_blocks.erase(begin);
         }
@@ -649,24 +712,23 @@ struct CachingDeviceAllocator
         mutex.unlock();
 
         // Attempt to revert back to entry-point device if necessary
-        if (entrypoint_device != INVALID_DEVICE_ORDINAL)
+        if(entrypoint_device != INVALID_DEVICE_ORDINAL)
         {
-            if (HipcubDebug(error = hipSetDevice(entrypoint_device))) return error;
+            if(HipcubDebug(error = hipSetDevice(entrypoint_device)))
+                return error;
         }
 
         return error;
     }
-
 
     /**
      * \brief Destructor
      */
     virtual ~CachingDeviceAllocator()
     {
-        if (!skip_cleanup)
+        if(!skip_cleanup)
             FreeAllCached();
     }
-
 };
 
 END_HIPCUB_NAMESPACE

--- a/hipcub/include/hipcub/rocprim/util_type.hpp
+++ b/hipcub/include/hipcub/rocprim/util_type.hpp
@@ -38,31 +38,31 @@ BEGIN_HIPCUB_NAMESPACE
 
 using NullType = ::rocprim::empty_type;
 
-template<bool B, typename T, typename F>
+template <bool B, typename T, typename F>
 struct If
 {
     using Type = typename std::conditional<B, T, F>::type;
 };
 
-template<typename T>
+template <typename T>
 struct IsPointer
 {
     static constexpr bool VALUE = std::is_pointer<T>::value;
 };
 
-template<typename T>
+template <typename T>
 struct IsVolatile
 {
     static constexpr bool VALUE = std::is_volatile<T>::value;
 };
 
-template<typename T>
+template <typename T>
 struct RemoveQualifiers
 {
     using Type = typename std::remove_cv<T>::type;
 };
 
-template<int N>
+template <int N>
 struct PowerOfTwo
 {
     static constexpr bool VALUE = ::rocprim::detail::is_power_of_two<N>();
@@ -71,88 +71,79 @@ struct PowerOfTwo
 namespace detail
 {
 
-template<int N, int CURRENT_VAL = N, int COUNT = 0>
-struct Log2Impl
-{
-    static constexpr int VALUE = Log2Impl<N, (CURRENT_VAL >> 1), COUNT + 1>::VALUE;
-};
+    template <int N, int CURRENT_VAL = N, int COUNT = 0>
+    struct Log2Impl
+    {
+        static constexpr int VALUE = Log2Impl<N, (CURRENT_VAL >> 1), COUNT + 1>::VALUE;
+    };
 
-template<int N, int COUNT>
-struct Log2Impl<N, 0, COUNT>
-{
-    static constexpr int VALUE = (1 << (COUNT - 1) < N) ? COUNT : COUNT - 1;
-};
+    template <int N, int COUNT>
+    struct Log2Impl<N, 0, COUNT>
+    {
+        static constexpr int VALUE = (1 << (COUNT - 1) < N) ? COUNT : COUNT - 1;
+    };
 
 } // end of detail namespace
 
-template<int N>
+template <int N>
 struct Log2
 {
     static_assert(N != 0, "The logarithm of zero is undefined");
     static constexpr int VALUE = detail::Log2Impl<N>::VALUE;
 };
 
-template<typename T>
+template <typename T>
 struct DoubleBuffer
 {
-    T * d_buffers[2];
+    T* d_buffers[2];
 
     int selector;
 
-    HIPCUB_HOST_DEVICE inline
-    DoubleBuffer()
+    HIPCUB_HOST_DEVICE inline DoubleBuffer()
     {
-        selector = 0;
+        selector     = 0;
         d_buffers[0] = nullptr;
         d_buffers[1] = nullptr;
     }
 
-    HIPCUB_HOST_DEVICE inline
-    DoubleBuffer(T * d_current, T * d_alternate)
+    HIPCUB_HOST_DEVICE inline DoubleBuffer(T* d_current, T* d_alternate)
     {
-        selector = 0;
+        selector     = 0;
         d_buffers[0] = d_current;
         d_buffers[1] = d_alternate;
     }
 
-    HIPCUB_HOST_DEVICE inline
-    T * Current()
+    HIPCUB_HOST_DEVICE inline T* Current()
     {
         return d_buffers[selector];
     }
 
-    HIPCUB_HOST_DEVICE inline
-    T * Alternate()
+    HIPCUB_HOST_DEVICE inline T* Alternate()
     {
         return d_buffers[selector ^ 1];
     }
 };
 
-template<
-    class Key,
-    class Value
->
+template <class Key, class Value>
 using KeyValuePair = ::rocprim::key_value_pair<Key, Value>;
 
 namespace detail
 {
 
-template<typename T>
-inline
-::rocprim::double_buffer<T> to_double_buffer(DoubleBuffer<T>& source)
-{
-    return ::rocprim::double_buffer<T>(source.Current(), source.Alternate());
-}
-
-template<typename T>
-inline
-void update_double_buffer(DoubleBuffer<T>& target, ::rocprim::double_buffer<T>& source)
-{
-    if(target.Current() != source.current())
+    template <typename T>
+    inline ::rocprim::double_buffer<T> to_double_buffer(DoubleBuffer<T>& source)
     {
-        target.selector ^= 1;
+        return ::rocprim::double_buffer<T>(source.Current(), source.Alternate());
     }
-}
+
+    template <typename T>
+    inline void update_double_buffer(DoubleBuffer<T>& target, ::rocprim::double_buffer<T>& source)
+    {
+        if(target.Current() != source.current())
+        {
+            target.selector ^= 1;
+        }
+    }
 
 }
 

--- a/hipcub/include/hipcub/rocprim/warp/warp_reduce.hpp
+++ b/hipcub/include/hipcub/rocprim/warp/warp_reduce.hpp
@@ -32,93 +32,78 @@
 
 #include "../../config.hpp"
 
-#include "../util_ptx.hpp"
 #include "../thread/thread_operators.hpp"
+#include "../util_ptx.hpp"
 
 BEGIN_HIPCUB_NAMESPACE
 
-template<
-    typename T,
-    int LOGICAL_WARP_THREADS = HIPCUB_WARP_THREADS,
-    int ARCH = HIPCUB_ARCH>
+template <typename T, int LOGICAL_WARP_THREADS = HIPCUB_WARP_THREADS, int ARCH = HIPCUB_ARCH>
 class WarpReduce : private ::rocprim::warp_reduce<T, LOGICAL_WARP_THREADS>
 {
     static_assert(LOGICAL_WARP_THREADS > 0, "LOGICAL_WARP_THREADS must be greater than 0");
     using base_type = typename ::rocprim::warp_reduce<T, LOGICAL_WARP_THREADS>;
 
-    typename base_type::storage_type &temp_storage_;
+    typename base_type::storage_type& temp_storage_;
 
 public:
     using TempStorage = typename base_type::storage_type;
 
-    HIPCUB_DEVICE inline
-    WarpReduce(TempStorage& temp_storage) : temp_storage_(temp_storage)
+    HIPCUB_DEVICE inline WarpReduce(TempStorage& temp_storage)
+        : temp_storage_(temp_storage)
     {
     }
 
-    HIPCUB_DEVICE inline
-    T Sum(T input)
+    HIPCUB_DEVICE inline T Sum(T input)
     {
         base_type::reduce(input, input, temp_storage_);
         return input;
     }
 
-    HIPCUB_DEVICE inline
-    T Sum(T input, int valid_items)
+    HIPCUB_DEVICE inline T Sum(T input, int valid_items)
     {
         base_type::reduce(input, input, valid_items, temp_storage_);
         return input;
     }
 
-    template<typename FlagT>
-    HIPCUB_DEVICE inline
-    T HeadSegmentedSum(T input, FlagT head_flag)
+    template <typename FlagT>
+    HIPCUB_DEVICE inline T HeadSegmentedSum(T input, FlagT head_flag)
     {
         base_type::head_segmented_reduce(input, input, head_flag, temp_storage_);
         return input;
     }
 
-    template<typename FlagT>
-    HIPCUB_DEVICE inline
-    T TailSegmentedSum(T input, FlagT tail_flag)
+    template <typename FlagT>
+    HIPCUB_DEVICE inline T TailSegmentedSum(T input, FlagT tail_flag)
     {
         base_type::tail_segmented_reduce(input, input, tail_flag, temp_storage_);
         return input;
     }
 
-    template<typename ReduceOp>
-    HIPCUB_DEVICE inline
-    T Reduce(T input, ReduceOp reduce_op)
+    template <typename ReduceOp>
+    HIPCUB_DEVICE inline T Reduce(T input, ReduceOp reduce_op)
     {
         base_type::reduce(input, input, temp_storage_, reduce_op);
         return input;
     }
 
-    template<typename ReduceOp>
-    HIPCUB_DEVICE inline
-    T Reduce(T input, ReduceOp reduce_op, int valid_items)
+    template <typename ReduceOp>
+    HIPCUB_DEVICE inline T Reduce(T input, ReduceOp reduce_op, int valid_items)
     {
         base_type::reduce(input, input, valid_items, temp_storage_, reduce_op);
         return input;
     }
 
-    template<typename ReduceOp, typename FlagT>
-    HIPCUB_DEVICE inline
-    T HeadSegmentedReduce(T input, FlagT head_flag, ReduceOp reduce_op)
+    template <typename ReduceOp, typename FlagT>
+    HIPCUB_DEVICE inline T HeadSegmentedReduce(T input, FlagT head_flag, ReduceOp reduce_op)
     {
-        base_type::head_segmented_reduce(
-            input, input, head_flag, temp_storage_, reduce_op
-        );
+        base_type::head_segmented_reduce(input, input, head_flag, temp_storage_, reduce_op);
         return input;
     }
 
-    template<typename ReduceOp, typename FlagT>
-    HIPCUB_DEVICE inline
-    T TailSegmentedReduce(T input, FlagT tail_flag, ReduceOp reduce_op)
+    template <typename ReduceOp, typename FlagT>
+    HIPCUB_DEVICE inline T TailSegmentedReduce(T input, FlagT tail_flag, ReduceOp reduce_op)
     {
-        base_type::tail_segmented_reduce(
-            input, input, tail_flag, temp_storage_, reduce_op
-        );
+        base_type::tail_segmented_reduce(input, input, tail_flag, temp_storage_, reduce_op);
         return input;
     }
 };

--- a/hipcub/include/hipcub/rocprim/warp/warp_scan.hpp
+++ b/hipcub/include/hipcub/rocprim/warp/warp_scan.hpp
@@ -32,125 +32,104 @@
 
 #include "../../config.hpp"
 
-#include "../util_ptx.hpp"
 #include "../thread/thread_operators.hpp"
+#include "../util_ptx.hpp"
 
 BEGIN_HIPCUB_NAMESPACE
 
-template<
-    typename T,
-    int LOGICAL_WARP_THREADS = HIPCUB_WARP_THREADS,
-    int ARCH = HIPCUB_ARCH>
+template <typename T, int LOGICAL_WARP_THREADS = HIPCUB_WARP_THREADS, int ARCH = HIPCUB_ARCH>
 class WarpScan : private ::rocprim::warp_scan<T, LOGICAL_WARP_THREADS>
 {
     static_assert(LOGICAL_WARP_THREADS > 0, "LOGICAL_WARP_THREADS must be greater than 0");
     using base_type = typename ::rocprim::warp_scan<T, LOGICAL_WARP_THREADS>;
 
-    typename base_type::storage_type &temp_storage_;
+    typename base_type::storage_type& temp_storage_;
 
 public:
     using TempStorage = typename base_type::storage_type;
 
-    HIPCUB_DEVICE inline
-    WarpScan(TempStorage& temp_storage) : temp_storage_(temp_storage)
+    HIPCUB_DEVICE inline WarpScan(TempStorage& temp_storage)
+        : temp_storage_(temp_storage)
     {
     }
 
-    HIPCUB_DEVICE inline
-    void InclusiveSum(T input, T& inclusive_output)
+    HIPCUB_DEVICE inline void InclusiveSum(T input, T& inclusive_output)
     {
         base_type::inclusive_scan(input, inclusive_output, temp_storage_);
     }
 
-    HIPCUB_DEVICE inline
-    void InclusiveSum(T input, T& inclusive_output, T& warp_aggregate)
+    HIPCUB_DEVICE inline void InclusiveSum(T input, T& inclusive_output, T& warp_aggregate)
     {
         base_type::inclusive_scan(input, inclusive_output, warp_aggregate, temp_storage_);
     }
 
-    HIPCUB_DEVICE inline
-    void ExclusiveSum(T input, T& exclusive_output)
+    HIPCUB_DEVICE inline void ExclusiveSum(T input, T& exclusive_output)
     {
         base_type::exclusive_scan(input, exclusive_output, T(0), temp_storage_);
     }
 
-    HIPCUB_DEVICE inline
-    void ExclusiveSum(T input, T& exclusive_output, T& warp_aggregate)
+    HIPCUB_DEVICE inline void ExclusiveSum(T input, T& exclusive_output, T& warp_aggregate)
     {
         base_type::exclusive_scan(input, exclusive_output, T(0), warp_aggregate, temp_storage_);
     }
 
-    template<typename ScanOp>
-    HIPCUB_DEVICE inline
-    void InclusiveScan(T input, T& inclusive_output, ScanOp scan_op)
+    template <typename ScanOp>
+    HIPCUB_DEVICE inline void InclusiveScan(T input, T& inclusive_output, ScanOp scan_op)
     {
         base_type::inclusive_scan(input, inclusive_output, temp_storage_, scan_op);
     }
 
-    template<typename ScanOp>
-    HIPCUB_DEVICE inline
-    void InclusiveScan(T input, T& inclusive_output, ScanOp scan_op, T& warp_aggregate)
+    template <typename ScanOp>
+    HIPCUB_DEVICE inline void
+        InclusiveScan(T input, T& inclusive_output, ScanOp scan_op, T& warp_aggregate)
     {
-        base_type::inclusive_scan(
-            input, inclusive_output, warp_aggregate,
-            temp_storage_, scan_op
-        );
+        base_type::inclusive_scan(input, inclusive_output, warp_aggregate, temp_storage_, scan_op);
     }
 
-    template<typename ScanOp>
-    HIPCUB_DEVICE inline
-    void ExclusiveScan(T input, T& exclusive_output, ScanOp scan_op)
+    template <typename ScanOp>
+    HIPCUB_DEVICE inline void ExclusiveScan(T input, T& exclusive_output, ScanOp scan_op)
     {
         base_type::inclusive_scan(input, exclusive_output, temp_storage_, scan_op);
         base_type::to_exclusive(exclusive_output, exclusive_output, temp_storage_);
     }
 
-    template<typename ScanOp>
-    HIPCUB_DEVICE inline
-    void ExclusiveScan(T input, T& exclusive_output, T initial_value, ScanOp scan_op)
+    template <typename ScanOp>
+    HIPCUB_DEVICE inline void
+        ExclusiveScan(T input, T& exclusive_output, T initial_value, ScanOp scan_op)
     {
-        base_type::exclusive_scan(
-            input, exclusive_output, initial_value,
-            temp_storage_, scan_op
-        );
+        base_type::exclusive_scan(input, exclusive_output, initial_value, temp_storage_, scan_op);
     }
 
-    template<typename ScanOp>
-    HIPCUB_DEVICE inline
-    void ExclusiveScan(T input, T& exclusive_output, ScanOp scan_op, T& warp_aggregate)
+    template <typename ScanOp>
+    HIPCUB_DEVICE inline void
+        ExclusiveScan(T input, T& exclusive_output, ScanOp scan_op, T& warp_aggregate)
     {
-        base_type::inclusive_scan(
-            input, exclusive_output, warp_aggregate, temp_storage_, scan_op
-        );
+        base_type::inclusive_scan(input, exclusive_output, warp_aggregate, temp_storage_, scan_op);
         base_type::to_exclusive(exclusive_output, exclusive_output, temp_storage_);
     }
 
-    template<typename ScanOp>
-    HIPCUB_DEVICE inline
-    void ExclusiveScan(T input, T& exclusive_output, T initial_value, ScanOp scan_op, T& warp_aggregate)
+    template <typename ScanOp>
+    HIPCUB_DEVICE inline void ExclusiveScan(
+        T input, T& exclusive_output, T initial_value, ScanOp scan_op, T& warp_aggregate)
     {
         base_type::exclusive_scan(
-            input, exclusive_output, initial_value, warp_aggregate,
-            temp_storage_, scan_op
-        );
+            input, exclusive_output, initial_value, warp_aggregate, temp_storage_, scan_op);
     }
 
-    template<typename ScanOp>
-    HIPCUB_DEVICE inline
-    void Scan(T input, T& inclusive_output, T& exclusive_output, ScanOp scan_op)
+    template <typename ScanOp>
+    HIPCUB_DEVICE inline void
+        Scan(T input, T& inclusive_output, T& exclusive_output, ScanOp scan_op)
     {
         base_type::inclusive_scan(input, inclusive_output, temp_storage_, scan_op);
         base_type::to_exclusive(inclusive_output, exclusive_output, temp_storage_);
     }
 
-    template<typename ScanOp>
-    HIPCUB_DEVICE inline
-    void Scan(T input, T& inclusive_output, T& exclusive_output, T initial_value, ScanOp scan_op)
+    template <typename ScanOp>
+    HIPCUB_DEVICE inline void
+        Scan(T input, T& inclusive_output, T& exclusive_output, T initial_value, ScanOp scan_op)
     {
         base_type::scan(
-            input, inclusive_output, exclusive_output, initial_value,
-            temp_storage_, scan_op
-        );
+            input, inclusive_output, exclusive_output, initial_value, temp_storage_, scan_op);
         // In CUB documentation it's unclear if inclusive_output should include initial_value,
         // however,the implementation includes initial_value in inclusive_output in WarpScan::Scan().
         // In rocPRIM it's not included, and this is a fix to match CUB implementation.
@@ -158,8 +137,7 @@ public:
         inclusive_output = scan_op(initial_value, inclusive_output);
     }
 
-    HIPCUB_DEVICE inline
-    T Broadcast(T input, unsigned int src_lane)
+    HIPCUB_DEVICE inline T Broadcast(T input, unsigned int src_lane)
     {
         return base_type::broadcast(input, src_lane, temp_storage_);
     }

--- a/test/extra/test_hipcub_package.cpp
+++ b/test/extra/test_hipcub_package.cpp
@@ -18,42 +18,37 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#include <algorithm>
 #include <iostream>
 #include <vector>
-#include <algorithm>
 
 #include <hip/hip_runtime.h>
 #include <hipcub/hipcub.hpp>
 
-#define HIP_CHECK(error)         \
-  {                                  \
-    if(error != hipSuccess){         \
-        std::cout << error << std::endl; \
-        exit(error); \
-    } \
-  }
+#define HIP_CHECK(error)                     \
+    {                                        \
+        if(error != hipSuccess)              \
+        {                                    \
+            std::cout << error << std::endl; \
+            exit(error);                     \
+        }                                    \
+    }
 
 int main(int, char**)
 {
     using T = unsigned int;
 
     // host input/output
-    const size_t size = 1024 * 256;
+    const size_t   size = 1024 * 256;
     std::vector<T> input(size, 1);
-    T output = 0;
+    T              output = 0;
 
     // device input/output
-    T * d_input;
-    T * d_output;
+    T* d_input;
+    T* d_output;
     HIP_CHECK(hipMalloc(&d_input, input.size() * sizeof(T)));
     HIP_CHECK(hipMalloc(&d_output, sizeof(T)));
-    HIP_CHECK(
-        hipMemcpy(
-            d_input, input.data(),
-            input.size() * sizeof(T),
-            hipMemcpyHostToDevice
-        )
-    );
+    HIP_CHECK(hipMemcpy(d_input, input.data(), input.size() * sizeof(T), hipMemcpyHostToDevice));
     HIP_CHECK(hipDeviceSynchronize());
 
     // Calculate expected results on host
@@ -61,44 +56,28 @@ int main(int, char**)
 
     // Temporary storage
     size_t temp_storage_size_bytes;
-    void * d_temp_storage = nullptr;
+    void*  d_temp_storage = nullptr;
     // Get size of d_temp_storage
-    HIP_CHECK(
-        hipcub::DeviceReduce::Sum(
-            d_temp_storage, temp_storage_size_bytes,
-            d_input, d_output, input.size()
-        )
-    );
+    HIP_CHECK(hipcub::DeviceReduce::Sum(
+        d_temp_storage, temp_storage_size_bytes, d_input, d_output, input.size()));
 
     // Allocate temporary storage
     HIP_CHECK(hipMalloc(&d_temp_storage, temp_storage_size_bytes));
     HIP_CHECK(hipDeviceSynchronize());
 
     // Run
-    HIP_CHECK(
-        hipcub::DeviceReduce::Sum(
-            d_temp_storage, temp_storage_size_bytes,
-            d_input, d_output, input.size()
-        )
-    );
+    HIP_CHECK(hipcub::DeviceReduce::Sum(
+        d_temp_storage, temp_storage_size_bytes, d_input, d_output, input.size()));
     HIP_CHECK(hipDeviceSynchronize());
 
     // Copy output to host
-    HIP_CHECK(
-        hipMemcpy(
-            &output, d_output,
-            sizeof(T),
-            hipMemcpyDeviceToHost
-        )
-    );
+    HIP_CHECK(hipMemcpy(&output, d_output, sizeof(T), hipMemcpyDeviceToHost));
     HIP_CHECK(hipDeviceSynchronize());
 
     if(output != expected)
     {
-        std::cout
-            << "Failure: output (" << output
-            << ") != expected (" << expected << ")"
-            << std::endl;
+        std::cout << "Failure: output (" << output << ") != expected (" << expected << ")"
+                  << std::endl;
         return 1;
     }
     return 0;

--- a/test/hipcub/detail/get_hipcub_version.cpp
+++ b/test/hipcub/detail/get_hipcub_version.cpp
@@ -22,8 +22,7 @@
 
 #include "get_hipcub_version.hpp"
 
-__global__
-void get_version_kernel(unsigned int * version)
+__global__ void get_version_kernel(unsigned int* version)
 {
     *version = HIPCUB_VERSION;
 }
@@ -32,25 +31,15 @@ unsigned int get_hipcub_version_on_device()
 {
     unsigned int version = 0;
 
-    unsigned int * d_version;
+    unsigned int* d_version;
     HIP_CHECK(hipMalloc(&d_version, sizeof(unsigned int)));
     HIP_CHECK(hipDeviceSynchronize());
 
-    hipLaunchKernelGGL(
-        get_version_kernel,
-        dim3(1), dim3(1), 0, 0,
-        d_version
-    );
+    hipLaunchKernelGGL(get_version_kernel, dim3(1), dim3(1), 0, 0, d_version);
     HIP_CHECK(hipPeekAtLastError());
     HIP_CHECK(hipDeviceSynchronize());
 
-    HIP_CHECK(
-        hipMemcpy(
-            &version, d_version,
-            sizeof(unsigned int),
-            hipMemcpyDeviceToHost
-        )
-    );
+    HIP_CHECK(hipMemcpy(&version, d_version, sizeof(unsigned int), hipMemcpyDeviceToHost));
     HIP_CHECK(hipDeviceSynchronize());
     HIP_CHECK(hipFree(d_version));
 

--- a/test/hipcub/detail/get_hipcub_version.hpp
+++ b/test/hipcub/detail/get_hipcub_version.hpp
@@ -23,20 +23,21 @@
 #ifndef HIPCUB_TEST_DETAIL_GET_HIPCUB_VERSION_HPP_
 #define HIPCUB_TEST_DETAIL_GET_HIPCUB_VERSION_HPP_
 
-#include <iostream>
 #include <cstdio>
+#include <iostream>
 
 // hipCUB API
 #include <hipcub/hipcub.hpp>
 
-#define HIP_CHECK(condition)         \
-{                                  \
-    hipError_t error = condition;    \
-    if(error != hipSuccess){         \
-        std::cout << "HIP error: " << error << " line: " << __LINE__ << std::endl; \
-        exit(error); \
-    } \
-}
+#define HIP_CHECK(condition)                                                           \
+    {                                                                                  \
+        hipError_t error = condition;                                                  \
+        if(error != hipSuccess)                                                        \
+        {                                                                              \
+            std::cout << "HIP error: " << error << " line: " << __LINE__ << std::endl; \
+            exit(error);                                                               \
+        }                                                                              \
+    }
 
 unsigned int get_hipcub_version_on_device();
 

--- a/test/hipcub/test_hipcub_block_histogram.cpp
+++ b/test/hipcub/test_hipcub_block_histogram.cpp
@@ -33,84 +33,80 @@
 #define HIP_CHECK(error) ASSERT_EQ(static_cast<hipError_t>(error), hipSuccess)
 
 // Params for tests
-template<
-    class T,
-    unsigned int BlockSize = 256U,
-    unsigned int ItemsPerThread = 1U,
-    unsigned int BinSize = BlockSize,
-    hipcub::BlockHistogramAlgorithm Algorithm = hipcub::BlockHistogramAlgorithm::BLOCK_HISTO_ATOMIC
->
+template <class T,
+          unsigned int                    BlockSize      = 256U,
+          unsigned int                    ItemsPerThread = 1U,
+          unsigned int                    BinSize        = BlockSize,
+          hipcub::BlockHistogramAlgorithm Algorithm
+          = hipcub::BlockHistogramAlgorithm::BLOCK_HISTO_ATOMIC>
 struct params
 {
-    using type = T;
-    static constexpr hipcub::BlockHistogramAlgorithm algorithm = Algorithm;
-    static constexpr unsigned int block_size = BlockSize;
-    static constexpr unsigned int items_per_thread = ItemsPerThread;
-    static constexpr unsigned int bin_size = BinSize;
+    using type                                                        = T;
+    static constexpr hipcub::BlockHistogramAlgorithm algorithm        = Algorithm;
+    static constexpr unsigned int                    block_size       = BlockSize;
+    static constexpr unsigned int                    items_per_thread = ItemsPerThread;
+    static constexpr unsigned int                    bin_size         = BinSize;
 };
 
-template<class Params>
+template <class Params>
 class HipcubBlockHistogramInputArrayTests : public ::testing::Test
 {
 public:
-    using type = typename Params::type;
-    static constexpr unsigned int block_size = Params::block_size;
-    static constexpr hipcub::BlockHistogramAlgorithm algorithm = Params::algorithm;
-    static constexpr unsigned int items_per_thread = Params::items_per_thread;
-    static constexpr unsigned int bin_size = Params::bin_size;
+    using type                                                        = typename Params::type;
+    static constexpr unsigned int                    block_size       = Params::block_size;
+    static constexpr hipcub::BlockHistogramAlgorithm algorithm        = Params::algorithm;
+    static constexpr unsigned int                    items_per_thread = Params::items_per_thread;
+    static constexpr unsigned int                    bin_size         = Params::bin_size;
 };
 
 typedef ::testing::Types<
     // -----------------------------------------------------------------------
     // hipcub::BlockHistogramAlgorithm::BLOCK_HISTO_ATOMIC
     // -----------------------------------------------------------------------
-    params<unsigned int, 6U,   32, 18U>,
-    params<unsigned int, 32,   2, 64>,
-    params<unsigned int, 256,  3, 512>,
-    params<unsigned int, 512,  4>,
+    params<unsigned int, 6U, 32, 18U>,
+    params<unsigned int, 32, 2, 64>,
+    params<unsigned int, 256, 3, 512>,
+    params<unsigned int, 512, 4>,
     params<unsigned int, 1024, 1>,
-    params<unsigned int, 37,   2>,
-    params<unsigned int, 65,   5>,
-    params<unsigned int, 162,  7>,
-    params<unsigned int, 255,  15>,
+    params<unsigned int, 37, 2>,
+    params<unsigned int, 65, 5>,
+    params<unsigned int, 162, 7>,
+    params<unsigned int, 255, 15>,
     // -----------------------------------------------------------------------
     // hipcub::BlockHistogramAlgorithm::BLOCK_HISTO_SORT
     // -----------------------------------------------------------------------
-    params<unsigned int, 6U,   32,  18U, hipcub::BlockHistogramAlgorithm::BLOCK_HISTO_SORT>,
-    params<unsigned int, 32,   2,   64, hipcub::BlockHistogramAlgorithm::BLOCK_HISTO_SORT>,
-    params<unsigned int, 256,  3,  512, hipcub::BlockHistogramAlgorithm::BLOCK_HISTO_SORT>,
-    params<unsigned int, 512,  4,  512, hipcub::BlockHistogramAlgorithm::BLOCK_HISTO_SORT>,
+    params<unsigned int, 6U, 32, 18U, hipcub::BlockHistogramAlgorithm::BLOCK_HISTO_SORT>,
+    params<unsigned int, 32, 2, 64, hipcub::BlockHistogramAlgorithm::BLOCK_HISTO_SORT>,
+    params<unsigned int, 256, 3, 512, hipcub::BlockHistogramAlgorithm::BLOCK_HISTO_SORT>,
+    params<unsigned int, 512, 4, 512, hipcub::BlockHistogramAlgorithm::BLOCK_HISTO_SORT>,
     params<unsigned int, 1024, 1, 1024, hipcub::BlockHistogramAlgorithm::BLOCK_HISTO_SORT>,
-    params<unsigned int, 37,   2,   37, hipcub::BlockHistogramAlgorithm::BLOCK_HISTO_SORT>,
-    params<unsigned int, 65,   5,   65, hipcub::BlockHistogramAlgorithm::BLOCK_HISTO_SORT>,
-    params<unsigned int, 162,  7,  162, hipcub::BlockHistogramAlgorithm::BLOCK_HISTO_SORT>,
-    params<unsigned int, 255,  15, 255, hipcub::BlockHistogramAlgorithm::BLOCK_HISTO_SORT>,
-    params<unsigned char, 6U,   32,  18U, hipcub::BlockHistogramAlgorithm::BLOCK_HISTO_SORT>,
-    params<unsigned char, 32,   2,   64, hipcub::BlockHistogramAlgorithm::BLOCK_HISTO_SORT>,
-    params<unsigned char, 256,  3,  512, hipcub::BlockHistogramAlgorithm::BLOCK_HISTO_SORT>,
-    params<unsigned char, 512,  4,  512, hipcub::BlockHistogramAlgorithm::BLOCK_HISTO_SORT>,
+    params<unsigned int, 37, 2, 37, hipcub::BlockHistogramAlgorithm::BLOCK_HISTO_SORT>,
+    params<unsigned int, 65, 5, 65, hipcub::BlockHistogramAlgorithm::BLOCK_HISTO_SORT>,
+    params<unsigned int, 162, 7, 162, hipcub::BlockHistogramAlgorithm::BLOCK_HISTO_SORT>,
+    params<unsigned int, 255, 15, 255, hipcub::BlockHistogramAlgorithm::BLOCK_HISTO_SORT>,
+    params<unsigned char, 6U, 32, 18U, hipcub::BlockHistogramAlgorithm::BLOCK_HISTO_SORT>,
+    params<unsigned char, 32, 2, 64, hipcub::BlockHistogramAlgorithm::BLOCK_HISTO_SORT>,
+    params<unsigned char, 256, 3, 512, hipcub::BlockHistogramAlgorithm::BLOCK_HISTO_SORT>,
+    params<unsigned char, 512, 4, 512, hipcub::BlockHistogramAlgorithm::BLOCK_HISTO_SORT>,
     params<unsigned char, 1024, 1, 1024, hipcub::BlockHistogramAlgorithm::BLOCK_HISTO_SORT>,
-    params<unsigned short, 6U,   32,  18U, hipcub::BlockHistogramAlgorithm::BLOCK_HISTO_SORT>,
-    params<unsigned short, 32,   2,   64, hipcub::BlockHistogramAlgorithm::BLOCK_HISTO_SORT>,
-    params<unsigned short, 256,  3,  512, hipcub::BlockHistogramAlgorithm::BLOCK_HISTO_SORT>,
-    params<unsigned short, 512,  4,  512, hipcub::BlockHistogramAlgorithm::BLOCK_HISTO_SORT>,
-    params<unsigned short, 1024, 1, 1024, hipcub::BlockHistogramAlgorithm::BLOCK_HISTO_SORT>
-> InputArrayTestParams;
+    params<unsigned short, 6U, 32, 18U, hipcub::BlockHistogramAlgorithm::BLOCK_HISTO_SORT>,
+    params<unsigned short, 32, 2, 64, hipcub::BlockHistogramAlgorithm::BLOCK_HISTO_SORT>,
+    params<unsigned short, 256, 3, 512, hipcub::BlockHistogramAlgorithm::BLOCK_HISTO_SORT>,
+    params<unsigned short, 512, 4, 512, hipcub::BlockHistogramAlgorithm::BLOCK_HISTO_SORT>,
+    params<unsigned short, 1024, 1, 1024, hipcub::BlockHistogramAlgorithm::BLOCK_HISTO_SORT>>
+    InputArrayTestParams;
 
 TYPED_TEST_CASE(HipcubBlockHistogramInputArrayTests, InputArrayTestParams);
 
-template<
-    unsigned int BlockSize,
-    unsigned int ItemsPerThread,
-    unsigned int BinSize,
-    hipcub::BlockHistogramAlgorithm Algorithm,
-    class T
->
-__global__
-void histogram_kernel(T* device_output, T* device_output_bin)
+template <unsigned int                    BlockSize,
+          unsigned int                    ItemsPerThread,
+          unsigned int                    BinSize,
+          hipcub::BlockHistogramAlgorithm Algorithm,
+          class T>
+__global__ void histogram_kernel(T* device_output, T* device_output_bin)
 {
     const unsigned int index = ((hipBlockIdx_x * BlockSize) + hipThreadIdx_x) * ItemsPerThread;
-    unsigned int global_offset = hipBlockIdx_x * BinSize;
+    unsigned int       global_offset = hipBlockIdx_x * BinSize;
     __shared__ T hist[BinSize];
     // load
     T in_out[ItemsPerThread];
@@ -124,8 +120,8 @@ void histogram_kernel(T* device_output, T* device_output_bin)
     bhistogram_t(temp_storage).Histogram(in_out, hist);
     __syncthreads();
 
-    #pragma unroll
-    for (unsigned int offset = 0; offset < BinSize; offset += BlockSize)
+#pragma unroll
+    for(unsigned int offset = 0; offset < BinSize; offset += BlockSize)
     {
         if(offset + hipThreadIdx_x < BinSize)
         {
@@ -137,11 +133,11 @@ void histogram_kernel(T* device_output, T* device_output_bin)
 
 TYPED_TEST(HipcubBlockHistogramInputArrayTests, Histogram)
 {
-    using T = typename TestFixture::type;
-    constexpr auto algorithm = TestFixture::algorithm;
-    constexpr size_t block_size = TestFixture::block_size;
+    using T                           = typename TestFixture::type;
+    constexpr auto   algorithm        = TestFixture::algorithm;
+    constexpr size_t block_size       = TestFixture::block_size;
     constexpr size_t items_per_thread = TestFixture::items_per_thread;
-    constexpr size_t bin = TestFixture::bin_size;
+    constexpr size_t bin              = TestFixture::bin_size;
 
     // Given block size not supported
     if(block_size > test_utils::get_max_block_size())
@@ -150,9 +146,9 @@ TYPED_TEST(HipcubBlockHistogramInputArrayTests, Histogram)
     }
 
     const size_t items_per_block = block_size * items_per_thread;
-    const size_t size = items_per_block * 37;
-    const size_t bin_sizes = bin * 37;
-    const size_t grid_size = size / items_per_block;
+    const size_t size            = items_per_block * 37;
+    const size_t bin_sizes       = bin * 37;
+    const size_t grid_size       = size / items_per_block;
     // Generate data
     std::vector<T> output = test_utils::get_random_data<T>(size, 0, T(bin - 1));
 
@@ -166,7 +162,7 @@ TYPED_TEST(HipcubBlockHistogramInputArrayTests, Histogram)
         for(size_t j = 0; j < items_per_block; j++)
         {
             auto bin_idx = i * bin;
-            auto idx = i * items_per_block + j;
+            auto idx     = i * items_per_block + j;
             expected_bin[bin_idx + static_cast<unsigned int>(output[idx])]++;
         }
     }
@@ -178,42 +174,32 @@ TYPED_TEST(HipcubBlockHistogramInputArrayTests, Histogram)
     HIP_CHECK(hipMalloc(&device_output_bin, output_bin.size() * sizeof(T)));
 
     HIP_CHECK(
-        hipMemcpy(
-            device_output, output.data(),
-            output.size() * sizeof(T),
-            hipMemcpyHostToDevice
-        )
-    );
+        hipMemcpy(device_output, output.data(), output.size() * sizeof(T), hipMemcpyHostToDevice));
 
-    HIP_CHECK(
-        hipMemcpy(
-            device_output_bin, output_bin.data(),
-            output_bin.size() * sizeof(T),
-            hipMemcpyHostToDevice
-        )
-    );
+    HIP_CHECK(hipMemcpy(device_output_bin,
+                        output_bin.data(),
+                        output_bin.size() * sizeof(T),
+                        hipMemcpyHostToDevice));
 
     // Running kernel
     hipLaunchKernelGGL(
         HIP_KERNEL_NAME(histogram_kernel<block_size, items_per_thread, bin, algorithm, T>),
-        dim3(grid_size), dim3(block_size), 0, 0,
-        device_output, device_output_bin
-    );
+        dim3(grid_size),
+        dim3(block_size),
+        0,
+        0,
+        device_output,
+        device_output_bin);
 
     // Reading results back
-    HIP_CHECK(
-        hipMemcpy(
-            output_bin.data(), device_output_bin,
-            output_bin.size() * sizeof(T),
-            hipMemcpyDeviceToHost
-        )
-    );
+    HIP_CHECK(hipMemcpy(output_bin.data(),
+                        device_output_bin,
+                        output_bin.size() * sizeof(T),
+                        hipMemcpyDeviceToHost));
 
     for(size_t i = 0; i < output_bin.size(); i++)
     {
-        ASSERT_EQ(
-            output_bin[i], expected_bin[i]
-        );
+        ASSERT_EQ(output_bin[i], expected_bin[i]);
     }
 
     HIP_CHECK(hipFree(device_output));

--- a/test/hipcub/test_hipcub_block_load_store.cpp
+++ b/test/hipcub/test_hipcub_block_load_store.cpp
@@ -21,8 +21,8 @@
 // SOFTWARE.
 
 #include <iostream>
-#include <vector>
 #include <type_traits>
+#include <vector>
 
 // Google Test
 #include <gtest/gtest.h>
@@ -33,154 +33,295 @@
 
 #define HIP_CHECK(error) ASSERT_EQ(error, hipSuccess)
 
-template<
-    class Type,
-    hipcub::BlockLoadAlgorithm Load,
-    hipcub::BlockStoreAlgorithm Store,
-    unsigned int BlockSize,
-    unsigned int ItemsPerThread
->
+template <class Type,
+          hipcub::BlockLoadAlgorithm  Load,
+          hipcub::BlockStoreAlgorithm Store,
+          unsigned int                BlockSize,
+          unsigned int                ItemsPerThread>
 struct class_params
 {
-    using type = Type;
-    static constexpr hipcub::BlockLoadAlgorithm load_method = Load;
-    static constexpr hipcub::BlockStoreAlgorithm store_method = Store;
-    static constexpr unsigned int block_size = BlockSize;
-    static constexpr unsigned int items_per_thread = ItemsPerThread;
+    using type                                                    = Type;
+    static constexpr hipcub::BlockLoadAlgorithm  load_method      = Load;
+    static constexpr hipcub::BlockStoreAlgorithm store_method     = Store;
+    static constexpr unsigned int                block_size       = BlockSize;
+    static constexpr unsigned int                items_per_thread = ItemsPerThread;
 };
 
-template<class ClassParams>
-class HipcubBlockLoadStoreClassTests : public ::testing::Test {
+template <class ClassParams>
+class HipcubBlockLoadStoreClassTests : public ::testing::Test
+{
 public:
     using params = ClassParams;
 };
 
 typedef ::testing::Types<
     // BLOCK_LOAD_DIRECT
-    class_params<int, hipcub::BlockLoadAlgorithm::BLOCK_LOAD_DIRECT,
-                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_DIRECT, 64U, 1>,
-    class_params<int, hipcub::BlockLoadAlgorithm::BLOCK_LOAD_DIRECT,
-                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_DIRECT, 64U, 4>,
-    class_params<int, hipcub::BlockLoadAlgorithm::BLOCK_LOAD_DIRECT,
-                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_DIRECT, 256U, 1>,
-    class_params<int, hipcub::BlockLoadAlgorithm::BLOCK_LOAD_DIRECT,
-                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_DIRECT, 256U, 4>,
-    class_params<int, hipcub::BlockLoadAlgorithm::BLOCK_LOAD_DIRECT,
-                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_DIRECT, 512U, 1>,
-    class_params<int, hipcub::BlockLoadAlgorithm::BLOCK_LOAD_DIRECT,
-                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_DIRECT, 512U, 4>,
+    class_params<int,
+                 hipcub::BlockLoadAlgorithm::BLOCK_LOAD_DIRECT,
+                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_DIRECT,
+                 64U,
+                 1>,
+    class_params<int,
+                 hipcub::BlockLoadAlgorithm::BLOCK_LOAD_DIRECT,
+                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_DIRECT,
+                 64U,
+                 4>,
+    class_params<int,
+                 hipcub::BlockLoadAlgorithm::BLOCK_LOAD_DIRECT,
+                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_DIRECT,
+                 256U,
+                 1>,
+    class_params<int,
+                 hipcub::BlockLoadAlgorithm::BLOCK_LOAD_DIRECT,
+                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_DIRECT,
+                 256U,
+                 4>,
+    class_params<int,
+                 hipcub::BlockLoadAlgorithm::BLOCK_LOAD_DIRECT,
+                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_DIRECT,
+                 512U,
+                 1>,
+    class_params<int,
+                 hipcub::BlockLoadAlgorithm::BLOCK_LOAD_DIRECT,
+                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_DIRECT,
+                 512U,
+                 4>,
 
-    class_params<double, hipcub::BlockLoadAlgorithm::BLOCK_LOAD_DIRECT,
-                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_DIRECT, 64U, 1>,
-    class_params<double, hipcub::BlockLoadAlgorithm::BLOCK_LOAD_DIRECT,
-                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_DIRECT, 64U, 4>,
-    class_params<double, hipcub::BlockLoadAlgorithm::BLOCK_LOAD_DIRECT,
-                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_DIRECT, 256U, 1>,
-    class_params<double, hipcub::BlockLoadAlgorithm::BLOCK_LOAD_DIRECT,
-                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_DIRECT, 256U, 4>,
-    class_params<double, hipcub::BlockLoadAlgorithm::BLOCK_LOAD_DIRECT,
-                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_DIRECT, 512U, 1>,
-    class_params<double, hipcub::BlockLoadAlgorithm::BLOCK_LOAD_DIRECT,
-                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_DIRECT, 512U, 4>,
+    class_params<double,
+                 hipcub::BlockLoadAlgorithm::BLOCK_LOAD_DIRECT,
+                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_DIRECT,
+                 64U,
+                 1>,
+    class_params<double,
+                 hipcub::BlockLoadAlgorithm::BLOCK_LOAD_DIRECT,
+                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_DIRECT,
+                 64U,
+                 4>,
+    class_params<double,
+                 hipcub::BlockLoadAlgorithm::BLOCK_LOAD_DIRECT,
+                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_DIRECT,
+                 256U,
+                 1>,
+    class_params<double,
+                 hipcub::BlockLoadAlgorithm::BLOCK_LOAD_DIRECT,
+                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_DIRECT,
+                 256U,
+                 4>,
+    class_params<double,
+                 hipcub::BlockLoadAlgorithm::BLOCK_LOAD_DIRECT,
+                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_DIRECT,
+                 512U,
+                 1>,
+    class_params<double,
+                 hipcub::BlockLoadAlgorithm::BLOCK_LOAD_DIRECT,
+                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_DIRECT,
+                 512U,
+                 4>,
 
-    class_params<test_utils::custom_test_type<int>, hipcub::BlockLoadAlgorithm::BLOCK_LOAD_DIRECT,
-                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_DIRECT, 64U, 1>,
-    class_params<test_utils::custom_test_type<int>, hipcub::BlockLoadAlgorithm::BLOCK_LOAD_DIRECT,
-                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_DIRECT, 64U, 4>,
-    class_params<test_utils::custom_test_type<double>, hipcub::BlockLoadAlgorithm::BLOCK_LOAD_DIRECT,
-                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_DIRECT, 256U, 1>,
-    class_params<test_utils::custom_test_type<double>, hipcub::BlockLoadAlgorithm::BLOCK_LOAD_DIRECT,
-                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_DIRECT, 256U, 4>,
+    class_params<test_utils::custom_test_type<int>,
+                 hipcub::BlockLoadAlgorithm::BLOCK_LOAD_DIRECT,
+                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_DIRECT,
+                 64U,
+                 1>,
+    class_params<test_utils::custom_test_type<int>,
+                 hipcub::BlockLoadAlgorithm::BLOCK_LOAD_DIRECT,
+                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_DIRECT,
+                 64U,
+                 4>,
+    class_params<test_utils::custom_test_type<double>,
+                 hipcub::BlockLoadAlgorithm::BLOCK_LOAD_DIRECT,
+                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_DIRECT,
+                 256U,
+                 1>,
+    class_params<test_utils::custom_test_type<double>,
+                 hipcub::BlockLoadAlgorithm::BLOCK_LOAD_DIRECT,
+                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_DIRECT,
+                 256U,
+                 4>,
 
     // BLOCK_LOAD_VECTORIZE
-    class_params<int, hipcub::BlockLoadAlgorithm::BLOCK_LOAD_VECTORIZE,
-                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_VECTORIZE, 64U, 1>,
-    class_params<int, hipcub::BlockLoadAlgorithm::BLOCK_LOAD_VECTORIZE,
-                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_VECTORIZE, 64U, 4>,
-    class_params<int, hipcub::BlockLoadAlgorithm::BLOCK_LOAD_VECTORIZE,
-                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_VECTORIZE, 256U, 1>,
-    class_params<int, hipcub::BlockLoadAlgorithm::BLOCK_LOAD_VECTORIZE,
-                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_VECTORIZE, 256U, 4>,
-    class_params<int, hipcub::BlockLoadAlgorithm::BLOCK_LOAD_VECTORIZE,
-                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_VECTORIZE, 512U, 1>,
-    class_params<int, hipcub::BlockLoadAlgorithm::BLOCK_LOAD_VECTORIZE,
-                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_VECTORIZE, 512U, 4>,
+    class_params<int,
+                 hipcub::BlockLoadAlgorithm::BLOCK_LOAD_VECTORIZE,
+                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_VECTORIZE,
+                 64U,
+                 1>,
+    class_params<int,
+                 hipcub::BlockLoadAlgorithm::BLOCK_LOAD_VECTORIZE,
+                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_VECTORIZE,
+                 64U,
+                 4>,
+    class_params<int,
+                 hipcub::BlockLoadAlgorithm::BLOCK_LOAD_VECTORIZE,
+                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_VECTORIZE,
+                 256U,
+                 1>,
+    class_params<int,
+                 hipcub::BlockLoadAlgorithm::BLOCK_LOAD_VECTORIZE,
+                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_VECTORIZE,
+                 256U,
+                 4>,
+    class_params<int,
+                 hipcub::BlockLoadAlgorithm::BLOCK_LOAD_VECTORIZE,
+                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_VECTORIZE,
+                 512U,
+                 1>,
+    class_params<int,
+                 hipcub::BlockLoadAlgorithm::BLOCK_LOAD_VECTORIZE,
+                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_VECTORIZE,
+                 512U,
+                 4>,
 
-    class_params<double, hipcub::BlockLoadAlgorithm::BLOCK_LOAD_VECTORIZE,
-                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_VECTORIZE, 64U, 1>,
-    class_params<double, hipcub::BlockLoadAlgorithm::BLOCK_LOAD_VECTORIZE,
-                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_VECTORIZE, 64U, 4>,
-    class_params<double, hipcub::BlockLoadAlgorithm::BLOCK_LOAD_VECTORIZE,
-                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_VECTORIZE, 256U, 1>,
-    class_params<double, hipcub::BlockLoadAlgorithm::BLOCK_LOAD_VECTORIZE,
-                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_VECTORIZE, 256U, 4>,
-    class_params<double, hipcub::BlockLoadAlgorithm::BLOCK_LOAD_VECTORIZE,
-                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_VECTORIZE, 512U, 1>,
-    class_params<double, hipcub::BlockLoadAlgorithm::BLOCK_LOAD_VECTORIZE,
-                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_VECTORIZE, 512U, 4>,
+    class_params<double,
+                 hipcub::BlockLoadAlgorithm::BLOCK_LOAD_VECTORIZE,
+                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_VECTORIZE,
+                 64U,
+                 1>,
+    class_params<double,
+                 hipcub::BlockLoadAlgorithm::BLOCK_LOAD_VECTORIZE,
+                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_VECTORIZE,
+                 64U,
+                 4>,
+    class_params<double,
+                 hipcub::BlockLoadAlgorithm::BLOCK_LOAD_VECTORIZE,
+                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_VECTORIZE,
+                 256U,
+                 1>,
+    class_params<double,
+                 hipcub::BlockLoadAlgorithm::BLOCK_LOAD_VECTORIZE,
+                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_VECTORIZE,
+                 256U,
+                 4>,
+    class_params<double,
+                 hipcub::BlockLoadAlgorithm::BLOCK_LOAD_VECTORIZE,
+                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_VECTORIZE,
+                 512U,
+                 1>,
+    class_params<double,
+                 hipcub::BlockLoadAlgorithm::BLOCK_LOAD_VECTORIZE,
+                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_VECTORIZE,
+                 512U,
+                 4>,
 
-    class_params<test_utils::custom_test_type<int>, hipcub::BlockLoadAlgorithm::BLOCK_LOAD_VECTORIZE,
-                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_VECTORIZE, 64U, 1>,
-    class_params<test_utils::custom_test_type<int>, hipcub::BlockLoadAlgorithm::BLOCK_LOAD_VECTORIZE,
-                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_VECTORIZE, 64U, 4>,
-    class_params<test_utils::custom_test_type<double>, hipcub::BlockLoadAlgorithm::BLOCK_LOAD_VECTORIZE,
-                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_VECTORIZE, 256U, 1>,
-    class_params<test_utils::custom_test_type<double>, hipcub::BlockLoadAlgorithm::BLOCK_LOAD_VECTORIZE,
-                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_VECTORIZE, 256U, 4>,
+    class_params<test_utils::custom_test_type<int>,
+                 hipcub::BlockLoadAlgorithm::BLOCK_LOAD_VECTORIZE,
+                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_VECTORIZE,
+                 64U,
+                 1>,
+    class_params<test_utils::custom_test_type<int>,
+                 hipcub::BlockLoadAlgorithm::BLOCK_LOAD_VECTORIZE,
+                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_VECTORIZE,
+                 64U,
+                 4>,
+    class_params<test_utils::custom_test_type<double>,
+                 hipcub::BlockLoadAlgorithm::BLOCK_LOAD_VECTORIZE,
+                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_VECTORIZE,
+                 256U,
+                 1>,
+    class_params<test_utils::custom_test_type<double>,
+                 hipcub::BlockLoadAlgorithm::BLOCK_LOAD_VECTORIZE,
+                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_VECTORIZE,
+                 256U,
+                 4>,
 
     // BLOCK_LOAD_TRANSPOSE
-    class_params<int, hipcub::BlockLoadAlgorithm::BLOCK_LOAD_TRANSPOSE,
-                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_TRANSPOSE, 64U, 1>,
-    class_params<int, hipcub::BlockLoadAlgorithm::BLOCK_LOAD_TRANSPOSE,
-                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_TRANSPOSE, 64U, 4>,
-    class_params<int, hipcub::BlockLoadAlgorithm::BLOCK_LOAD_TRANSPOSE,
-                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_TRANSPOSE, 256U, 1>,
-    class_params<int, hipcub::BlockLoadAlgorithm::BLOCK_LOAD_TRANSPOSE,
-                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_TRANSPOSE, 256U, 4>,
-    class_params<int, hipcub::BlockLoadAlgorithm::BLOCK_LOAD_TRANSPOSE,
-                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_TRANSPOSE, 512U, 1>,
-    class_params<int, hipcub::BlockLoadAlgorithm::BLOCK_LOAD_TRANSPOSE,
-                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_TRANSPOSE, 512U, 4>,
+    class_params<int,
+                 hipcub::BlockLoadAlgorithm::BLOCK_LOAD_TRANSPOSE,
+                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_TRANSPOSE,
+                 64U,
+                 1>,
+    class_params<int,
+                 hipcub::BlockLoadAlgorithm::BLOCK_LOAD_TRANSPOSE,
+                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_TRANSPOSE,
+                 64U,
+                 4>,
+    class_params<int,
+                 hipcub::BlockLoadAlgorithm::BLOCK_LOAD_TRANSPOSE,
+                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_TRANSPOSE,
+                 256U,
+                 1>,
+    class_params<int,
+                 hipcub::BlockLoadAlgorithm::BLOCK_LOAD_TRANSPOSE,
+                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_TRANSPOSE,
+                 256U,
+                 4>,
+    class_params<int,
+                 hipcub::BlockLoadAlgorithm::BLOCK_LOAD_TRANSPOSE,
+                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_TRANSPOSE,
+                 512U,
+                 1>,
+    class_params<int,
+                 hipcub::BlockLoadAlgorithm::BLOCK_LOAD_TRANSPOSE,
+                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_TRANSPOSE,
+                 512U,
+                 4>,
 
-    class_params<double, hipcub::BlockLoadAlgorithm::BLOCK_LOAD_TRANSPOSE,
-                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_TRANSPOSE, 64U, 1>,
-    class_params<double, hipcub::BlockLoadAlgorithm::BLOCK_LOAD_TRANSPOSE,
-                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_TRANSPOSE, 64U, 4>,
-    class_params<double, hipcub::BlockLoadAlgorithm::BLOCK_LOAD_TRANSPOSE,
-                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_TRANSPOSE, 256U, 1>,
-    class_params<double, hipcub::BlockLoadAlgorithm::BLOCK_LOAD_TRANSPOSE,
-                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_TRANSPOSE, 256U, 4>,
-    class_params<double, hipcub::BlockLoadAlgorithm::BLOCK_LOAD_TRANSPOSE,
-                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_TRANSPOSE, 512U, 1>,
-    class_params<double, hipcub::BlockLoadAlgorithm::BLOCK_LOAD_TRANSPOSE,
-                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_TRANSPOSE, 512U, 4>,
+    class_params<double,
+                 hipcub::BlockLoadAlgorithm::BLOCK_LOAD_TRANSPOSE,
+                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_TRANSPOSE,
+                 64U,
+                 1>,
+    class_params<double,
+                 hipcub::BlockLoadAlgorithm::BLOCK_LOAD_TRANSPOSE,
+                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_TRANSPOSE,
+                 64U,
+                 4>,
+    class_params<double,
+                 hipcub::BlockLoadAlgorithm::BLOCK_LOAD_TRANSPOSE,
+                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_TRANSPOSE,
+                 256U,
+                 1>,
+    class_params<double,
+                 hipcub::BlockLoadAlgorithm::BLOCK_LOAD_TRANSPOSE,
+                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_TRANSPOSE,
+                 256U,
+                 4>,
+    class_params<double,
+                 hipcub::BlockLoadAlgorithm::BLOCK_LOAD_TRANSPOSE,
+                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_TRANSPOSE,
+                 512U,
+                 1>,
+    class_params<double,
+                 hipcub::BlockLoadAlgorithm::BLOCK_LOAD_TRANSPOSE,
+                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_TRANSPOSE,
+                 512U,
+                 4>,
 
-    class_params<test_utils::custom_test_type<int>, hipcub::BlockLoadAlgorithm::BLOCK_LOAD_TRANSPOSE,
-                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_TRANSPOSE, 64U, 1>,
-    class_params<test_utils::custom_test_type<int>, hipcub::BlockLoadAlgorithm::BLOCK_LOAD_TRANSPOSE,
-                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_TRANSPOSE, 64U, 4>,
-    class_params<test_utils::custom_test_type<double>, hipcub::BlockLoadAlgorithm::BLOCK_LOAD_TRANSPOSE,
-                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_TRANSPOSE, 256U, 1>,
-    class_params<test_utils::custom_test_type<double>, hipcub::BlockLoadAlgorithm::BLOCK_LOAD_TRANSPOSE,
-                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_TRANSPOSE, 256U, 4>
+    class_params<test_utils::custom_test_type<int>,
+                 hipcub::BlockLoadAlgorithm::BLOCK_LOAD_TRANSPOSE,
+                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_TRANSPOSE,
+                 64U,
+                 1>,
+    class_params<test_utils::custom_test_type<int>,
+                 hipcub::BlockLoadAlgorithm::BLOCK_LOAD_TRANSPOSE,
+                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_TRANSPOSE,
+                 64U,
+                 4>,
+    class_params<test_utils::custom_test_type<double>,
+                 hipcub::BlockLoadAlgorithm::BLOCK_LOAD_TRANSPOSE,
+                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_TRANSPOSE,
+                 256U,
+                 1>,
+    class_params<test_utils::custom_test_type<double>,
+                 hipcub::BlockLoadAlgorithm::BLOCK_LOAD_TRANSPOSE,
+                 hipcub::BlockStoreAlgorithm::BLOCK_STORE_TRANSPOSE,
+                 256U,
+                 4>
 
-> ClassParams;
+    >
+    ClassParams;
 
 TYPED_TEST_CASE(HipcubBlockLoadStoreClassTests, ClassParams);
 
-template<
-    class Type,
-    hipcub::BlockLoadAlgorithm LoadMethod,
-    hipcub::BlockStoreAlgorithm StoreMethod,
-    unsigned int BlockSize,
-    unsigned int ItemsPerThread
->
-__global__
-void load_store_kernel(Type* device_input, Type* device_output)
+template <class Type,
+          hipcub::BlockLoadAlgorithm  LoadMethod,
+          hipcub::BlockStoreAlgorithm StoreMethod,
+          unsigned int                BlockSize,
+          unsigned int                ItemsPerThread>
+__global__ void load_store_kernel(Type* device_input, Type* device_output)
 {
-    Type items[ItemsPerThread];
+    Type         items[ItemsPerThread];
     unsigned int offset = hipBlockIdx_x * BlockSize * ItemsPerThread;
-    hipcub::BlockLoad<Type, BlockSize, ItemsPerThread, LoadMethod> load;
+    hipcub::BlockLoad<Type, BlockSize, ItemsPerThread, LoadMethod>   load;
     hipcub::BlockStore<Type, BlockSize, ItemsPerThread, StoreMethod> store;
     load.Load(device_input + offset, items);
     store.Store(device_output + offset, items);
@@ -188,14 +329,14 @@ void load_store_kernel(Type* device_input, Type* device_output)
 
 TYPED_TEST(HipcubBlockLoadStoreClassTests, LoadStoreClass)
 {
-    using Type = typename TestFixture::params::type;
-    constexpr size_t block_size = TestFixture::params::block_size;
-    constexpr hipcub::BlockLoadAlgorithm load_method = TestFixture::params::load_method;
-    constexpr hipcub::BlockStoreAlgorithm store_method = TestFixture::params::store_method;
-    const size_t items_per_thread = TestFixture::params::items_per_thread;
-    constexpr auto items_per_block = block_size * items_per_thread;
-    const size_t size = items_per_block * 113;
-    const auto grid_size = size / items_per_block;
+    using Type                                             = typename TestFixture::params::type;
+    constexpr size_t                      block_size       = TestFixture::params::block_size;
+    constexpr hipcub::BlockLoadAlgorithm  load_method      = TestFixture::params::load_method;
+    constexpr hipcub::BlockStoreAlgorithm store_method     = TestFixture::params::store_method;
+    const size_t                          items_per_thread = TestFixture::params::items_per_thread;
+    constexpr auto                        items_per_block  = block_size * items_per_thread;
+    const size_t                          size             = items_per_block * 113;
+    const auto                            grid_size        = size / items_per_block;
     // Given block size not supported
     if(block_size > test_utils::get_max_block_size() || (block_size & (block_size - 1)) != 0)
     {
@@ -208,10 +349,10 @@ TYPED_TEST(HipcubBlockLoadStoreClassTests, LoadStoreClass)
 
     // Calculate expected results on host
     std::vector<Type> expected(input.size(), 0);
-    for (size_t i = 0; i < 113; i++)
+    for(size_t i = 0; i < 113; i++)
     {
         size_t block_offset = i * items_per_block;
-        for (size_t j = 0; j < items_per_block; j++)
+        for(size_t j = 0; j < items_per_block; j++)
         {
             expected[j + block_offset] = input[j + block_offset];
         }
@@ -219,38 +360,33 @@ TYPED_TEST(HipcubBlockLoadStoreClassTests, LoadStoreClass)
 
     // Preparing device
     Type* device_input;
-    HIP_CHECK(hipMalloc(&device_input, input.size() * sizeof(typename decltype(input)::value_type)));
-    Type* device_output;
-    HIP_CHECK(hipMalloc(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
-
     HIP_CHECK(
-        hipMemcpy(
-            device_input, input.data(),
-            input.size() * sizeof(typename decltype(input)::value_type),
-            hipMemcpyHostToDevice
-        )
-    );
+        hipMalloc(&device_input, input.size() * sizeof(typename decltype(input)::value_type)));
+    Type* device_output;
+    HIP_CHECK(
+        hipMalloc(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
+
+    HIP_CHECK(hipMemcpy(device_input,
+                        input.data(),
+                        input.size() * sizeof(typename decltype(input)::value_type),
+                        hipMemcpyHostToDevice));
 
     // Running kernel
     hipLaunchKernelGGL(
         HIP_KERNEL_NAME(
-            load_store_kernel<
-                Type, load_method, store_method,
-                block_size, items_per_thread
-            >
-        ),
-        dim3(grid_size), dim3(block_size), 0, 0,
-        device_input, device_output
-    );
+            load_store_kernel<Type, load_method, store_method, block_size, items_per_thread>),
+        dim3(grid_size),
+        dim3(block_size),
+        0,
+        0,
+        device_input,
+        device_output);
 
     // Reading results from device
-    HIP_CHECK(
-        hipMemcpy(
-            output.data(), device_output,
-            output.size() * sizeof(typename decltype(output)::value_type),
-            hipMemcpyDeviceToHost
-        )
-    );
+    HIP_CHECK(hipMemcpy(output.data(),
+                        device_output,
+                        output.size() * sizeof(typename decltype(output)::value_type),
+                        hipMemcpyDeviceToHost));
 
     // Validating results
     for(size_t i = 0; i < output.size(); i++)
@@ -262,19 +398,16 @@ TYPED_TEST(HipcubBlockLoadStoreClassTests, LoadStoreClass)
     HIP_CHECK(hipFree(device_output));
 }
 
-template<
-    class Type,
-    hipcub::BlockLoadAlgorithm LoadMethod,
-    hipcub::BlockStoreAlgorithm StoreMethod,
-    unsigned int BlockSize,
-    unsigned int ItemsPerThread
->
-__global__
-void load_store_valid_kernel(Type* device_input, Type* device_output, size_t valid)
+template <class Type,
+          hipcub::BlockLoadAlgorithm  LoadMethod,
+          hipcub::BlockStoreAlgorithm StoreMethod,
+          unsigned int                BlockSize,
+          unsigned int                ItemsPerThread>
+__global__ void load_store_valid_kernel(Type* device_input, Type* device_output, size_t valid)
 {
-    Type items[ItemsPerThread];
+    Type         items[ItemsPerThread];
     unsigned int offset = hipBlockIdx_x * BlockSize * ItemsPerThread;
-    hipcub::BlockLoad<Type, BlockSize, ItemsPerThread, LoadMethod> load;
+    hipcub::BlockLoad<Type, BlockSize, ItemsPerThread, LoadMethod>   load;
     hipcub::BlockStore<Type, BlockSize, ItemsPerThread, StoreMethod> store;
     load.Load(device_input + offset, items, valid);
     store.Store(device_output + offset, items, valid);
@@ -282,14 +415,14 @@ void load_store_valid_kernel(Type* device_input, Type* device_output, size_t val
 
 TYPED_TEST(HipcubBlockLoadStoreClassTests, LoadStoreClassValid)
 {
-    using Type = typename TestFixture::params::type;
-    constexpr size_t block_size = TestFixture::params::block_size;
-    constexpr hipcub::BlockLoadAlgorithm load_method = TestFixture::params::load_method;
-    constexpr hipcub::BlockStoreAlgorithm store_method = TestFixture::params::store_method;
-    const size_t items_per_thread = TestFixture::params::items_per_thread;
-    constexpr auto items_per_block = block_size * items_per_thread;
-    const size_t size = items_per_block * 113;
-    const auto grid_size = size / items_per_block;
+    using Type                                             = typename TestFixture::params::type;
+    constexpr size_t                      block_size       = TestFixture::params::block_size;
+    constexpr hipcub::BlockLoadAlgorithm  load_method      = TestFixture::params::load_method;
+    constexpr hipcub::BlockStoreAlgorithm store_method     = TestFixture::params::store_method;
+    const size_t                          items_per_thread = TestFixture::params::items_per_thread;
+    constexpr auto                        items_per_block  = block_size * items_per_thread;
+    const size_t                          size             = items_per_block * 113;
+    const auto                            grid_size        = size / items_per_block;
     // Given block size not supported
     if(block_size > test_utils::get_max_block_size() || (block_size & (block_size - 1)) != 0)
     {
@@ -303,12 +436,12 @@ TYPED_TEST(HipcubBlockLoadStoreClassTests, LoadStoreClassValid)
 
     // Calculate expected results on host
     std::vector<Type> expected(input.size(), 0);
-    for (size_t i = 0; i < 113; i++)
+    for(size_t i = 0; i < 113; i++)
     {
         size_t block_offset = i * items_per_block;
-        for (size_t j = 0; j < items_per_block; j++)
+        for(size_t j = 0; j < items_per_block; j++)
         {
-            if (j < valid)
+            if(j < valid)
             {
                 expected[j + block_offset] = input[j + block_offset];
             }
@@ -317,47 +450,40 @@ TYPED_TEST(HipcubBlockLoadStoreClassTests, LoadStoreClassValid)
 
     // Preparing device
     Type* device_input;
-    HIP_CHECK(hipMalloc(&device_input, input.size() * sizeof(typename decltype(input)::value_type)));
-    Type* device_output;
-    HIP_CHECK(hipMalloc(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
-
     HIP_CHECK(
-        hipMemcpy(
-            device_input, input.data(),
-            input.size() * sizeof(typename decltype(input)::value_type),
-            hipMemcpyHostToDevice
-        )
-    );
+        hipMalloc(&device_input, input.size() * sizeof(typename decltype(input)::value_type)));
+    Type* device_output;
+    HIP_CHECK(
+        hipMalloc(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
+
+    HIP_CHECK(hipMemcpy(device_input,
+                        input.data(),
+                        input.size() * sizeof(typename decltype(input)::value_type),
+                        hipMemcpyHostToDevice));
 
     // Have to initialize output for unvalid data to make sure they are not changed
-    HIP_CHECK(
-        hipMemcpy(
-            device_output, output.data(),
-            output.size() * sizeof(typename decltype(output)::value_type),
-            hipMemcpyHostToDevice
-        )
-    );
+    HIP_CHECK(hipMemcpy(device_output,
+                        output.data(),
+                        output.size() * sizeof(typename decltype(output)::value_type),
+                        hipMemcpyHostToDevice));
 
     // Running kernel
     hipLaunchKernelGGL(
         HIP_KERNEL_NAME(
-            load_store_valid_kernel<
-                Type, load_method, store_method,
-                block_size, items_per_thread
-            >
-        ),
-        dim3(grid_size), dim3(block_size), 0, 0,
-        device_input, device_output, valid
-    );
+            load_store_valid_kernel<Type, load_method, store_method, block_size, items_per_thread>),
+        dim3(grid_size),
+        dim3(block_size),
+        0,
+        0,
+        device_input,
+        device_output,
+        valid);
 
     // Reading results from device
-    HIP_CHECK(
-        hipMemcpy(
-            output.data(), device_output,
-            output.size() * sizeof(typename decltype(output)::value_type),
-            hipMemcpyDeviceToHost
-        )
-    );
+    HIP_CHECK(hipMemcpy(output.data(),
+                        device_output,
+                        output.size() * sizeof(typename decltype(output)::value_type),
+                        hipMemcpyDeviceToHost));
 
     // Validating results
     for(size_t i = 0; i < output.size(); i++)
@@ -369,19 +495,19 @@ TYPED_TEST(HipcubBlockLoadStoreClassTests, LoadStoreClassValid)
     HIP_CHECK(hipFree(device_output));
 }
 
-template<
-    class Type,
-    hipcub::BlockLoadAlgorithm LoadMethod,
-    hipcub::BlockStoreAlgorithm StoreMethod,
-    unsigned int BlockSize,
-    unsigned int ItemsPerThread
->
-__global__
-void load_store_valid_default_kernel(Type* device_input, Type* device_output, size_t valid, int _default)
+template <class Type,
+          hipcub::BlockLoadAlgorithm  LoadMethod,
+          hipcub::BlockStoreAlgorithm StoreMethod,
+          unsigned int                BlockSize,
+          unsigned int                ItemsPerThread>
+__global__ void load_store_valid_default_kernel(Type*  device_input,
+                                                Type*  device_output,
+                                                size_t valid,
+                                                int    _default)
 {
-    Type items[ItemsPerThread];
+    Type         items[ItemsPerThread];
     unsigned int offset = hipBlockIdx_x * BlockSize * ItemsPerThread;
-    hipcub::BlockLoad<Type, BlockSize, ItemsPerThread, LoadMethod> load;
+    hipcub::BlockLoad<Type, BlockSize, ItemsPerThread, LoadMethod>   load;
     hipcub::BlockStore<Type, BlockSize, ItemsPerThread, StoreMethod> store;
     load.Load(device_input + offset, items, valid, _default);
     store.Store(device_output + offset, items);
@@ -389,34 +515,34 @@ void load_store_valid_default_kernel(Type* device_input, Type* device_output, si
 
 TYPED_TEST(HipcubBlockLoadStoreClassTests, LoadStoreClassDefault)
 {
-    using Type = typename TestFixture::params::type;
-    constexpr size_t block_size = TestFixture::params::block_size;
-    constexpr hipcub::BlockLoadAlgorithm load_method = TestFixture::params::load_method;
-    constexpr hipcub::BlockStoreAlgorithm store_method = TestFixture::params::store_method;
-    const size_t items_per_thread = TestFixture::params::items_per_thread;
-    constexpr auto items_per_block = block_size * items_per_thread;
-    const size_t size = items_per_block * 113;
-    const auto grid_size = size / items_per_block;
+    using Type                                             = typename TestFixture::params::type;
+    constexpr size_t                      block_size       = TestFixture::params::block_size;
+    constexpr hipcub::BlockLoadAlgorithm  load_method      = TestFixture::params::load_method;
+    constexpr hipcub::BlockStoreAlgorithm store_method     = TestFixture::params::store_method;
+    const size_t                          items_per_thread = TestFixture::params::items_per_thread;
+    constexpr auto                        items_per_block  = block_size * items_per_thread;
+    const size_t                          size             = items_per_block * 113;
+    const auto                            grid_size        = size / items_per_block;
     // Given block size not supported
     if(block_size > test_utils::get_max_block_size() || (block_size & (block_size - 1)) != 0)
     {
         return;
     }
 
-    const size_t valid = items_per_thread + 1;
-    int _default = -1;
+    const size_t valid    = items_per_thread + 1;
+    int          _default = -1;
     // Generate data
     std::vector<Type> input = test_utils::get_random_data<Type>(size, -100, 100);
     std::vector<Type> output(input.size(), 0);
 
     // Calculate expected results on host
     std::vector<Type> expected(input.size(), _default);
-    for (size_t i = 0; i < 113; i++)
+    for(size_t i = 0; i < 113; i++)
     {
         size_t block_offset = i * items_per_block;
-        for (size_t j = 0; j < items_per_block; j++)
+        for(size_t j = 0; j < items_per_block; j++)
         {
-            if (j < valid)
+            if(j < valid)
             {
                 expected[j + block_offset] = input[j + block_offset];
             }
@@ -425,38 +551,37 @@ TYPED_TEST(HipcubBlockLoadStoreClassTests, LoadStoreClassDefault)
 
     // Preparing device
     Type* device_input;
-    HIP_CHECK(hipMalloc(&device_input, input.size() * sizeof(typename decltype(input)::value_type)));
-    Type* device_output;
-    HIP_CHECK(hipMalloc(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
-
     HIP_CHECK(
-        hipMemcpy(
-            device_input, input.data(),
-            input.size() * sizeof(typename decltype(input)::value_type),
-            hipMemcpyHostToDevice
-        )
-    );
+        hipMalloc(&device_input, input.size() * sizeof(typename decltype(input)::value_type)));
+    Type* device_output;
+    HIP_CHECK(
+        hipMalloc(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
+
+    HIP_CHECK(hipMemcpy(device_input,
+                        input.data(),
+                        input.size() * sizeof(typename decltype(input)::value_type),
+                        hipMemcpyHostToDevice));
 
     // Running kernel
-    hipLaunchKernelGGL(
-        HIP_KERNEL_NAME(
-            load_store_valid_default_kernel<
-                Type, load_method, store_method,
-                block_size, items_per_thread
-            >
-        ),
-        dim3(grid_size), dim3(block_size), 0, 0,
-        device_input, device_output, valid, _default
-    );
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(load_store_valid_default_kernel<Type,
+                                                                       load_method,
+                                                                       store_method,
+                                                                       block_size,
+                                                                       items_per_thread>),
+                       dim3(grid_size),
+                       dim3(block_size),
+                       0,
+                       0,
+                       device_input,
+                       device_output,
+                       valid,
+                       _default);
 
     // Reading results from device
-    HIP_CHECK(
-        hipMemcpy(
-            output.data(), device_output,
-            output.size() * sizeof(typename decltype(output)::value_type),
-            hipMemcpyDeviceToHost
-        )
-    );
+    HIP_CHECK(hipMemcpy(output.data(),
+                        device_output,
+                        output.size() * sizeof(typename decltype(output)::value_type),
+                        hipMemcpyDeviceToHost));
 
     // Validating results
     for(size_t i = 0; i < output.size(); i++)

--- a/test/hipcub/test_hipcub_caching_device_allocator.cpp
+++ b/test/hipcub/test_hipcub_caching_device_allocator.cpp
@@ -41,7 +41,7 @@
 
 #define HIP_CHECK(error) ASSERT_EQ(error, hipSuccess)
 
-__global__ void EmptyKernel() { }
+__global__ void EmptyKernel() {}
 
 // Hipified test/test_allocator.cu
 
@@ -67,21 +67,18 @@ TEST(HipcubCachingDeviceAllocatorTests, Test1)
     HIP_CHECK(hipStreamCreate(&other_stream));
 
     // Allocate 999 bytes on the current gpu in stream0
-    char *d_999B_stream0_a;
-    char *d_999B_stream0_b;
-    HIP_CHECK(allocator.DeviceAllocate((void **) &d_999B_stream0_a, 999, 0));
+    char* d_999B_stream0_a;
+    char* d_999B_stream0_b;
+    HIP_CHECK(allocator.DeviceAllocate((void**)&d_999B_stream0_a, 999, 0));
 
     // Run some big kernel in stream 0
-    hipLaunchKernelGGL(
-        HIP_KERNEL_NAME(EmptyKernel),
-        dim3(32000), dim3(256), 1024 * 8, 0
-    );
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(EmptyKernel), dim3(32000), dim3(256), 1024 * 8, 0);
 
     // Free d_999B_stream0_a
     HIP_CHECK(allocator.DeviceFree(d_999B_stream0_a));
 
     // Allocate another 999 bytes in stream 0
-    HIP_CHECK(allocator.DeviceAllocate((void **) &d_999B_stream0_b, 999, 0));
+    HIP_CHECK(allocator.DeviceAllocate((void**)&d_999B_stream0_b, 999, 0));
 
     // Check that that we have 1 live block on the initial GPU
     ASSERT_EQ(allocator.live_blocks.size(), 1u);
@@ -90,18 +87,15 @@ TEST(HipcubCachingDeviceAllocatorTests, Test1)
     ASSERT_EQ(allocator.cached_blocks.size(), 0u);
 
     // Run some big kernel in stream 0
-    hipLaunchKernelGGL(
-        HIP_KERNEL_NAME(EmptyKernel),
-        dim3(32000), dim3(256), 1024 * 8, 0
-    );
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(EmptyKernel), dim3(32000), dim3(256), 1024 * 8, 0);
 
     // Free d_999B_stream0_b
     HIP_CHECK(allocator.DeviceFree(d_999B_stream0_b));
 
     // Allocate 999 bytes on the current gpu in other_stream
-    char *d_999B_stream_other_a;
-    char *d_999B_stream_other_b;
-    HIP_CHECK(allocator.DeviceAllocate((void **) &d_999B_stream_other_a, 999, other_stream));
+    char* d_999B_stream_other_a;
+    char* d_999B_stream_other_b;
+    HIP_CHECK(allocator.DeviceAllocate((void**)&d_999B_stream_other_a, 999, other_stream));
 
     // Check that that we have 1 live blocks on the initial GPU (that we allocated a new one because d_999B_stream0_b is only available for stream 0 until it becomes idle)
     ASSERT_EQ(allocator.live_blocks.size(), 1u);
@@ -111,17 +105,15 @@ TEST(HipcubCachingDeviceAllocatorTests, Test1)
 
     // Run some big kernel in other_stream
     hipLaunchKernelGGL(
-        HIP_KERNEL_NAME(EmptyKernel),
-        dim3(32000), dim3(256), 1024 * 8, other_stream
-    );
+        HIP_KERNEL_NAME(EmptyKernel), dim3(32000), dim3(256), 1024 * 8, other_stream);
 
     // Free d_999B_stream_other
     HIP_CHECK(allocator.DeviceFree(d_999B_stream_other_a));
 
     // Check that we can now use both allocations in stream 0 after synchronizing the device
     HIP_CHECK(hipDeviceSynchronize());
-    HIP_CHECK(allocator.DeviceAllocate((void **) &d_999B_stream0_a, 999, 0));
-    HIP_CHECK(allocator.DeviceAllocate((void **) &d_999B_stream0_b, 999, 0));
+    HIP_CHECK(allocator.DeviceAllocate((void**)&d_999B_stream0_a, 999, 0));
+    HIP_CHECK(allocator.DeviceAllocate((void**)&d_999B_stream0_b, 999, 0));
 
     // Check that that we have 2 live blocks on the initial GPU
     ASSERT_EQ(allocator.live_blocks.size(), 2u);
@@ -135,8 +127,8 @@ TEST(HipcubCachingDeviceAllocatorTests, Test1)
 
     // Check that we can now use both allocations in other_stream
     HIP_CHECK(hipDeviceSynchronize());
-    HIP_CHECK(allocator.DeviceAllocate((void **) &d_999B_stream_other_a, 999, other_stream));
-    HIP_CHECK(allocator.DeviceAllocate((void **) &d_999B_stream_other_b, 999, other_stream));
+    HIP_CHECK(allocator.DeviceAllocate((void**)&d_999B_stream_other_a, 999, other_stream));
+    HIP_CHECK(allocator.DeviceAllocate((void**)&d_999B_stream_other_b, 999, other_stream));
 
     // Check that that we have 2 live blocks on the initial GPU
     ASSERT_EQ(allocator.live_blocks.size(), 2u);
@@ -146,9 +138,7 @@ TEST(HipcubCachingDeviceAllocatorTests, Test1)
 
     // Run some big kernel in other_stream
     hipLaunchKernelGGL(
-        HIP_KERNEL_NAME(EmptyKernel),
-        dim3(32000), dim3(256), 1024 * 8, other_stream
-    );
+        HIP_KERNEL_NAME(EmptyKernel), dim3(32000), dim3(256), 1024 * 8, other_stream);
 
     // Free d_999B_stream_other_a and d_999B_stream_other_b
     HIP_CHECK(allocator.DeviceFree(d_999B_stream_other_a));
@@ -157,8 +147,8 @@ TEST(HipcubCachingDeviceAllocatorTests, Test1)
     // Check that we can now use both allocations in stream 0 after synchronizing the device and destroying the other stream
     HIP_CHECK(hipDeviceSynchronize());
     HIP_CHECK(hipStreamDestroy(other_stream));
-    HIP_CHECK(allocator.DeviceAllocate((void **) &d_999B_stream0_a, 999, 0));
-    HIP_CHECK(allocator.DeviceAllocate((void **) &d_999B_stream0_b, 999, 0));
+    HIP_CHECK(allocator.DeviceAllocate((void**)&d_999B_stream0_a, 999, 0));
+    HIP_CHECK(allocator.DeviceAllocate((void**)&d_999B_stream0_b, 999, 0));
 
     // Check that that we have 2 live blocks on the initial GPU
     ASSERT_EQ(allocator.live_blocks.size(), 2u);
@@ -178,8 +168,8 @@ TEST(HipcubCachingDeviceAllocatorTests, Test1)
     //
 
     // Allocate 5 bytes on the current gpu
-    char *d_5B;
-    HIP_CHECK(allocator.DeviceAllocate((void **) &d_5B, 5));
+    char* d_5B;
+    HIP_CHECK(allocator.DeviceAllocate((void**)&d_5B, 5));
 
     // Check that that we have zero free bytes cached on the initial GPU
     ASSERT_EQ(allocator.cached_bytes[initial_gpu].free, 0u);
@@ -192,8 +182,8 @@ TEST(HipcubCachingDeviceAllocatorTests, Test1)
     //
 
     // Allocate 4096 bytes on the current gpu
-    char *d_4096B;
-    HIP_CHECK(allocator.DeviceAllocate((void **) &d_4096B, 4096));
+    char* d_4096B;
+    HIP_CHECK(allocator.DeviceAllocate((void**)&d_4096B, 4096));
 
     // Check that that we have 2 live blocks on the initial GPU
     ASSERT_EQ(allocator.live_blocks.size(), 2u);
@@ -235,8 +225,8 @@ TEST(HipcubCachingDeviceAllocatorTests, Test1)
     //
 
     // Allocate 768 bytes on the current gpu
-    char *d_768B;
-    HIP_CHECK(allocator.DeviceAllocate((void **) &d_768B, 768));
+    char* d_768B;
+    HIP_CHECK(allocator.DeviceAllocate((void**)&d_768B, 768));
 
     // Check that that we have the min_bin free bytes cached on the initial gpu (4096 was reused)
     ASSERT_EQ(allocator.cached_bytes[initial_gpu].free, allocator.min_bin_bytes);
@@ -252,8 +242,8 @@ TEST(HipcubCachingDeviceAllocatorTests, Test1)
     //
 
     // Allocate max_cached_bytes on the current gpu
-    char *d_max_cached;
-    HIP_CHECK(allocator.DeviceAllocate((void **) &d_max_cached, allocator.max_cached_bytes));
+    char* d_max_cached;
+    HIP_CHECK(allocator.DeviceAllocate((void**)&d_max_cached, allocator.max_cached_bytes));
 
     // DeviceFree d_max_cached
     HIP_CHECK(allocator.DeviceFree(d_max_cached));
@@ -288,8 +278,8 @@ TEST(HipcubCachingDeviceAllocatorTests, Test1)
     //
 
     // Allocate max cached bytes + 1 on the current gpu
-    char *d_max_cached_plus;
-    HIP_CHECK(allocator.DeviceAllocate((void **) &d_max_cached_plus, allocator.max_cached_bytes + 1));
+    char* d_max_cached_plus;
+    HIP_CHECK(allocator.DeviceAllocate((void**)&d_max_cached_plus, allocator.max_cached_bytes + 1));
 
     // DeviceFree max cached bytes
     HIP_CHECK(allocator.DeviceFree(d_max_cached_plus));
@@ -298,7 +288,7 @@ TEST(HipcubCachingDeviceAllocatorTests, Test1)
     HIP_CHECK(allocator.DeviceFree(d_768B));
 
     unsigned int power;
-    size_t rounded_bytes;
+    size_t       rounded_bytes;
     allocator.NearestPowerOf(power, rounded_bytes, allocator.bin_growth, 768);
 
     // Check that that we have 4096 free bytes cached on the initial gpu
@@ -310,22 +300,22 @@ TEST(HipcubCachingDeviceAllocatorTests, Test1)
     // Check that that still we have 0 live block across all GPUs
     ASSERT_EQ(allocator.live_blocks.size(), 0u);
 
-    if (num_gpus > 1)
+    if(num_gpus > 1)
     {
         //
         // Test9
         //
 
         // Allocate 768 bytes on the next gpu
-        int next_gpu = (initial_gpu + 1) % num_gpus;
-        char *d_768B_2;
-        HIP_CHECK(allocator.DeviceAllocate(next_gpu, (void **) &d_768B_2, 768));
+        int   next_gpu = (initial_gpu + 1) % num_gpus;
+        char* d_768B_2;
+        HIP_CHECK(allocator.DeviceAllocate(next_gpu, (void**)&d_768B_2, 768));
 
         // DeviceFree d_768B on the next gpu
         HIP_CHECK(allocator.DeviceFree(next_gpu, d_768B_2));
 
         // Re-allocate 768 bytes on the next gpu
-        HIP_CHECK(allocator.DeviceAllocate(next_gpu, (void **) &d_768B_2, 768));
+        HIP_CHECK(allocator.DeviceAllocate(next_gpu, (void**)&d_768B_2, 768));
 
         // Re-free d_768B on the next gpu
         HIP_CHECK(allocator.DeviceFree(next_gpu, d_768B_2));

--- a/test/hipcub/test_hipcub_device_radix_sort.cpp
+++ b/test/hipcub/test_hipcub_device_radix_sort.cpp
@@ -24,8 +24,8 @@
 #include <functional>
 #include <iostream>
 #include <type_traits>
-#include <vector>
 #include <utility>
+#include <vector>
 
 // Google Test
 #include <gtest/gtest.h>
@@ -36,87 +36,83 @@
 
 #define HIP_CHECK(error) ASSERT_EQ(error, hipSuccess)
 
-template<
-    class Key,
-    class Value,
-    bool Descending = false,
-    unsigned int StartBit = 0,
-    unsigned int EndBit = sizeof(Key) * 8,
-    bool CheckHugeSizes = false
->
+template <class Key,
+          class Value,
+          bool         Descending     = false,
+          unsigned int StartBit       = 0,
+          unsigned int EndBit         = sizeof(Key) * 8,
+          bool         CheckHugeSizes = false>
 struct params
 {
-    using key_type = Key;
-    using value_type = Value;
-    static constexpr bool descending = Descending;
-    static constexpr unsigned int start_bit = StartBit;
-    static constexpr unsigned int end_bit = EndBit;
-    static constexpr bool check_huge_sizes = CheckHugeSizes;
+    using key_type                                 = Key;
+    using value_type                               = Value;
+    static constexpr bool         descending       = Descending;
+    static constexpr unsigned int start_bit        = StartBit;
+    static constexpr unsigned int end_bit          = EndBit;
+    static constexpr bool         check_huge_sizes = CheckHugeSizes;
 };
 
-template<class Params>
-class HipcubDeviceRadixSort : public ::testing::Test {
+template <class Params>
+class HipcubDeviceRadixSort : public ::testing::Test
+{
 public:
     using params = Params;
 };
 
-typedef ::testing::Types<
-    params<signed char, double, true>,
-    params<int, short>,
-    params<short, int, true>,
-    params<long long, char>,
-    params<double, unsigned int>,
-    params<double, int, true>,
-    params<float, int>,
-    params<int, test_utils::custom_test_type<float>>,
+typedef ::testing::Types<params<signed char, double, true>,
+                         params<int, short>,
+                         params<short, int, true>,
+                         params<long long, char>,
+                         params<double, unsigned int>,
+                         params<double, int, true>,
+                         params<float, int>,
+                         params<int, test_utils::custom_test_type<float>>,
 
-    // start_bit and end_bit
-    params<unsigned char, int, true, 0, 7>,
-    params<unsigned short, int, true, 4, 10>,
-    params<unsigned int, short, false, 3, 22>,
-    params<unsigned int, double, true, 4, 21>,
-    params<unsigned int, short, true, 0, 15>,
-    params<unsigned long long, char, false, 8, 20>,
-    params<unsigned short, double, false, 8, 11>,
+                         // start_bit and end_bit
+                         params<unsigned char, int, true, 0, 7>,
+                         params<unsigned short, int, true, 4, 10>,
+                         params<unsigned int, short, false, 3, 22>,
+                         params<unsigned int, double, true, 4, 21>,
+                         params<unsigned int, short, true, 0, 15>,
+                         params<unsigned long long, char, false, 8, 20>,
+                         params<unsigned short, double, false, 8, 11>,
 
-    // huge sizes to check correctness of more than 1 block per batch
-    params<float, char, true, 0, 32, true>
-> Params;
+                         // huge sizes to check correctness of more than 1 block per batch
+                         params<float, char, true, 0, 32, true>>
+    Params;
 
 TYPED_TEST_CASE(HipcubDeviceRadixSort, Params);
 
-template<class Key, bool Descending, unsigned int StartBit, unsigned int EndBit>
+template <class Key, bool Descending, unsigned int StartBit, unsigned int EndBit>
 struct key_comparator
 {
 private:
-    template<unsigned int CStartBit, unsigned int CEndBit>
+    template <unsigned int CStartBit, unsigned int CEndBit>
     constexpr static bool all_bits()
     {
         return (CStartBit == 0 && CEndBit == sizeof(Key) * 8);
     }
 
-    template<unsigned int CStartBit, unsigned int CEndBit>
-    auto compare(const Key& lhs, const Key& rhs) const
-        -> typename std::enable_if<all_bits<CStartBit, CEndBit>(), bool>::type
+    template <unsigned int CStartBit, unsigned int CEndBit>
+    auto compare(const Key& lhs, const Key& rhs) const ->
+        typename std::enable_if<all_bits<CStartBit, CEndBit>(), bool>::type
     {
         return Descending ? (rhs < lhs) : (lhs < rhs);
     }
 
-    template<unsigned int CStartBit, unsigned int CEndBit>
-    auto compare(const Key& lhs, const Key& rhs) const
-        -> typename std::enable_if<!all_bits<CStartBit, CEndBit>(), bool>::type
+    template <unsigned int CStartBit, unsigned int CEndBit>
+    auto compare(const Key& lhs, const Key& rhs) const ->
+        typename std::enable_if<!all_bits<CStartBit, CEndBit>(), bool>::type
     {
         auto mask = (1ull << (EndBit - StartBit)) - 1;
-        auto l = (static_cast<unsigned long long>(lhs) >> StartBit) & mask;
-        auto r = (static_cast<unsigned long long>(rhs) >> StartBit) & mask;
+        auto l    = (static_cast<unsigned long long>(lhs) >> StartBit) & mask;
+        auto r    = (static_cast<unsigned long long>(rhs) >> StartBit) & mask;
         return Descending ? (r < l) : (l < r);
     }
 
 public:
-    static_assert(
-        key_comparator::all_bits<StartBit, EndBit>() || std::is_unsigned<Key>::value,
-        "Test supports start and end bits only for unsigned integers"
-    );
+    static_assert(key_comparator::all_bits<StartBit, EndBit>() || std::is_unsigned<Key>::value,
+                  "Test supports start and end bits only for unsigned integers");
 
     bool operator()(const Key& lhs, const Key& rhs)
     {
@@ -124,7 +120,7 @@ public:
     }
 };
 
-template<class Key, class Value, bool Descending, unsigned int StartBit, unsigned int EndBit>
+template <class Key, class Value, bool Descending, unsigned int StartBit, unsigned int EndBit>
 struct key_value_comparator
 {
     bool operator()(const std::pair<Key, Value>& lhs, const std::pair<Key, Value>& rhs)
@@ -135,7 +131,8 @@ struct key_value_comparator
 
 std::vector<size_t> get_sizes()
 {
-    std::vector<size_t> sizes = { 1, 10, 53, 211, 1024, 2345, 4096, 34567, (1 << 16) - 1220, (1 << 23) - 76543 };
+    std::vector<size_t> sizes
+        = {1, 10, 53, 211, 1024, 2345, 4096, 34567, (1 << 16) - 1220, (1 << 23) - 76543};
     const std::vector<size_t> random_sizes = test_utils::get_random_data<size_t>(10, 1, 100000);
     sizes.insert(sizes.end(), random_sizes.begin(), random_sizes.end());
     return sizes;
@@ -143,11 +140,11 @@ std::vector<size_t> get_sizes()
 
 TYPED_TEST(HipcubDeviceRadixSort, SortKeys)
 {
-    using key_type = typename TestFixture::params::key_type;
-    constexpr bool descending = TestFixture::params::descending;
-    constexpr unsigned int start_bit = TestFixture::params::start_bit;
-    constexpr unsigned int end_bit = TestFixture::params::end_bit;
-    constexpr bool check_huge_sizes = TestFixture::params::check_huge_sizes;
+    using key_type                          = typename TestFixture::params::key_type;
+    constexpr bool         descending       = TestFixture::params::descending;
+    constexpr unsigned int start_bit        = TestFixture::params::start_bit;
+    constexpr unsigned int end_bit          = TestFixture::params::end_bit;
+    constexpr bool         check_huge_sizes = TestFixture::params::check_huge_sizes;
 
     hipStream_t stream = 0;
 
@@ -156,7 +153,8 @@ TYPED_TEST(HipcubDeviceRadixSort, SortKeys)
     const std::vector<size_t> sizes = get_sizes();
     for(size_t size : sizes)
     {
-        if(size > (1 << 20) && !check_huge_sizes) continue;
+        if(size > (1 << 20) && !check_huge_sizes)
+            continue;
 
         SCOPED_TRACE(testing::Message() << "with size = " << size);
 
@@ -164,81 +162,73 @@ TYPED_TEST(HipcubDeviceRadixSort, SortKeys)
         std::vector<key_type> keys_input;
         if(std::is_floating_point<key_type>::value)
         {
-            keys_input = test_utils::get_random_data<key_type>(size, (key_type)-1000, (key_type)+1000);
+            keys_input
+                = test_utils::get_random_data<key_type>(size, (key_type)-1000, (key_type) + 1000);
         }
         else
         {
             keys_input = test_utils::get_random_data<key_type>(
-                size,
-                std::numeric_limits<key_type>::min(),
-                std::numeric_limits<key_type>::max()
-            );
+                size, std::numeric_limits<key_type>::min(), std::numeric_limits<key_type>::max());
         }
 
-        key_type * d_keys_input;
-        key_type * d_keys_output;
+        key_type* d_keys_input;
+        key_type* d_keys_output;
         HIP_CHECK(hipMalloc(&d_keys_input, size * sizeof(key_type)));
         HIP_CHECK(hipMalloc(&d_keys_output, size * sizeof(key_type)));
-        HIP_CHECK(
-            hipMemcpy(
-                d_keys_input, keys_input.data(),
-                size * sizeof(key_type),
-                hipMemcpyHostToDevice
-            )
-        );
+        HIP_CHECK(hipMemcpy(
+            d_keys_input, keys_input.data(), size * sizeof(key_type), hipMemcpyHostToDevice));
 
         // Calculate expected results on host
         std::vector<key_type> expected(keys_input);
-        std::stable_sort(expected.begin(), expected.end(), key_comparator<key_type, descending, start_bit, end_bit>());
+        std::stable_sort(expected.begin(),
+                         expected.end(),
+                         key_comparator<key_type, descending, start_bit, end_bit>());
 
         size_t temporary_storage_bytes = 0;
-        HIP_CHECK(
-            hipcub::DeviceRadixSort::SortKeys(
-                nullptr, temporary_storage_bytes,
-                d_keys_input, d_keys_output, size,
-                start_bit, end_bit
-            )
-        );
+        HIP_CHECK(hipcub::DeviceRadixSort::SortKeys(nullptr,
+                                                    temporary_storage_bytes,
+                                                    d_keys_input,
+                                                    d_keys_output,
+                                                    size,
+                                                    start_bit,
+                                                    end_bit));
 
         ASSERT_GT(temporary_storage_bytes, 0U);
 
-        void * d_temporary_storage;
+        void* d_temporary_storage;
         HIP_CHECK(hipMalloc(&d_temporary_storage, temporary_storage_bytes));
 
         if(descending)
         {
-            HIP_CHECK(
-                hipcub::DeviceRadixSort::SortKeysDescending(
-                    d_temporary_storage, temporary_storage_bytes,
-                    d_keys_input, d_keys_output, size,
-                    start_bit, end_bit,
-                    stream, debug_synchronous
-                )
-            );
+            HIP_CHECK(hipcub::DeviceRadixSort::SortKeysDescending(d_temporary_storage,
+                                                                  temporary_storage_bytes,
+                                                                  d_keys_input,
+                                                                  d_keys_output,
+                                                                  size,
+                                                                  start_bit,
+                                                                  end_bit,
+                                                                  stream,
+                                                                  debug_synchronous));
         }
         else
         {
-            HIP_CHECK(
-                hipcub::DeviceRadixSort::SortKeys(
-                    d_temporary_storage, temporary_storage_bytes,
-                    d_keys_input, d_keys_output, size,
-                    start_bit, end_bit,
-                    stream, debug_synchronous
-                )
-            );
+            HIP_CHECK(hipcub::DeviceRadixSort::SortKeys(d_temporary_storage,
+                                                        temporary_storage_bytes,
+                                                        d_keys_input,
+                                                        d_keys_output,
+                                                        size,
+                                                        start_bit,
+                                                        end_bit,
+                                                        stream,
+                                                        debug_synchronous));
         }
 
         HIP_CHECK(hipFree(d_temporary_storage));
         HIP_CHECK(hipFree(d_keys_input));
 
         std::vector<key_type> keys_output(size);
-        HIP_CHECK(
-            hipMemcpy(
-                keys_output.data(), d_keys_output,
-                size * sizeof(key_type),
-                hipMemcpyDeviceToHost
-            )
-        );
+        HIP_CHECK(hipMemcpy(
+            keys_output.data(), d_keys_output, size * sizeof(key_type), hipMemcpyDeviceToHost));
 
         HIP_CHECK(hipFree(d_keys_output));
 
@@ -251,12 +241,12 @@ TYPED_TEST(HipcubDeviceRadixSort, SortKeys)
 
 TYPED_TEST(HipcubDeviceRadixSort, SortPairs)
 {
-    using key_type = typename TestFixture::params::key_type;
-    using value_type = typename TestFixture::params::value_type;
-    constexpr bool descending = TestFixture::params::descending;
-    constexpr unsigned int start_bit = TestFixture::params::start_bit;
-    constexpr unsigned int end_bit = TestFixture::params::end_bit;
-    constexpr bool check_huge_sizes = TestFixture::params::check_huge_sizes;
+    using key_type                          = typename TestFixture::params::key_type;
+    using value_type                        = typename TestFixture::params::value_type;
+    constexpr bool         descending       = TestFixture::params::descending;
+    constexpr unsigned int start_bit        = TestFixture::params::start_bit;
+    constexpr unsigned int end_bit          = TestFixture::params::end_bit;
+    constexpr bool         check_huge_sizes = TestFixture::params::check_huge_sizes;
 
     hipStream_t stream = 0;
 
@@ -265,7 +255,8 @@ TYPED_TEST(HipcubDeviceRadixSort, SortPairs)
     const std::vector<size_t> sizes = get_sizes();
     for(size_t size : sizes)
     {
-        if(size > (1 << 20) && !check_huge_sizes) continue;
+        if(size > (1 << 20) && !check_huge_sizes)
+            continue;
 
         SCOPED_TRACE(testing::Message() << "with size = " << size);
 
@@ -273,43 +264,31 @@ TYPED_TEST(HipcubDeviceRadixSort, SortPairs)
         std::vector<key_type> keys_input;
         if(std::is_floating_point<key_type>::value)
         {
-            keys_input = test_utils::get_random_data<key_type>(size, (key_type)-1000, (key_type)+1000);
+            keys_input
+                = test_utils::get_random_data<key_type>(size, (key_type)-1000, (key_type) + 1000);
         }
         else
         {
             keys_input = test_utils::get_random_data<key_type>(
-                size,
-                std::numeric_limits<key_type>::min(),
-                std::numeric_limits<key_type>::max()
-            );
+                size, std::numeric_limits<key_type>::min(), std::numeric_limits<key_type>::max());
         }
 
         std::vector<value_type> values_input(size);
         std::iota(values_input.begin(), values_input.end(), 0);
 
-        key_type * d_keys_input;
-        key_type * d_keys_output;
+        key_type* d_keys_input;
+        key_type* d_keys_output;
         HIP_CHECK(hipMalloc(&d_keys_input, size * sizeof(key_type)));
         HIP_CHECK(hipMalloc(&d_keys_output, size * sizeof(key_type)));
-        HIP_CHECK(
-            hipMemcpy(
-                d_keys_input, keys_input.data(),
-                size * sizeof(key_type),
-                hipMemcpyHostToDevice
-            )
-        );
+        HIP_CHECK(hipMemcpy(
+            d_keys_input, keys_input.data(), size * sizeof(key_type), hipMemcpyHostToDevice));
 
-        value_type * d_values_input;
-        value_type * d_values_output;
+        value_type* d_values_input;
+        value_type* d_values_output;
         HIP_CHECK(hipMalloc(&d_values_input, size * sizeof(value_type)));
         HIP_CHECK(hipMalloc(&d_values_output, size * sizeof(value_type)));
-        HIP_CHECK(
-            hipMemcpy(
-                d_values_input, values_input.data(),
-                size * sizeof(value_type),
-                hipMemcpyHostToDevice
-            )
-        );
+        HIP_CHECK(hipMemcpy(
+            d_values_input, values_input.data(), size * sizeof(value_type), hipMemcpyHostToDevice));
 
         using key_value = std::pair<key_type, value_type>;
 
@@ -320,19 +299,21 @@ TYPED_TEST(HipcubDeviceRadixSort, SortPairs)
             expected[i] = key_value(keys_input[i], values_input[i]);
         }
         std::stable_sort(
-            expected.begin(), expected.end(),
-            key_value_comparator<key_type, value_type, descending, start_bit, end_bit>()
-        );
+            expected.begin(),
+            expected.end(),
+            key_value_comparator<key_type, value_type, descending, start_bit, end_bit>());
 
-        void * d_temporary_storage = nullptr;
+        void*  d_temporary_storage     = nullptr;
         size_t temporary_storage_bytes = 0;
-        HIP_CHECK(
-            hipcub::DeviceRadixSort::SortPairs(
-                d_temporary_storage, temporary_storage_bytes,
-                d_keys_input, d_keys_output, d_values_input, d_values_output, size,
-                start_bit, end_bit
-            )
-        );
+        HIP_CHECK(hipcub::DeviceRadixSort::SortPairs(d_temporary_storage,
+                                                     temporary_storage_bytes,
+                                                     d_keys_input,
+                                                     d_keys_output,
+                                                     d_values_input,
+                                                     d_values_output,
+                                                     size,
+                                                     start_bit,
+                                                     end_bit));
 
         ASSERT_GT(temporary_storage_bytes, 0U);
 
@@ -340,25 +321,31 @@ TYPED_TEST(HipcubDeviceRadixSort, SortPairs)
 
         if(descending)
         {
-            HIP_CHECK(
-                hipcub::DeviceRadixSort::SortPairsDescending(
-                    d_temporary_storage, temporary_storage_bytes,
-                    d_keys_input, d_keys_output, d_values_input, d_values_output, size,
-                    start_bit, end_bit,
-                    stream, debug_synchronous
-                )
-            );
+            HIP_CHECK(hipcub::DeviceRadixSort::SortPairsDescending(d_temporary_storage,
+                                                                   temporary_storage_bytes,
+                                                                   d_keys_input,
+                                                                   d_keys_output,
+                                                                   d_values_input,
+                                                                   d_values_output,
+                                                                   size,
+                                                                   start_bit,
+                                                                   end_bit,
+                                                                   stream,
+                                                                   debug_synchronous));
         }
         else
         {
-            HIP_CHECK(
-                hipcub::DeviceRadixSort::SortPairs(
-                    d_temporary_storage, temporary_storage_bytes,
-                    d_keys_input, d_keys_output, d_values_input, d_values_output, size,
-                    start_bit, end_bit,
-                    stream, debug_synchronous
-                )
-            );
+            HIP_CHECK(hipcub::DeviceRadixSort::SortPairs(d_temporary_storage,
+                                                         temporary_storage_bytes,
+                                                         d_keys_input,
+                                                         d_keys_output,
+                                                         d_values_input,
+                                                         d_values_output,
+                                                         size,
+                                                         start_bit,
+                                                         end_bit,
+                                                         stream,
+                                                         debug_synchronous));
         }
 
         HIP_CHECK(hipFree(d_temporary_storage));
@@ -366,22 +353,14 @@ TYPED_TEST(HipcubDeviceRadixSort, SortPairs)
         HIP_CHECK(hipFree(d_values_input));
 
         std::vector<key_type> keys_output(size);
-        HIP_CHECK(
-            hipMemcpy(
-                keys_output.data(), d_keys_output,
-                size * sizeof(key_type),
-                hipMemcpyDeviceToHost
-            )
-        );
+        HIP_CHECK(hipMemcpy(
+            keys_output.data(), d_keys_output, size * sizeof(key_type), hipMemcpyDeviceToHost));
 
         std::vector<value_type> values_output(size);
-        HIP_CHECK(
-            hipMemcpy(
-                values_output.data(), d_values_output,
-                size * sizeof(value_type),
-                hipMemcpyDeviceToHost
-            )
-        );
+        HIP_CHECK(hipMemcpy(values_output.data(),
+                            d_values_output,
+                            size * sizeof(value_type),
+                            hipMemcpyDeviceToHost));
 
         HIP_CHECK(hipFree(d_keys_output));
         HIP_CHECK(hipFree(d_values_output));
@@ -396,11 +375,11 @@ TYPED_TEST(HipcubDeviceRadixSort, SortPairs)
 
 TYPED_TEST(HipcubDeviceRadixSort, SortKeysDoubleBuffer)
 {
-    using key_type = typename TestFixture::params::key_type;
-    constexpr bool descending = TestFixture::params::descending;
-    constexpr unsigned int start_bit = TestFixture::params::start_bit;
-    constexpr unsigned int end_bit = TestFixture::params::end_bit;
-    constexpr bool check_huge_sizes = TestFixture::params::check_huge_sizes;
+    using key_type                          = typename TestFixture::params::key_type;
+    constexpr bool         descending       = TestFixture::params::descending;
+    constexpr unsigned int start_bit        = TestFixture::params::start_bit;
+    constexpr unsigned int end_bit          = TestFixture::params::end_bit;
+    constexpr bool         check_huge_sizes = TestFixture::params::check_huge_sizes;
 
     hipStream_t stream = 0;
 
@@ -409,7 +388,8 @@ TYPED_TEST(HipcubDeviceRadixSort, SortKeysDoubleBuffer)
     const std::vector<size_t> sizes = get_sizes();
     for(size_t size : sizes)
     {
-        if(size > (1 << 20) && !check_huge_sizes) continue;
+        if(size > (1 << 20) && !check_huge_sizes)
+            continue;
 
         SCOPED_TRACE(testing::Message() << "with size = " << size);
 
@@ -417,82 +397,67 @@ TYPED_TEST(HipcubDeviceRadixSort, SortKeysDoubleBuffer)
         std::vector<key_type> keys_input;
         if(std::is_floating_point<key_type>::value)
         {
-            keys_input = test_utils::get_random_data<key_type>(size, (key_type)-1000, (key_type)+1000);
+            keys_input
+                = test_utils::get_random_data<key_type>(size, (key_type)-1000, (key_type) + 1000);
         }
         else
         {
             keys_input = test_utils::get_random_data<key_type>(
-                size,
-                std::numeric_limits<key_type>::min(),
-                std::numeric_limits<key_type>::max()
-            );
+                size, std::numeric_limits<key_type>::min(), std::numeric_limits<key_type>::max());
         }
 
-        key_type * d_keys_input;
-        key_type * d_keys_output;
+        key_type* d_keys_input;
+        key_type* d_keys_output;
         HIP_CHECK(hipMalloc(&d_keys_input, size * sizeof(key_type)));
         HIP_CHECK(hipMalloc(&d_keys_output, size * sizeof(key_type)));
-        HIP_CHECK(
-            hipMemcpy(
-                d_keys_input, keys_input.data(),
-                size * sizeof(key_type),
-                hipMemcpyHostToDevice
-            )
-        );
+        HIP_CHECK(hipMemcpy(
+            d_keys_input, keys_input.data(), size * sizeof(key_type), hipMemcpyHostToDevice));
 
         // Calculate expected results on host
         std::vector<key_type> expected(keys_input);
-        std::stable_sort(expected.begin(), expected.end(), key_comparator<key_type, descending, start_bit, end_bit>());
+        std::stable_sort(expected.begin(),
+                         expected.end(),
+                         key_comparator<key_type, descending, start_bit, end_bit>());
 
         hipcub::DoubleBuffer<key_type> d_keys(d_keys_input, d_keys_output);
 
         size_t temporary_storage_bytes = 0;
-        HIP_CHECK(
-            hipcub::DeviceRadixSort::SortKeys(
-                nullptr, temporary_storage_bytes,
-                d_keys, size,
-                start_bit, end_bit
-            )
-        );
+        HIP_CHECK(hipcub::DeviceRadixSort::SortKeys(
+            nullptr, temporary_storage_bytes, d_keys, size, start_bit, end_bit));
 
         ASSERT_GT(temporary_storage_bytes, 0U);
 
-        void * d_temporary_storage;
+        void* d_temporary_storage;
         HIP_CHECK(hipMalloc(&d_temporary_storage, temporary_storage_bytes));
 
         if(descending)
         {
-            HIP_CHECK(
-                hipcub::DeviceRadixSort::SortKeysDescending(
-                    d_temporary_storage, temporary_storage_bytes,
-                    d_keys, size,
-                    start_bit, end_bit,
-                    stream, debug_synchronous
-                )
-            );
+            HIP_CHECK(hipcub::DeviceRadixSort::SortKeysDescending(d_temporary_storage,
+                                                                  temporary_storage_bytes,
+                                                                  d_keys,
+                                                                  size,
+                                                                  start_bit,
+                                                                  end_bit,
+                                                                  stream,
+                                                                  debug_synchronous));
         }
         else
         {
-            HIP_CHECK(
-                hipcub::DeviceRadixSort::SortKeys(
-                    d_temporary_storage, temporary_storage_bytes,
-                    d_keys, size,
-                    start_bit, end_bit,
-                    stream, debug_synchronous
-                )
-            );
+            HIP_CHECK(hipcub::DeviceRadixSort::SortKeys(d_temporary_storage,
+                                                        temporary_storage_bytes,
+                                                        d_keys,
+                                                        size,
+                                                        start_bit,
+                                                        end_bit,
+                                                        stream,
+                                                        debug_synchronous));
         }
 
         HIP_CHECK(hipFree(d_temporary_storage));
 
         std::vector<key_type> keys_output(size);
-        HIP_CHECK(
-            hipMemcpy(
-                keys_output.data(), d_keys.Current(),
-                size * sizeof(key_type),
-                hipMemcpyDeviceToHost
-            )
-        );
+        HIP_CHECK(hipMemcpy(
+            keys_output.data(), d_keys.Current(), size * sizeof(key_type), hipMemcpyDeviceToHost));
 
         HIP_CHECK(hipFree(d_keys_input));
         HIP_CHECK(hipFree(d_keys_output));
@@ -506,12 +471,12 @@ TYPED_TEST(HipcubDeviceRadixSort, SortKeysDoubleBuffer)
 
 TYPED_TEST(HipcubDeviceRadixSort, SortPairsDoubleBuffer)
 {
-    using key_type = typename TestFixture::params::key_type;
-    using value_type = typename TestFixture::params::value_type;
-    constexpr bool descending = TestFixture::params::descending;
-    constexpr unsigned int start_bit = TestFixture::params::start_bit;
-    constexpr unsigned int end_bit = TestFixture::params::end_bit;
-    constexpr bool check_huge_sizes = TestFixture::params::check_huge_sizes;
+    using key_type                          = typename TestFixture::params::key_type;
+    using value_type                        = typename TestFixture::params::value_type;
+    constexpr bool         descending       = TestFixture::params::descending;
+    constexpr unsigned int start_bit        = TestFixture::params::start_bit;
+    constexpr unsigned int end_bit          = TestFixture::params::end_bit;
+    constexpr bool         check_huge_sizes = TestFixture::params::check_huge_sizes;
 
     hipStream_t stream = 0;
 
@@ -520,7 +485,8 @@ TYPED_TEST(HipcubDeviceRadixSort, SortPairsDoubleBuffer)
     const std::vector<size_t> sizes = get_sizes();
     for(size_t size : sizes)
     {
-        if(size > (1 << 20) && !check_huge_sizes) continue;
+        if(size > (1 << 20) && !check_huge_sizes)
+            continue;
 
         SCOPED_TRACE(testing::Message() << "with size = " << size);
 
@@ -528,43 +494,31 @@ TYPED_TEST(HipcubDeviceRadixSort, SortPairsDoubleBuffer)
         std::vector<key_type> keys_input;
         if(std::is_floating_point<key_type>::value)
         {
-            keys_input = test_utils::get_random_data<key_type>(size, (key_type)-1000, (key_type)+1000);
+            keys_input
+                = test_utils::get_random_data<key_type>(size, (key_type)-1000, (key_type) + 1000);
         }
         else
         {
             keys_input = test_utils::get_random_data<key_type>(
-                size,
-                std::numeric_limits<key_type>::min(),
-                std::numeric_limits<key_type>::max()
-            );
+                size, std::numeric_limits<key_type>::min(), std::numeric_limits<key_type>::max());
         }
 
         std::vector<value_type> values_input(size);
         std::iota(values_input.begin(), values_input.end(), 0);
 
-        key_type * d_keys_input;
-        key_type * d_keys_output;
+        key_type* d_keys_input;
+        key_type* d_keys_output;
         HIP_CHECK(hipMalloc(&d_keys_input, size * sizeof(key_type)));
         HIP_CHECK(hipMalloc(&d_keys_output, size * sizeof(key_type)));
-        HIP_CHECK(
-            hipMemcpy(
-                d_keys_input, keys_input.data(),
-                size * sizeof(key_type),
-                hipMemcpyHostToDevice
-            )
-        );
+        HIP_CHECK(hipMemcpy(
+            d_keys_input, keys_input.data(), size * sizeof(key_type), hipMemcpyHostToDevice));
 
-        value_type * d_values_input;
-        value_type * d_values_output;
+        value_type* d_values_input;
+        value_type* d_values_output;
         HIP_CHECK(hipMalloc(&d_values_input, size * sizeof(value_type)));
         HIP_CHECK(hipMalloc(&d_values_output, size * sizeof(value_type)));
-        HIP_CHECK(
-            hipMemcpy(
-                d_values_input, values_input.data(),
-                size * sizeof(value_type),
-                hipMemcpyHostToDevice
-            )
-        );
+        HIP_CHECK(hipMemcpy(
+            d_values_input, values_input.data(), size * sizeof(value_type), hipMemcpyHostToDevice));
 
         using key_value = std::pair<key_type, value_type>;
 
@@ -575,22 +529,22 @@ TYPED_TEST(HipcubDeviceRadixSort, SortPairsDoubleBuffer)
             expected[i] = key_value(keys_input[i], values_input[i]);
         }
         std::stable_sort(
-            expected.begin(), expected.end(),
-            key_value_comparator<key_type, value_type, descending, start_bit, end_bit>()
-        );
+            expected.begin(),
+            expected.end(),
+            key_value_comparator<key_type, value_type, descending, start_bit, end_bit>());
 
-        hipcub::DoubleBuffer<key_type> d_keys(d_keys_input, d_keys_output);
+        hipcub::DoubleBuffer<key_type>   d_keys(d_keys_input, d_keys_output);
         hipcub::DoubleBuffer<value_type> d_values(d_values_input, d_values_output);
 
-        void * d_temporary_storage = nullptr;
+        void*  d_temporary_storage     = nullptr;
         size_t temporary_storage_bytes = 0;
-        HIP_CHECK(
-            hipcub::DeviceRadixSort::SortPairs(
-                d_temporary_storage, temporary_storage_bytes,
-                d_keys, d_values, size,
-                start_bit, end_bit
-            )
-        );
+        HIP_CHECK(hipcub::DeviceRadixSort::SortPairs(d_temporary_storage,
+                                                     temporary_storage_bytes,
+                                                     d_keys,
+                                                     d_values,
+                                                     size,
+                                                     start_bit,
+                                                     end_bit));
 
         ASSERT_GT(temporary_storage_bytes, 0U);
 
@@ -598,46 +552,40 @@ TYPED_TEST(HipcubDeviceRadixSort, SortPairsDoubleBuffer)
 
         if(descending)
         {
-            HIP_CHECK(
-                hipcub::DeviceRadixSort::SortPairsDescending(
-                    d_temporary_storage, temporary_storage_bytes,
-                    d_keys, d_values, size,
-                    start_bit, end_bit,
-                    stream, debug_synchronous
-                )
-            );
+            HIP_CHECK(hipcub::DeviceRadixSort::SortPairsDescending(d_temporary_storage,
+                                                                   temporary_storage_bytes,
+                                                                   d_keys,
+                                                                   d_values,
+                                                                   size,
+                                                                   start_bit,
+                                                                   end_bit,
+                                                                   stream,
+                                                                   debug_synchronous));
         }
         else
         {
-            HIP_CHECK(
-                hipcub::DeviceRadixSort::SortPairs(
-                    d_temporary_storage, temporary_storage_bytes,
-                    d_keys, d_values, size,
-                    start_bit, end_bit,
-                    stream, debug_synchronous
-                )
-            );
+            HIP_CHECK(hipcub::DeviceRadixSort::SortPairs(d_temporary_storage,
+                                                         temporary_storage_bytes,
+                                                         d_keys,
+                                                         d_values,
+                                                         size,
+                                                         start_bit,
+                                                         end_bit,
+                                                         stream,
+                                                         debug_synchronous));
         }
 
         HIP_CHECK(hipFree(d_temporary_storage));
 
         std::vector<key_type> keys_output(size);
-        HIP_CHECK(
-            hipMemcpy(
-                keys_output.data(), d_keys.Current(),
-                size * sizeof(key_type),
-                hipMemcpyDeviceToHost
-            )
-        );
+        HIP_CHECK(hipMemcpy(
+            keys_output.data(), d_keys.Current(), size * sizeof(key_type), hipMemcpyDeviceToHost));
 
         std::vector<value_type> values_output(size);
-        HIP_CHECK(
-            hipMemcpy(
-                values_output.data(), d_values.Current(),
-                size * sizeof(value_type),
-                hipMemcpyDeviceToHost
-            )
-        );
+        HIP_CHECK(hipMemcpy(values_output.data(),
+                            d_values.Current(),
+                            size * sizeof(value_type),
+                            hipMemcpyDeviceToHost));
 
         HIP_CHECK(hipFree(d_keys_input));
         HIP_CHECK(hipFree(d_keys_output));

--- a/test/hipcub/test_hipcub_device_reduce_by_key.cpp
+++ b/test/hipcub/test_hipcub_device_reduce_by_key.cpp
@@ -25,8 +25,8 @@
 #include <iostream>
 #include <random>
 #include <type_traits>
-#include <vector>
 #include <utility>
+#include <vector>
 
 // Google Test
 #include <gtest/gtest.h>
@@ -39,26 +39,25 @@
 
 #define HIP_CHECK(error) ASSERT_EQ(error, hipSuccess)
 
-template<
-    class Key,
-    class Value,
-    class ReduceOp,
-    unsigned int MinSegmentLength,
-    unsigned int MaxSegmentLength,
-    class Aggregate = Value
->
+template <class Key,
+          class Value,
+          class ReduceOp,
+          unsigned int MinSegmentLength,
+          unsigned int MaxSegmentLength,
+          class Aggregate = Value>
 struct params
 {
-    using key_type = Key;
-    using value_type = Value;
-    using reduce_op_type = ReduceOp;
+    using key_type                                   = Key;
+    using value_type                                 = Value;
+    using reduce_op_type                             = ReduceOp;
     static constexpr unsigned int min_segment_length = MinSegmentLength;
     static constexpr unsigned int max_segment_length = MaxSegmentLength;
-    using aggregate_type = Aggregate;
+    using aggregate_type                             = Aggregate;
 };
 
-template<class Params>
-class HipcubDeviceReduceByKey : public ::testing::Test {
+template <class Params>
+class HipcubDeviceReduceByKey : public ::testing::Test
+{
 public:
     using params = Params;
 };
@@ -76,20 +75,28 @@ typedef ::testing::Types<
     params<unsigned int, int, hipcub::Sum, 2048, 2048>,
     params<unsigned int, double, hipcub::Min, 1000, 50000>,
     params<long long, short, hipcub::Sum, 1000, 10000, long long>,
-    params<unsigned long long, unsigned long long, hipcub::Sum, 100000, 100000>
-> Params;
+    params<unsigned long long, unsigned long long, hipcub::Sum, 100000, 100000>>
+    Params;
 
 TYPED_TEST_CASE(HipcubDeviceReduceByKey, Params);
 
 std::vector<size_t> get_sizes()
 {
-    std::vector<size_t> sizes = {
-        1024, 2048, 4096, 1792,
-        1, 10, 53, 211, 500,
-        2345, 11001, 34567,
-        100000,
-        (1 << 16) - 1220, (1 << 23) - 76543
-    };
+    std::vector<size_t>       sizes        = {1024,
+                                 2048,
+                                 4096,
+                                 1792,
+                                 1,
+                                 10,
+                                 53,
+                                 211,
+                                 500,
+                                 2345,
+                                 11001,
+                                 34567,
+                                 100000,
+                                 (1 << 16) - 1220,
+                                 (1 << 23) - 76543};
     const std::vector<size_t> random_sizes = test_utils::get_random_data<size_t>(10, 1, 100000);
     sizes.insert(sizes.end(), random_sizes.begin(), random_sizes.end());
     return sizes;
@@ -97,24 +104,23 @@ std::vector<size_t> get_sizes()
 
 TYPED_TEST(HipcubDeviceReduceByKey, ReduceByKey)
 {
-    using key_type = typename TestFixture::params::key_type;
-    using value_type = typename TestFixture::params::value_type;
+    using key_type       = typename TestFixture::params::key_type;
+    using value_type     = typename TestFixture::params::value_type;
     using aggregate_type = typename TestFixture::params::aggregate_type;
     using reduce_op_type = typename TestFixture::params::reduce_op_type;
-    using key_distribution_type = typename std::conditional<
-        std::is_floating_point<key_type>::value,
-        std::uniform_real_distribution<key_type>,
-        std::uniform_int_distribution<key_type>
-    >::type;
+    using key_distribution_type =
+        typename std::conditional<std::is_floating_point<key_type>::value,
+                                  std::uniform_real_distribution<key_type>,
+                                  std::uniform_int_distribution<key_type>>::type;
 
     const bool debug_synchronous = false;
 
-    reduce_op_type reduce_op;
+    reduce_op_type   reduce_op;
     hipcub::Equality key_compare_op;
 
     const std::vector<size_t> sizes = get_sizes();
 
-    const unsigned int seed = 123;
+    const unsigned int         seed = 123;
     std::default_random_engine gen(seed);
 
     for(size_t size : sizes)
@@ -124,21 +130,20 @@ TYPED_TEST(HipcubDeviceReduceByKey, ReduceByKey)
         hipStream_t stream = 0; // default
 
         // Generate data and calculate expected results
-        std::vector<key_type> unique_expected;
+        std::vector<key_type>       unique_expected;
         std::vector<aggregate_type> aggregates_expected;
-        size_t unique_count_expected = 0;
+        size_t                      unique_count_expected = 0;
 
-        std::vector<key_type> keys_input(size);
-        key_distribution_type key_delta_dis(1, 5);
+        std::vector<key_type>                 keys_input(size);
+        key_distribution_type                 key_delta_dis(1, 5);
         std::uniform_int_distribution<size_t> key_count_dis(
-            TestFixture::params::min_segment_length,
-            TestFixture::params::max_segment_length
-        );
-        std::vector<value_type> values_input = test_utils::get_random_data<value_type>(size, 0, 100);
+            TestFixture::params::min_segment_length, TestFixture::params::max_segment_length);
+        std::vector<value_type> values_input
+            = test_utils::get_random_data<value_type>(size, 0, 100);
 
-        size_t offset = 0;
+        size_t   offset      = 0;
         key_type current_key = key_distribution_type(0, 100)(gen);
-        key_type prev_key = current_key;
+        key_type prev_key    = current_key;
         while(offset < size)
         {
             const size_t key_count = key_count_dis(gen);
@@ -172,87 +177,70 @@ TYPED_TEST(HipcubDeviceReduceByKey, ReduceByKey)
             offset += key_count;
         }
 
-        key_type * d_keys_input;
-        value_type * d_values_input;
+        key_type*   d_keys_input;
+        value_type* d_values_input;
         HIP_CHECK(hipMalloc(&d_keys_input, size * sizeof(key_type)));
         HIP_CHECK(hipMalloc(&d_values_input, size * sizeof(value_type)));
-        HIP_CHECK(
-            hipMemcpy(
-                d_keys_input, keys_input.data(),
-                size * sizeof(key_type),
-                hipMemcpyHostToDevice
-            )
-        );
-        HIP_CHECK(
-            hipMemcpy(
-                d_values_input, values_input.data(),
-                size * sizeof(value_type),
-                hipMemcpyHostToDevice
-            )
-        );
+        HIP_CHECK(hipMemcpy(
+            d_keys_input, keys_input.data(), size * sizeof(key_type), hipMemcpyHostToDevice));
+        HIP_CHECK(hipMemcpy(
+            d_values_input, values_input.data(), size * sizeof(value_type), hipMemcpyHostToDevice));
 
-        key_type * d_unique_output;
-        aggregate_type * d_aggregates_output;
-        unsigned int * d_unique_count_output;
+        key_type*       d_unique_output;
+        aggregate_type* d_aggregates_output;
+        unsigned int*   d_unique_count_output;
         HIP_CHECK(hipMalloc(&d_unique_output, unique_count_expected * sizeof(key_type)));
         HIP_CHECK(hipMalloc(&d_aggregates_output, unique_count_expected * sizeof(aggregate_type)));
         HIP_CHECK(hipMalloc(&d_unique_count_output, sizeof(unsigned int)));
 
         size_t temporary_storage_bytes = 0;
 
-        HIP_CHECK(
-            hipcub::DeviceReduce::ReduceByKey(
-                nullptr, temporary_storage_bytes,
-                d_keys_input, d_unique_output,
-                d_values_input, d_aggregates_output,
-                d_unique_count_output,
-                reduce_op, size,
-                stream, debug_synchronous
-            )
-        );
+        HIP_CHECK(hipcub::DeviceReduce::ReduceByKey(nullptr,
+                                                    temporary_storage_bytes,
+                                                    d_keys_input,
+                                                    d_unique_output,
+                                                    d_values_input,
+                                                    d_aggregates_output,
+                                                    d_unique_count_output,
+                                                    reduce_op,
+                                                    size,
+                                                    stream,
+                                                    debug_synchronous));
 
         ASSERT_GT(temporary_storage_bytes, 0U);
 
-        void * d_temporary_storage;
+        void* d_temporary_storage;
         HIP_CHECK(hipMalloc(&d_temporary_storage, temporary_storage_bytes));
 
-        HIP_CHECK(
-            hipcub::DeviceReduce::ReduceByKey(
-                d_temporary_storage, temporary_storage_bytes,
-                d_keys_input, d_unique_output,
-                d_values_input, d_aggregates_output,
-                d_unique_count_output,
-                reduce_op, size,
-                stream, debug_synchronous
-            )
-        );
+        HIP_CHECK(hipcub::DeviceReduce::ReduceByKey(d_temporary_storage,
+                                                    temporary_storage_bytes,
+                                                    d_keys_input,
+                                                    d_unique_output,
+                                                    d_values_input,
+                                                    d_aggregates_output,
+                                                    d_unique_count_output,
+                                                    reduce_op,
+                                                    size,
+                                                    stream,
+                                                    debug_synchronous));
 
         HIP_CHECK(hipFree(d_temporary_storage));
 
-        std::vector<key_type> unique_output(unique_count_expected);
+        std::vector<key_type>       unique_output(unique_count_expected);
         std::vector<aggregate_type> aggregates_output(unique_count_expected);
-        std::vector<unsigned int> unique_count_output(1);
-        HIP_CHECK(
-            hipMemcpy(
-                unique_output.data(), d_unique_output,
-                unique_count_expected * sizeof(key_type),
-                hipMemcpyDeviceToHost
-            )
-        );
-        HIP_CHECK(
-            hipMemcpy(
-                aggregates_output.data(), d_aggregates_output,
-                unique_count_expected * sizeof(aggregate_type),
-                hipMemcpyDeviceToHost
-            )
-        );
-        HIP_CHECK(
-            hipMemcpy(
-                unique_count_output.data(), d_unique_count_output,
-                sizeof(unsigned int),
-                hipMemcpyDeviceToHost
-            )
-        );
+        std::vector<unsigned int>   unique_count_output(1);
+        HIP_CHECK(hipMemcpy(unique_output.data(),
+                            d_unique_output,
+                            unique_count_expected * sizeof(key_type),
+                            hipMemcpyDeviceToHost));
+        HIP_CHECK(hipMemcpy(aggregates_output.data(),
+                            d_aggregates_output,
+                            unique_count_expected * sizeof(aggregate_type),
+                            hipMemcpyDeviceToHost));
+        HIP_CHECK(hipMemcpy(unique_count_output.data(),
+                            d_unique_count_output,
+                            sizeof(unsigned int),
+                            hipMemcpyDeviceToHost));
 
         HIP_CHECK(hipFree(d_keys_input));
         HIP_CHECK(hipFree(d_values_input));
@@ -270,11 +258,10 @@ TYPED_TEST(HipcubDeviceReduceByKey, ReduceByKey)
             {
                 ASSERT_EQ(aggregates_output[i], aggregates_expected[i]);
             }
-            else if (std::is_floating_point<aggregate_type>::value)
+            else if(std::is_floating_point<aggregate_type>::value)
             {
-                auto tolerance = std::max<aggregate_type>(
-                    std::abs(0.1f * aggregates_expected[i]), aggregate_type(0.01f)
-                );
+                auto tolerance = std::max<aggregate_type>(std::abs(0.1f * aggregates_expected[i]),
+                                                          aggregate_type(0.01f));
                 ASSERT_NEAR(aggregates_output[i], aggregates_expected[i], tolerance);
             }
         }

--- a/test/hipcub/test_hipcub_device_run_length_encode.cpp
+++ b/test/hipcub/test_hipcub_device_run_length_encode.cpp
@@ -23,7 +23,7 @@
 // CUB's implementation of DeviceRunLengthEncode has unused parameters,
 // disable the warning because all warnings are threated as errors:
 #ifdef __HIP_PLATFORM_NVCC__
-    #pragma GCC diagnostic ignored "-Wunused-parameter"
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 #endif
 
 #include <algorithm>
@@ -31,8 +31,8 @@
 #include <iostream>
 #include <random>
 #include <type_traits>
-#include <vector>
 #include <utility>
+#include <vector>
 
 // Google Test
 #include <gtest/gtest.h>
@@ -45,52 +45,55 @@
 
 #define HIP_CHECK(error) ASSERT_EQ(error, hipSuccess)
 
-template<
-    class Key,
-    class Count,
-    unsigned int MinSegmentLength,
-    unsigned int MaxSegmentLength
->
+template <class Key, class Count, unsigned int MinSegmentLength, unsigned int MaxSegmentLength>
 struct params
 {
-    using key_type = Key;
-    using count_type = Count;
+    using key_type                                   = Key;
+    using count_type                                 = Count;
     static constexpr unsigned int min_segment_length = MinSegmentLength;
     static constexpr unsigned int max_segment_length = MaxSegmentLength;
 };
 
-template<class Params>
-class HipcubDeviceRunLengthEncode : public ::testing::Test {
+template <class Params>
+class HipcubDeviceRunLengthEncode : public ::testing::Test
+{
 public:
     using params = Params;
 };
 
-typedef ::testing::Types<
-    params<int, int, 1, 1>,
-    params<double, int, 3, 5>,
-    params<float, int, 1, 10>,
-    params<unsigned long long, size_t, 1, 30>,
-    params<int, unsigned int, 20, 100>,
-    params<float, unsigned long long, 100, 400>,
-    params<unsigned int, unsigned int, 200, 600>,
-    params<double, int, 100, 2000>,
-    params<int, unsigned int, 1000, 5000>,
-    params<unsigned int, size_t, 2048, 2048>,
-    params<unsigned int, unsigned int, 1000, 50000>,
-    params<unsigned long long, unsigned long long, 100000, 100000>
-> Params;
+typedef ::testing::Types<params<int, int, 1, 1>,
+                         params<double, int, 3, 5>,
+                         params<float, int, 1, 10>,
+                         params<unsigned long long, size_t, 1, 30>,
+                         params<int, unsigned int, 20, 100>,
+                         params<float, unsigned long long, 100, 400>,
+                         params<unsigned int, unsigned int, 200, 600>,
+                         params<double, int, 100, 2000>,
+                         params<int, unsigned int, 1000, 5000>,
+                         params<unsigned int, size_t, 2048, 2048>,
+                         params<unsigned int, unsigned int, 1000, 50000>,
+                         params<unsigned long long, unsigned long long, 100000, 100000>>
+    Params;
 
 TYPED_TEST_CASE(HipcubDeviceRunLengthEncode, Params);
 
 std::vector<size_t> get_sizes()
 {
-    std::vector<size_t> sizes = {
-        1024, 2048, 4096, 1792,
-        1, 10, 53, 211, 500,
-        2345, 11001, 34567,
-        100000,
-        (1 << 16) - 1220, (1 << 21) - 76543
-    };
+    std::vector<size_t>       sizes        = {1024,
+                                 2048,
+                                 4096,
+                                 1792,
+                                 1,
+                                 10,
+                                 53,
+                                 211,
+                                 500,
+                                 2345,
+                                 11001,
+                                 34567,
+                                 100000,
+                                 (1 << 16) - 1220,
+                                 (1 << 21) - 76543};
     const std::vector<size_t> random_sizes = test_utils::get_random_data<size_t>(5, 1, 100000);
     sizes.insert(sizes.end(), random_sizes.begin(), random_sizes.end());
     return sizes;
@@ -98,19 +101,18 @@ std::vector<size_t> get_sizes()
 
 TYPED_TEST(HipcubDeviceRunLengthEncode, Encode)
 {
-    using key_type = typename TestFixture::params::key_type;
+    using key_type   = typename TestFixture::params::key_type;
     using count_type = typename TestFixture::params::count_type;
-    using key_distribution_type = typename std::conditional<
-        std::is_floating_point<key_type>::value,
-        std::uniform_real_distribution<key_type>,
-        std::uniform_int_distribution<key_type>
-    >::type;
+    using key_distribution_type =
+        typename std::conditional<std::is_floating_point<key_type>::value,
+                                  std::uniform_real_distribution<key_type>,
+                                  std::uniform_int_distribution<key_type>>::type;
 
     const bool debug_synchronous = false;
 
     const std::vector<size_t> sizes = get_sizes();
 
-    const unsigned int seed = 123;
+    const unsigned int         seed = 123;
     std::default_random_engine gen(seed);
 
     for(size_t size : sizes)
@@ -120,19 +122,18 @@ TYPED_TEST(HipcubDeviceRunLengthEncode, Encode)
         hipStream_t stream = 0; // default
 
         // Generate data and calculate expected results
-        std::vector<key_type> unique_expected;
+        std::vector<key_type>   unique_expected;
         std::vector<count_type> counts_expected;
-        size_t runs_count_expected = 0;
+        size_t                  runs_count_expected = 0;
 
-        std::vector<key_type> input(size);
-        key_distribution_type key_delta_dis(1, 5);
+        std::vector<key_type>                 input(size);
+        key_distribution_type                 key_delta_dis(1, 5);
         std::uniform_int_distribution<size_t> key_count_dis(
-            TestFixture::params::min_segment_length,
-            TestFixture::params::max_segment_length
-        );
-        std::vector<count_type> values_input = test_utils::get_random_data<count_type>(size, 0, 100);
+            TestFixture::params::min_segment_length, TestFixture::params::max_segment_length);
+        std::vector<count_type> values_input
+            = test_utils::get_random_data<count_type>(size, 0, 100);
 
-        size_t offset = 0;
+        size_t   offset      = 0;
         key_type current_key = key_distribution_type(0, 100)(gen);
         while(offset < size)
         {
@@ -140,7 +141,7 @@ TYPED_TEST(HipcubDeviceRunLengthEncode, Encode)
             current_key += key_delta_dis(gen);
 
             const size_t end = std::min(size, offset + key_count);
-            key_count = end - offset;
+            key_count        = end - offset;
             for(size_t i = offset; i < end; i++)
             {
                 input[i] = current_key;
@@ -153,76 +154,61 @@ TYPED_TEST(HipcubDeviceRunLengthEncode, Encode)
             offset += key_count;
         }
 
-        key_type * d_input;
+        key_type* d_input;
         HIP_CHECK(hipMalloc(&d_input, size * sizeof(key_type)));
-        HIP_CHECK(
-            hipMemcpy(
-                d_input, input.data(),
-                size * sizeof(key_type),
-                hipMemcpyHostToDevice
-            )
-        );
+        HIP_CHECK(hipMemcpy(d_input, input.data(), size * sizeof(key_type), hipMemcpyHostToDevice));
 
-        key_type * d_unique_output;
-        count_type * d_counts_output;
-        count_type * d_runs_count_output;
+        key_type*   d_unique_output;
+        count_type* d_counts_output;
+        count_type* d_runs_count_output;
         HIP_CHECK(hipMalloc(&d_unique_output, runs_count_expected * sizeof(key_type)));
         HIP_CHECK(hipMalloc(&d_counts_output, runs_count_expected * sizeof(count_type)));
         HIP_CHECK(hipMalloc(&d_runs_count_output, sizeof(count_type)));
 
         size_t temporary_storage_bytes = 0;
 
-        HIP_CHECK(
-            hipcub::DeviceRunLengthEncode::Encode(
-                nullptr, temporary_storage_bytes,
-                d_input,
-                d_unique_output, d_counts_output, d_runs_count_output,
-                size,
-                stream, debug_synchronous
-            )
-        );
+        HIP_CHECK(hipcub::DeviceRunLengthEncode::Encode(nullptr,
+                                                        temporary_storage_bytes,
+                                                        d_input,
+                                                        d_unique_output,
+                                                        d_counts_output,
+                                                        d_runs_count_output,
+                                                        size,
+                                                        stream,
+                                                        debug_synchronous));
 
         ASSERT_GT(temporary_storage_bytes, 0U);
 
-        void * d_temporary_storage;
+        void* d_temporary_storage;
         HIP_CHECK(hipMalloc(&d_temporary_storage, temporary_storage_bytes));
 
-        HIP_CHECK(
-            hipcub::DeviceRunLengthEncode::Encode(
-                d_temporary_storage, temporary_storage_bytes,
-                d_input,
-                d_unique_output, d_counts_output, d_runs_count_output,
-                size,
-                stream, debug_synchronous
-            )
-        );
+        HIP_CHECK(hipcub::DeviceRunLengthEncode::Encode(d_temporary_storage,
+                                                        temporary_storage_bytes,
+                                                        d_input,
+                                                        d_unique_output,
+                                                        d_counts_output,
+                                                        d_runs_count_output,
+                                                        size,
+                                                        stream,
+                                                        debug_synchronous));
 
         HIP_CHECK(hipFree(d_temporary_storage));
 
-        std::vector<key_type> unique_output(runs_count_expected);
+        std::vector<key_type>   unique_output(runs_count_expected);
         std::vector<count_type> counts_output(runs_count_expected);
         std::vector<count_type> runs_count_output(1);
-        HIP_CHECK(
-            hipMemcpy(
-                unique_output.data(), d_unique_output,
-                runs_count_expected * sizeof(key_type),
-                hipMemcpyDeviceToHost
-            )
-        );
-        HIP_CHECK(
-            hipMemcpy(
-                counts_output.data(), d_counts_output,
-                runs_count_expected * sizeof(count_type),
-                hipMemcpyDeviceToHost
-            )
-        );
-        HIP_CHECK(
-            hipMemcpy(
-                runs_count_output.data(), d_runs_count_output,
-                sizeof(count_type),
-                hipMemcpyDeviceToHost
-            )
-        );
+        HIP_CHECK(hipMemcpy(unique_output.data(),
+                            d_unique_output,
+                            runs_count_expected * sizeof(key_type),
+                            hipMemcpyDeviceToHost));
+        HIP_CHECK(hipMemcpy(counts_output.data(),
+                            d_counts_output,
+                            runs_count_expected * sizeof(count_type),
+                            hipMemcpyDeviceToHost));
+        HIP_CHECK(hipMemcpy(runs_count_output.data(),
+                            d_runs_count_output,
+                            sizeof(count_type),
+                            hipMemcpyDeviceToHost));
 
         HIP_CHECK(hipFree(d_input));
         HIP_CHECK(hipFree(d_unique_output));
@@ -243,20 +229,19 @@ TYPED_TEST(HipcubDeviceRunLengthEncode, Encode)
 
 TYPED_TEST(HipcubDeviceRunLengthEncode, NonTrivialRuns)
 {
-    using key_type = typename TestFixture::params::key_type;
-    using count_type = typename TestFixture::params::count_type;
+    using key_type    = typename TestFixture::params::key_type;
+    using count_type  = typename TestFixture::params::count_type;
     using offset_type = typename TestFixture::params::count_type;
-    using key_distribution_type = typename std::conditional<
-        std::is_floating_point<key_type>::value,
-        std::uniform_real_distribution<key_type>,
-        std::uniform_int_distribution<key_type>
-    >::type;
+    using key_distribution_type =
+        typename std::conditional<std::is_floating_point<key_type>::value,
+                                  std::uniform_real_distribution<key_type>,
+                                  std::uniform_int_distribution<key_type>>::type;
 
     const bool debug_synchronous = false;
 
     const std::vector<size_t> sizes = get_sizes();
 
-    const unsigned int seed = 123;
+    const unsigned int         seed = 123;
     std::default_random_engine gen(seed);
 
     for(size_t size : sizes)
@@ -267,19 +252,18 @@ TYPED_TEST(HipcubDeviceRunLengthEncode, NonTrivialRuns)
 
         // Generate data and calculate expected results
         std::vector<offset_type> offsets_expected;
-        std::vector<count_type> counts_expected;
-        size_t runs_count_expected = 0;
+        std::vector<count_type>  counts_expected;
+        size_t                   runs_count_expected = 0;
 
-        std::vector<key_type> input(size);
-        key_distribution_type key_delta_dis(1, 5);
+        std::vector<key_type>                 input(size);
+        key_distribution_type                 key_delta_dis(1, 5);
         std::uniform_int_distribution<size_t> key_count_dis(
-            TestFixture::params::min_segment_length,
-            TestFixture::params::max_segment_length
-        );
+            TestFixture::params::min_segment_length, TestFixture::params::max_segment_length);
         std::bernoulli_distribution is_trivial_dis(0.1);
-        std::vector<count_type> values_input = test_utils::get_random_data<count_type>(size, 0, 100);
+        std::vector<count_type>     values_input
+            = test_utils::get_random_data<count_type>(size, 0, 100);
 
-        size_t offset = 0;
+        size_t   offset      = 0;
         key_type current_key = key_distribution_type(0, 100)(gen);
         while(offset < size)
         {
@@ -296,7 +280,7 @@ TYPED_TEST(HipcubDeviceRunLengthEncode, NonTrivialRuns)
             current_key += key_delta_dis(gen);
 
             const size_t end = std::min(size, offset + key_count);
-            key_count = end - offset;
+            key_count        = end - offset;
             for(size_t i = offset; i < end; i++)
             {
                 input[i] = current_key;
@@ -312,79 +296,66 @@ TYPED_TEST(HipcubDeviceRunLengthEncode, NonTrivialRuns)
             offset += key_count;
         }
 
-        key_type * d_input;
+        key_type* d_input;
         HIP_CHECK(hipMalloc(&d_input, size * sizeof(key_type)));
-        HIP_CHECK(
-            hipMemcpy(
-                d_input, input.data(),
-                size * sizeof(key_type),
-                hipMemcpyHostToDevice
-            )
-        );
+        HIP_CHECK(hipMemcpy(d_input, input.data(), size * sizeof(key_type), hipMemcpyHostToDevice));
 
-        offset_type * d_offsets_output;
-        count_type * d_counts_output;
-        count_type * d_runs_count_output;
-        HIP_CHECK(hipMalloc(&d_offsets_output, std::max<size_t>(1, runs_count_expected) * sizeof(offset_type)));
-        HIP_CHECK(hipMalloc(&d_counts_output, std::max<size_t>(1, runs_count_expected) * sizeof(count_type)));
+        offset_type* d_offsets_output;
+        count_type*  d_counts_output;
+        count_type*  d_runs_count_output;
+        HIP_CHECK(hipMalloc(&d_offsets_output,
+                            std::max<size_t>(1, runs_count_expected) * sizeof(offset_type)));
+        HIP_CHECK(hipMalloc(&d_counts_output,
+                            std::max<size_t>(1, runs_count_expected) * sizeof(count_type)));
         HIP_CHECK(hipMalloc(&d_runs_count_output, sizeof(count_type)));
 
         size_t temporary_storage_bytes = 0;
 
-        HIP_CHECK(
-            hipcub::DeviceRunLengthEncode::NonTrivialRuns(
-                nullptr, temporary_storage_bytes,
-                d_input,
-                d_offsets_output, d_counts_output, d_runs_count_output,
-                size,
-                stream, debug_synchronous
-            )
-        );
+        HIP_CHECK(hipcub::DeviceRunLengthEncode::NonTrivialRuns(nullptr,
+                                                                temporary_storage_bytes,
+                                                                d_input,
+                                                                d_offsets_output,
+                                                                d_counts_output,
+                                                                d_runs_count_output,
+                                                                size,
+                                                                stream,
+                                                                debug_synchronous));
 
         ASSERT_GT(temporary_storage_bytes, 0U);
 
-        void * d_temporary_storage;
+        void* d_temporary_storage;
         HIP_CHECK(hipMalloc(&d_temporary_storage, temporary_storage_bytes));
 
-        HIP_CHECK(
-            hipcub::DeviceRunLengthEncode::NonTrivialRuns(
-                d_temporary_storage, temporary_storage_bytes,
-                d_input,
-                d_offsets_output, d_counts_output, d_runs_count_output,
-                size,
-                stream, debug_synchronous
-            )
-        );
+        HIP_CHECK(hipcub::DeviceRunLengthEncode::NonTrivialRuns(d_temporary_storage,
+                                                                temporary_storage_bytes,
+                                                                d_input,
+                                                                d_offsets_output,
+                                                                d_counts_output,
+                                                                d_runs_count_output,
+                                                                size,
+                                                                stream,
+                                                                debug_synchronous));
 
         HIP_CHECK(hipFree(d_temporary_storage));
 
         std::vector<offset_type> offsets_output(runs_count_expected);
-        std::vector<count_type> counts_output(runs_count_expected);
-        std::vector<count_type> runs_count_output(1);
+        std::vector<count_type>  counts_output(runs_count_expected);
+        std::vector<count_type>  runs_count_output(1);
         if(runs_count_expected > 0)
         {
-            HIP_CHECK(
-                hipMemcpy(
-                    offsets_output.data(), d_offsets_output,
-                    runs_count_expected * sizeof(offset_type),
-                    hipMemcpyDeviceToHost
-                )
-            );
-            HIP_CHECK(
-                hipMemcpy(
-                    counts_output.data(), d_counts_output,
-                    runs_count_expected * sizeof(count_type),
-                    hipMemcpyDeviceToHost
-                )
-            );
+            HIP_CHECK(hipMemcpy(offsets_output.data(),
+                                d_offsets_output,
+                                runs_count_expected * sizeof(offset_type),
+                                hipMemcpyDeviceToHost));
+            HIP_CHECK(hipMemcpy(counts_output.data(),
+                                d_counts_output,
+                                runs_count_expected * sizeof(count_type),
+                                hipMemcpyDeviceToHost));
         }
-        HIP_CHECK(
-            hipMemcpy(
-                runs_count_output.data(), d_runs_count_output,
-                sizeof(count_type),
-                hipMemcpyDeviceToHost
-            )
-        );
+        HIP_CHECK(hipMemcpy(runs_count_output.data(),
+                            d_runs_count_output,
+                            sizeof(count_type),
+                            hipMemcpyDeviceToHost));
 
         HIP_CHECK(hipFree(d_input));
         HIP_CHECK(hipFree(d_offsets_output));

--- a/test/hipcub/test_hipcub_device_scan.cpp
+++ b/test/hipcub/test_hipcub_device_scan.cpp
@@ -20,9 +20,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+#include <algorithm>
 #include <iostream>
 #include <vector>
-#include <algorithm>
 
 // Google Test
 #include <gtest/gtest.h>
@@ -36,15 +36,11 @@
 #define HIP_CHECK(error) ASSERT_EQ(error, hipSuccess)
 
 // Params for tests
-template<
-    class InputType,
-    class OutputType = InputType,
-    class ScanOp = hipcub::Sum
->
+template <class InputType, class OutputType = InputType, class ScanOp = hipcub::Sum>
 struct DeviceScanParams
 {
-    using input_type = InputType;
-    using output_type = OutputType;
+    using input_type   = InputType;
+    using output_type  = OutputType;
     using scan_op_type = ScanOp;
 };
 
@@ -52,31 +48,26 @@ struct DeviceScanParams
 // Test for scan ops taking single input value
 // ---------------------------------------------------------
 
-template<class Params>
+template <class Params>
 class HipcubDeviceScanTests : public ::testing::Test
 {
 public:
-    using input_type = typename Params::input_type;
-    using output_type = typename Params::output_type;
-    using scan_op_type = typename Params::scan_op_type;
+    using input_type             = typename Params::input_type;
+    using output_type            = typename Params::output_type;
+    using scan_op_type           = typename Params::scan_op_type;
     const bool debug_synchronous = false;
 };
 
-typedef ::testing::Types<
-    DeviceScanParams<int, long>,
-    DeviceScanParams<unsigned long long, unsigned long long, hipcub::Min>,
-    DeviceScanParams<unsigned long>,
-    DeviceScanParams<short, float, hipcub::Max>,
-    DeviceScanParams<int, double>
-> HipcubDeviceScanTestsParams;
+typedef ::testing::Types<DeviceScanParams<int, long>,
+                         DeviceScanParams<unsigned long long, unsigned long long, hipcub::Min>,
+                         DeviceScanParams<unsigned long>,
+                         DeviceScanParams<short, float, hipcub::Max>,
+                         DeviceScanParams<int, double>>
+    HipcubDeviceScanTestsParams;
 
 std::vector<size_t> get_sizes()
 {
-    std::vector<size_t> sizes = {
-        1, 10, 53, 211,
-        1024, 2048, 5096,
-        34567, (1 << 18) - 1220
-    };
+    std::vector<size_t>       sizes = {1, 10, 53, 211, 1024, 2048, 5096, 34567, (1 << 18) - 1220};
     const std::vector<size_t> random_sizes = test_utils::get_random_data<size_t>(2, 1, 16384);
     sizes.insert(sizes.end(), random_sizes.begin(), random_sizes.end());
     std::sort(sizes.begin(), sizes.end());
@@ -87,9 +78,9 @@ TYPED_TEST_CASE(HipcubDeviceScanTests, HipcubDeviceScanTestsParams);
 
 TYPED_TEST(HipcubDeviceScanTests, InclusiveScan)
 {
-    using T = typename TestFixture::input_type;
-    using U = typename TestFixture::output_type;
-    using scan_op_type = typename TestFixture::scan_op_type;
+    using T                      = typename TestFixture::input_type;
+    using U                      = typename TestFixture::output_type;
+    using scan_op_type           = typename TestFixture::scan_op_type;
     const bool debug_synchronous = TestFixture::debug_synchronous;
 
     const std::vector<size_t> sizes = get_sizes();
@@ -103,17 +94,12 @@ TYPED_TEST(HipcubDeviceScanTests, InclusiveScan)
         std::vector<T> input = test_utils::get_random_data<T>(size, 1, 10);
         std::vector<U> output(input.size(), 0);
 
-        T * d_input;
-        U * d_output;
+        T* d_input;
+        U* d_output;
         HIP_CHECK(hipMalloc(&d_input, input.size() * sizeof(T)));
         HIP_CHECK(hipMalloc(&d_output, output.size() * sizeof(U)));
         HIP_CHECK(
-            hipMemcpy(
-                d_input, input.data(),
-                input.size() * sizeof(T),
-                hipMemcpyHostToDevice
-            )
-        );
+            hipMemcpy(d_input, input.data(), input.size() * sizeof(T), hipMemcpyHostToDevice));
         HIP_CHECK(hipDeviceSynchronize());
 
         // scan function
@@ -121,34 +107,32 @@ TYPED_TEST(HipcubDeviceScanTests, InclusiveScan)
 
         // Calculate expected results on host
         std::vector<U> expected(input.size());
-        test_utils::host_inclusive_scan(
-            input.begin(), input.end(),
-            expected.begin(), scan_op
-        );
+        test_utils::host_inclusive_scan(input.begin(), input.end(), expected.begin(), scan_op);
 
         // temp storage
         size_t temp_storage_size_bytes;
-        void * d_temp_storage = nullptr;
+        void*  d_temp_storage = nullptr;
         // Get size of d_temp_storage
         if(std::is_same<scan_op_type, hipcub::Sum>::value)
         {
-            HIP_CHECK(
-                hipcub::DeviceScan::InclusiveSum(
-                    d_temp_storage, temp_storage_size_bytes,
-                    d_input, d_output, input.size(),
-                    stream, debug_synchronous
-                )
-            );
+            HIP_CHECK(hipcub::DeviceScan::InclusiveSum(d_temp_storage,
+                                                       temp_storage_size_bytes,
+                                                       d_input,
+                                                       d_output,
+                                                       input.size(),
+                                                       stream,
+                                                       debug_synchronous));
         }
         else
         {
-            HIP_CHECK(
-                hipcub::DeviceScan::InclusiveScan(
-                    d_temp_storage, temp_storage_size_bytes,
-                    d_input, d_output, scan_op, input.size(),
-                    stream, debug_synchronous
-                )
-            );
+            HIP_CHECK(hipcub::DeviceScan::InclusiveScan(d_temp_storage,
+                                                        temp_storage_size_bytes,
+                                                        d_input,
+                                                        d_output,
+                                                        scan_op,
+                                                        input.size(),
+                                                        stream,
+                                                        debug_synchronous));
         }
 
         // temp_storage_size_bytes must be >0
@@ -161,42 +145,39 @@ TYPED_TEST(HipcubDeviceScanTests, InclusiveScan)
         // Run
         if(std::is_same<scan_op_type, hipcub::Sum>::value)
         {
-            HIP_CHECK(
-                hipcub::DeviceScan::InclusiveSum(
-                    d_temp_storage, temp_storage_size_bytes,
-                    d_input, d_output, input.size(),
-                    stream, debug_synchronous
-                )
-            );
+            HIP_CHECK(hipcub::DeviceScan::InclusiveSum(d_temp_storage,
+                                                       temp_storage_size_bytes,
+                                                       d_input,
+                                                       d_output,
+                                                       input.size(),
+                                                       stream,
+                                                       debug_synchronous));
         }
         else
         {
-            HIP_CHECK(
-                hipcub::DeviceScan::InclusiveScan(
-                    d_temp_storage, temp_storage_size_bytes,
-                    d_input, d_output, scan_op, input.size(),
-                    stream, debug_synchronous
-                )
-            );
+            HIP_CHECK(hipcub::DeviceScan::InclusiveScan(d_temp_storage,
+                                                        temp_storage_size_bytes,
+                                                        d_input,
+                                                        d_output,
+                                                        scan_op,
+                                                        input.size(),
+                                                        stream,
+                                                        debug_synchronous));
         }
         HIP_CHECK(hipPeekAtLastError());
         HIP_CHECK(hipDeviceSynchronize());
 
         // Copy output to host
         HIP_CHECK(
-            hipMemcpy(
-                output.data(), d_output,
-                output.size() * sizeof(U),
-                hipMemcpyDeviceToHost
-            )
-        );
+            hipMemcpy(output.data(), d_output, output.size() * sizeof(U), hipMemcpyDeviceToHost));
         HIP_CHECK(hipDeviceSynchronize());
 
         // Check if output values are as expected
         for(size_t i = 0; i < output.size(); i++)
         {
             auto diff = std::max<U>(std::abs(0.01f * expected[i]), U(0.01f));
-            if(std::is_integral<U>::value) diff = 0;
+            if(std::is_integral<U>::value)
+                diff = 0;
             ASSERT_NEAR(output[i], expected[i], diff) << "where index = " << i;
         }
 
@@ -208,9 +189,9 @@ TYPED_TEST(HipcubDeviceScanTests, InclusiveScan)
 
 TYPED_TEST(HipcubDeviceScanTests, ExclusiveScan)
 {
-    using T = typename TestFixture::input_type;
-    using U = typename TestFixture::output_type;
-    using scan_op_type = typename TestFixture::scan_op_type;
+    using T                      = typename TestFixture::input_type;
+    using U                      = typename TestFixture::output_type;
+    using scan_op_type           = typename TestFixture::scan_op_type;
     const bool debug_synchronous = TestFixture::debug_synchronous;
 
     const std::vector<size_t> sizes = get_sizes();
@@ -224,17 +205,12 @@ TYPED_TEST(HipcubDeviceScanTests, ExclusiveScan)
         std::vector<T> input = test_utils::get_random_data<T>(size, 1, 10);
         std::vector<U> output(input.size());
 
-        T * d_input;
-        U * d_output;
+        T* d_input;
+        U* d_output;
         HIP_CHECK(hipMalloc(&d_input, input.size() * sizeof(T)));
         HIP_CHECK(hipMalloc(&d_output, output.size() * sizeof(U)));
         HIP_CHECK(
-            hipMemcpy(
-                d_input, input.data(),
-                input.size() * sizeof(T),
-                hipMemcpyHostToDevice
-            )
-        );
+            hipMemcpy(d_input, input.data(), input.size() * sizeof(T), hipMemcpyHostToDevice));
         HIP_CHECK(hipDeviceSynchronize());
 
         // scan function
@@ -242,39 +218,37 @@ TYPED_TEST(HipcubDeviceScanTests, ExclusiveScan)
 
         // Calculate expected results on host
         std::vector<U> expected(input.size());
-        const T initial_value =
-            std::is_same<scan_op_type, hipcub::Sum>::value
-            ? T(0)
-            : test_utils::get_random_value<T>(1, 100);
+        const T        initial_value = std::is_same<scan_op_type, hipcub::Sum>::value
+                                    ? T(0)
+                                    : test_utils::get_random_value<T>(1, 100);
         test_utils::host_exclusive_scan(
-            input.begin(), input.end(),
-            initial_value, expected.begin(),
-            scan_op
-        );
+            input.begin(), input.end(), initial_value, expected.begin(), scan_op);
 
         // temp storage
         size_t temp_storage_size_bytes;
-        void * d_temp_storage = nullptr;
+        void*  d_temp_storage = nullptr;
         // Get size of d_temp_storage
         if(std::is_same<scan_op_type, hipcub::Sum>::value)
         {
-            HIP_CHECK(
-                hipcub::DeviceScan::ExclusiveSum(
-                    d_temp_storage, temp_storage_size_bytes,
-                    d_input, d_output, input.size(),
-                    stream, debug_synchronous
-                )
-            );
+            HIP_CHECK(hipcub::DeviceScan::ExclusiveSum(d_temp_storage,
+                                                       temp_storage_size_bytes,
+                                                       d_input,
+                                                       d_output,
+                                                       input.size(),
+                                                       stream,
+                                                       debug_synchronous));
         }
         else
         {
-            HIP_CHECK(
-                hipcub::DeviceScan::ExclusiveScan(
-                    d_temp_storage, temp_storage_size_bytes,
-                    d_input, d_output, scan_op, initial_value, input.size(),
-                    stream, debug_synchronous
-                )
-            );
+            HIP_CHECK(hipcub::DeviceScan::ExclusiveScan(d_temp_storage,
+                                                        temp_storage_size_bytes,
+                                                        d_input,
+                                                        d_output,
+                                                        scan_op,
+                                                        initial_value,
+                                                        input.size(),
+                                                        stream,
+                                                        debug_synchronous));
         }
 
         // temp_storage_size_bytes must be >0
@@ -287,42 +261,40 @@ TYPED_TEST(HipcubDeviceScanTests, ExclusiveScan)
         // Run
         if(std::is_same<scan_op_type, hipcub::Sum>::value)
         {
-            HIP_CHECK(
-                hipcub::DeviceScan::ExclusiveSum(
-                    d_temp_storage, temp_storage_size_bytes,
-                    d_input, d_output, input.size(),
-                    stream, debug_synchronous
-                )
-            );
+            HIP_CHECK(hipcub::DeviceScan::ExclusiveSum(d_temp_storage,
+                                                       temp_storage_size_bytes,
+                                                       d_input,
+                                                       d_output,
+                                                       input.size(),
+                                                       stream,
+                                                       debug_synchronous));
         }
         else
         {
-            HIP_CHECK(
-                hipcub::DeviceScan::ExclusiveScan(
-                    d_temp_storage, temp_storage_size_bytes,
-                    d_input, d_output, scan_op, initial_value, input.size(),
-                    stream, debug_synchronous
-                )
-            );
+            HIP_CHECK(hipcub::DeviceScan::ExclusiveScan(d_temp_storage,
+                                                        temp_storage_size_bytes,
+                                                        d_input,
+                                                        d_output,
+                                                        scan_op,
+                                                        initial_value,
+                                                        input.size(),
+                                                        stream,
+                                                        debug_synchronous));
         }
         HIP_CHECK(hipPeekAtLastError());
         HIP_CHECK(hipDeviceSynchronize());
 
         // Copy output to host
         HIP_CHECK(
-            hipMemcpy(
-                output.data(), d_output,
-                output.size() * sizeof(U),
-                hipMemcpyDeviceToHost
-            )
-        );
+            hipMemcpy(output.data(), d_output, output.size() * sizeof(U), hipMemcpyDeviceToHost));
         HIP_CHECK(hipDeviceSynchronize());
 
         // Check if output values are as expected
         for(size_t i = 0; i < output.size(); i++)
         {
             auto diff = std::max<U>(std::abs(0.01f * expected[i]), U(0.01f));
-            if(std::is_integral<U>::value) diff = 0;
+            if(std::is_integral<U>::value)
+                diff = 0;
             ASSERT_NEAR(output[i], expected[i], diff) << "where index = " << i;
         }
 

--- a/test/hipcub/test_hipcub_device_segmented_reduce.cpp
+++ b/test/hipcub/test_hipcub_device_segmented_reduce.cpp
@@ -26,8 +26,8 @@
 #include <limits>
 #include <random>
 #include <type_traits>
-#include <vector>
 #include <utility>
+#include <vector>
 
 // Google Test
 #include <gtest/gtest.h>
@@ -41,73 +41,65 @@
 std::vector<size_t> get_sizes()
 {
     std::vector<size_t> sizes = {
-        1024, 2048, 4096, 1792,
-        1, 10, 53, 211, 500,
-        2345, 11001, 34567,
-        100000,
-        (1 << 16) - 1220
-    };
+        1024, 2048, 4096, 1792, 1, 10, 53, 211, 500, 2345, 11001, 34567, 100000, (1 << 16) - 1220};
     const std::vector<size_t> random_sizes = test_utils::get_random_data<size_t>(5, 1, 1000000);
     sizes.insert(sizes.end(), random_sizes.begin(), random_sizes.end());
     return sizes;
 }
 
-template<
-    class Input,
-    class Output,
-    class ReduceOp = hipcub::Sum,
-    int Init = 0, // as only integral types supported, int is used here even for floating point inputs
-    unsigned int MinSegmentLength = 0,
-    unsigned int MaxSegmentLength = 1000
->
+template <class Input,
+          class Output,
+          class ReduceOp = hipcub::Sum,
+          int Init
+          = 0, // as only integral types supported, int is used here even for floating point inputs
+          unsigned int MinSegmentLength = 0,
+          unsigned int MaxSegmentLength = 1000>
 struct params1
 {
-    using input_type = Input;
-    using output_type = Output;
-    using reduce_op_type = ReduceOp;
-    static constexpr input_type init = Init;
+    using input_type                                 = Input;
+    using output_type                                = Output;
+    using reduce_op_type                             = ReduceOp;
+    static constexpr input_type   init               = Init;
     static constexpr unsigned int min_segment_length = MinSegmentLength;
     static constexpr unsigned int max_segment_length = MaxSegmentLength;
 };
 
-template<class Params>
-class HipcubDeviceSegmentedReduceOp : public ::testing::Test {
+template <class Params>
+class HipcubDeviceSegmentedReduceOp : public ::testing::Test
+{
 public:
     using params = Params;
 };
 
-typedef ::testing::Types<
-    params1<unsigned int, unsigned int, hipcub::Sum>,
-    params1<int, int, hipcub::Sum, -100, 0, 10000>,
-    params1<double, double, hipcub::Min, 1000, 0, 10000>,
-    params1<int, short, hipcub::Max, 10, 1000, 10000>,
-    params1<short, double, hipcub::Sum, 5, 1, 1000>,
-    params1<float, double, hipcub::Max, 50, 2, 10>,
-    params1<float, float, hipcub::Sum, 123, 100, 200>
-> Params1;
+typedef ::testing::Types<params1<unsigned int, unsigned int, hipcub::Sum>,
+                         params1<int, int, hipcub::Sum, -100, 0, 10000>,
+                         params1<double, double, hipcub::Min, 1000, 0, 10000>,
+                         params1<int, short, hipcub::Max, 10, 1000, 10000>,
+                         params1<short, double, hipcub::Sum, 5, 1, 1000>,
+                         params1<float, double, hipcub::Max, 50, 2, 10>,
+                         params1<float, float, hipcub::Sum, 123, 100, 200>>
+    Params1;
 
 TYPED_TEST_CASE(HipcubDeviceSegmentedReduceOp, Params1);
 
 TYPED_TEST(HipcubDeviceSegmentedReduceOp, Reduce)
 {
-    using input_type = typename TestFixture::params::input_type;
-    using output_type = typename TestFixture::params::output_type;
+    using input_type     = typename TestFixture::params::input_type;
+    using output_type    = typename TestFixture::params::output_type;
     using reduce_op_type = typename TestFixture::params::reduce_op_type;
 
     using result_type = output_type;
     using offset_type = unsigned int;
 
-    constexpr input_type init = TestFixture::params::init;
-    const bool debug_synchronous = false;
-    reduce_op_type reduce_op;
+    constexpr input_type init              = TestFixture::params::init;
+    const bool           debug_synchronous = false;
+    reduce_op_type       reduce_op;
 
-    std::random_device rd;
+    std::random_device         rd;
     std::default_random_engine gen(rd());
 
     std::uniform_int_distribution<size_t> segment_length_dis(
-        TestFixture::params::min_segment_length,
-        TestFixture::params::max_segment_length
-    );
+        TestFixture::params::min_segment_length, TestFixture::params::max_segment_length);
 
     const std::vector<size_t> sizes = get_sizes();
     for(size_t size : sizes)
@@ -119,18 +111,19 @@ TYPED_TEST(HipcubDeviceSegmentedReduceOp, Reduce)
         // Generate data and calculate expected results
         std::vector<output_type> aggregates_expected;
 
-        std::vector<input_type> values_input = test_utils::get_random_data<input_type>(size, 0, 100);
+        std::vector<input_type> values_input
+            = test_utils::get_random_data<input_type>(size, 0, 100);
 
         std::vector<offset_type> offsets;
-        unsigned int segments_count = 0;
-        size_t offset = 0;
+        unsigned int             segments_count = 0;
+        size_t                   offset         = 0;
         while(offset < size)
         {
             const size_t segment_length = segment_length_dis(gen);
             offsets.push_back(offset);
 
-            const size_t end = std::min(size, offset + segment_length);
-            result_type aggregate = init;
+            const size_t end       = std::min(size, offset + segment_length);
+            result_type  aggregate = init;
             for(size_t i = offset; i < end; i++)
             {
                 aggregate = reduce_op(aggregate, static_cast<result_type>(values_input[i]));
@@ -142,68 +135,59 @@ TYPED_TEST(HipcubDeviceSegmentedReduceOp, Reduce)
         }
         offsets.push_back(size);
 
-        input_type * d_values_input;
+        input_type* d_values_input;
         HIP_CHECK(hipMalloc(&d_values_input, size * sizeof(input_type)));
-        HIP_CHECK(
-            hipMemcpy(
-                d_values_input, values_input.data(),
-                size * sizeof(input_type),
-                hipMemcpyHostToDevice
-            )
-        );
+        HIP_CHECK(hipMemcpy(
+            d_values_input, values_input.data(), size * sizeof(input_type), hipMemcpyHostToDevice));
 
-        offset_type * d_offsets;
+        offset_type* d_offsets;
         HIP_CHECK(hipMalloc(&d_offsets, (segments_count + 1) * sizeof(offset_type)));
-        HIP_CHECK(
-            hipMemcpy(
-                d_offsets, offsets.data(),
-                (segments_count + 1) * sizeof(offset_type),
-                hipMemcpyHostToDevice
-            )
-        );
+        HIP_CHECK(hipMemcpy(d_offsets,
+                            offsets.data(),
+                            (segments_count + 1) * sizeof(offset_type),
+                            hipMemcpyHostToDevice));
 
-        output_type * d_aggregates_output;
+        output_type* d_aggregates_output;
         HIP_CHECK(hipMalloc(&d_aggregates_output, segments_count * sizeof(output_type)));
 
         size_t temporary_storage_bytes;
 
-        HIP_CHECK(
-            hipcub::DeviceSegmentedReduce::Reduce(
-                nullptr, temporary_storage_bytes,
-                d_values_input, d_aggregates_output,
-                segments_count,
-                d_offsets, d_offsets + 1,
-                reduce_op, init,
-                stream, debug_synchronous
-            )
-        );
+        HIP_CHECK(hipcub::DeviceSegmentedReduce::Reduce(nullptr,
+                                                        temporary_storage_bytes,
+                                                        d_values_input,
+                                                        d_aggregates_output,
+                                                        segments_count,
+                                                        d_offsets,
+                                                        d_offsets + 1,
+                                                        reduce_op,
+                                                        init,
+                                                        stream,
+                                                        debug_synchronous));
 
         ASSERT_GT(temporary_storage_bytes, 0U);
 
-        void * d_temporary_storage;
+        void* d_temporary_storage;
         HIP_CHECK(hipMalloc(&d_temporary_storage, temporary_storage_bytes));
 
-        HIP_CHECK(
-            hipcub::DeviceSegmentedReduce::Reduce(
-                d_temporary_storage, temporary_storage_bytes,
-                d_values_input, d_aggregates_output,
-                segments_count,
-                d_offsets, d_offsets + 1,
-                reduce_op, init,
-                stream, debug_synchronous
-            )
-        );
+        HIP_CHECK(hipcub::DeviceSegmentedReduce::Reduce(d_temporary_storage,
+                                                        temporary_storage_bytes,
+                                                        d_values_input,
+                                                        d_aggregates_output,
+                                                        segments_count,
+                                                        d_offsets,
+                                                        d_offsets + 1,
+                                                        reduce_op,
+                                                        init,
+                                                        stream,
+                                                        debug_synchronous));
 
         HIP_CHECK(hipFree(d_temporary_storage));
 
         std::vector<output_type> aggregates_output(segments_count);
-        HIP_CHECK(
-            hipMemcpy(
-                aggregates_output.data(), d_aggregates_output,
-                segments_count * sizeof(output_type),
-                hipMemcpyDeviceToHost
-            )
-        );
+        HIP_CHECK(hipMemcpy(aggregates_output.data(),
+                            d_aggregates_output,
+                            segments_count * sizeof(output_type),
+                            hipMemcpyDeviceToHost));
 
         HIP_CHECK(hipFree(d_values_input));
         HIP_CHECK(hipFree(d_offsets));
@@ -217,66 +201,60 @@ TYPED_TEST(HipcubDeviceSegmentedReduceOp, Reduce)
             }
             else
             {
-                auto diff = std::max<output_type>(
-                    std::abs(0.01 * aggregates_expected[i]), output_type(0.01)
-                );
+                auto diff = std::max<output_type>(std::abs(0.01 * aggregates_expected[i]),
+                                                  output_type(0.01));
                 ASSERT_NEAR(aggregates_output[i], aggregates_expected[i], diff);
             }
         }
     }
 }
 
-template<
-    class Input,
-    class Output,
-    unsigned int MinSegmentLength = 0,
-    unsigned int MaxSegmentLength = 1000
->
+template <class Input,
+          class Output,
+          unsigned int MinSegmentLength = 0,
+          unsigned int MaxSegmentLength = 1000>
 struct params2
 {
-    using input_type = Input;
-    using output_type = Output;
+    using input_type                                 = Input;
+    using output_type                                = Output;
     static constexpr unsigned int min_segment_length = MinSegmentLength;
     static constexpr unsigned int max_segment_length = MaxSegmentLength;
 };
 
-template<class Params>
-class HipcubDeviceSegmentedReduce : public ::testing::Test {
+template <class Params>
+class HipcubDeviceSegmentedReduce : public ::testing::Test
+{
 public:
     using params = Params;
 };
 
-typedef ::testing::Types<
-    params2<unsigned int, unsigned int>,
-    params2<int, int, 0, 10000>,
-    params2<double, double, 0, 10000>,
-    params2<int, long long, 1000, 10000>,
-    params2<float, double, 2, 10>,
-    params2<float, float, 100, 200>
-> Params2;
+typedef ::testing::Types<params2<unsigned int, unsigned int>,
+                         params2<int, int, 0, 10000>,
+                         params2<double, double, 0, 10000>,
+                         params2<int, long long, 1000, 10000>,
+                         params2<float, double, 2, 10>,
+                         params2<float, float, 100, 200>>
+    Params2;
 
 TYPED_TEST_CASE(HipcubDeviceSegmentedReduce, Params2);
 
 TYPED_TEST(HipcubDeviceSegmentedReduce, Sum)
 {
-    using input_type = typename TestFixture::params::input_type;
-    using output_type = typename TestFixture::params::output_type;
+    using input_type     = typename TestFixture::params::input_type;
+    using output_type    = typename TestFixture::params::output_type;
     using reduce_op_type = typename hipcub::Sum;
-    using result_type = output_type;
-    using offset_type = unsigned int;
+    using result_type    = output_type;
+    using offset_type    = unsigned int;
 
-    constexpr input_type init = input_type(0);
-    const bool debug_synchronous = false;
-    reduce_op_type reduce_op;
+    constexpr input_type init              = input_type(0);
+    const bool           debug_synchronous = false;
+    reduce_op_type       reduce_op;
 
-
-    std::random_device rd;
+    std::random_device         rd;
     std::default_random_engine gen(rd());
 
     std::uniform_int_distribution<size_t> segment_length_dis(
-        TestFixture::params::min_segment_length,
-        TestFixture::params::max_segment_length
-    );
+        TestFixture::params::min_segment_length, TestFixture::params::max_segment_length);
 
     const std::vector<size_t> sizes = get_sizes();
     for(size_t size : sizes)
@@ -288,18 +266,19 @@ TYPED_TEST(HipcubDeviceSegmentedReduce, Sum)
         // Generate data and calculate expected results
         std::vector<output_type> aggregates_expected;
 
-        std::vector<input_type> values_input = test_utils::get_random_data<input_type>(size, 0, 100);
+        std::vector<input_type> values_input
+            = test_utils::get_random_data<input_type>(size, 0, 100);
 
         std::vector<offset_type> offsets;
-        unsigned int segments_count = 0;
-        size_t offset = 0;
+        unsigned int             segments_count = 0;
+        size_t                   offset         = 0;
         while(offset < size)
         {
             const size_t segment_length = segment_length_dis(gen);
             offsets.push_back(offset);
 
-            const size_t end = std::min(size, offset + segment_length);
-            result_type aggregate = init;
+            const size_t end       = std::min(size, offset + segment_length);
+            result_type  aggregate = init;
             for(size_t i = offset; i < end; i++)
             {
                 aggregate = reduce_op(aggregate, static_cast<result_type>(values_input[i]));
@@ -311,66 +290,55 @@ TYPED_TEST(HipcubDeviceSegmentedReduce, Sum)
         }
         offsets.push_back(size);
 
-        input_type * d_values_input;
+        input_type* d_values_input;
         HIP_CHECK(hipMalloc(&d_values_input, size * sizeof(input_type)));
-        HIP_CHECK(
-            hipMemcpy(
-                d_values_input, values_input.data(),
-                size * sizeof(input_type),
-                hipMemcpyHostToDevice
-            )
-        );
+        HIP_CHECK(hipMemcpy(
+            d_values_input, values_input.data(), size * sizeof(input_type), hipMemcpyHostToDevice));
 
-        offset_type * d_offsets;
+        offset_type* d_offsets;
         HIP_CHECK(hipMalloc(&d_offsets, (segments_count + 1) * sizeof(offset_type)));
-        HIP_CHECK(
-            hipMemcpy(
-                d_offsets, offsets.data(),
-                (segments_count + 1) * sizeof(offset_type),
-                hipMemcpyHostToDevice
-            )
-        );
+        HIP_CHECK(hipMemcpy(d_offsets,
+                            offsets.data(),
+                            (segments_count + 1) * sizeof(offset_type),
+                            hipMemcpyHostToDevice));
 
-        output_type * d_aggregates_output;
+        output_type* d_aggregates_output;
         HIP_CHECK(hipMalloc(&d_aggregates_output, segments_count * sizeof(output_type)));
 
         size_t temporary_storage_bytes;
 
-        HIP_CHECK(
-            hipcub::DeviceSegmentedReduce::Sum(
-                nullptr, temporary_storage_bytes,
-                d_values_input, d_aggregates_output,
-                segments_count,
-                d_offsets, d_offsets + 1,
-                stream, debug_synchronous
-            )
-        );
+        HIP_CHECK(hipcub::DeviceSegmentedReduce::Sum(nullptr,
+                                                     temporary_storage_bytes,
+                                                     d_values_input,
+                                                     d_aggregates_output,
+                                                     segments_count,
+                                                     d_offsets,
+                                                     d_offsets + 1,
+                                                     stream,
+                                                     debug_synchronous));
 
         ASSERT_GT(temporary_storage_bytes, 0U);
 
-        void * d_temporary_storage;
+        void* d_temporary_storage;
         HIP_CHECK(hipMalloc(&d_temporary_storage, temporary_storage_bytes));
 
-        HIP_CHECK(
-            hipcub::DeviceSegmentedReduce::Sum(
-                d_temporary_storage, temporary_storage_bytes,
-                d_values_input, d_aggregates_output,
-                segments_count,
-                d_offsets, d_offsets + 1,
-                stream, debug_synchronous
-            )
-        );
+        HIP_CHECK(hipcub::DeviceSegmentedReduce::Sum(d_temporary_storage,
+                                                     temporary_storage_bytes,
+                                                     d_values_input,
+                                                     d_aggregates_output,
+                                                     segments_count,
+                                                     d_offsets,
+                                                     d_offsets + 1,
+                                                     stream,
+                                                     debug_synchronous));
 
         HIP_CHECK(hipFree(d_temporary_storage));
 
         std::vector<output_type> aggregates_output(segments_count);
-        HIP_CHECK(
-            hipMemcpy(
-                aggregates_output.data(), d_aggregates_output,
-                segments_count * sizeof(output_type),
-                hipMemcpyDeviceToHost
-            )
-        );
+        HIP_CHECK(hipMemcpy(aggregates_output.data(),
+                            d_aggregates_output,
+                            segments_count * sizeof(output_type),
+                            hipMemcpyDeviceToHost));
 
         HIP_CHECK(hipFree(d_values_input));
         HIP_CHECK(hipFree(d_offsets));
@@ -384,9 +352,8 @@ TYPED_TEST(HipcubDeviceSegmentedReduce, Sum)
             }
             else
             {
-                auto diff = std::max<output_type>(
-                    std::abs(0.01 * aggregates_expected[i]), output_type(0.01)
-                );
+                auto diff = std::max<output_type>(std::abs(0.01 * aggregates_expected[i]),
+                                                  output_type(0.01));
                 ASSERT_NEAR(aggregates_output[i], aggregates_expected[i], diff);
             }
         }
@@ -395,23 +362,21 @@ TYPED_TEST(HipcubDeviceSegmentedReduce, Sum)
 
 TYPED_TEST(HipcubDeviceSegmentedReduce, Min)
 {
-    using input_type = typename TestFixture::params::input_type;
-    using output_type = typename TestFixture::params::output_type;
+    using input_type     = typename TestFixture::params::input_type;
+    using output_type    = typename TestFixture::params::output_type;
     using reduce_op_type = typename hipcub::Min;
-    using result_type = output_type;
-    using offset_type = unsigned int;
+    using result_type    = output_type;
+    using offset_type    = unsigned int;
 
-    constexpr input_type init = std::numeric_limits<input_type>::max();
-    const bool debug_synchronous = false;
-    reduce_op_type reduce_op;
+    constexpr input_type init              = std::numeric_limits<input_type>::max();
+    const bool           debug_synchronous = false;
+    reduce_op_type       reduce_op;
 
-    std::random_device rd;
+    std::random_device         rd;
     std::default_random_engine gen(rd());
 
     std::uniform_int_distribution<size_t> segment_length_dis(
-        TestFixture::params::min_segment_length,
-        TestFixture::params::max_segment_length
-    );
+        TestFixture::params::min_segment_length, TestFixture::params::max_segment_length);
 
     const std::vector<size_t> sizes = get_sizes();
     for(size_t size : sizes)
@@ -423,18 +388,19 @@ TYPED_TEST(HipcubDeviceSegmentedReduce, Min)
         // Generate data and calculate expected results
         std::vector<output_type> aggregates_expected;
 
-        std::vector<input_type> values_input = test_utils::get_random_data<input_type>(size, 0, 100);
+        std::vector<input_type> values_input
+            = test_utils::get_random_data<input_type>(size, 0, 100);
 
         std::vector<offset_type> offsets;
-        unsigned int segments_count = 0;
-        size_t offset = 0;
+        unsigned int             segments_count = 0;
+        size_t                   offset         = 0;
         while(offset < size)
         {
             const size_t segment_length = segment_length_dis(gen);
             offsets.push_back(offset);
 
-            const size_t end = std::min(size, offset + segment_length);
-            result_type aggregate = init;
+            const size_t end       = std::min(size, offset + segment_length);
+            result_type  aggregate = init;
             for(size_t i = offset; i < end; i++)
             {
                 aggregate = reduce_op(aggregate, static_cast<result_type>(values_input[i]));
@@ -446,66 +412,55 @@ TYPED_TEST(HipcubDeviceSegmentedReduce, Min)
         }
         offsets.push_back(size);
 
-        input_type * d_values_input;
+        input_type* d_values_input;
         HIP_CHECK(hipMalloc(&d_values_input, size * sizeof(input_type)));
-        HIP_CHECK(
-            hipMemcpy(
-                d_values_input, values_input.data(),
-                size * sizeof(input_type),
-                hipMemcpyHostToDevice
-            )
-        );
+        HIP_CHECK(hipMemcpy(
+            d_values_input, values_input.data(), size * sizeof(input_type), hipMemcpyHostToDevice));
 
-        offset_type * d_offsets;
+        offset_type* d_offsets;
         HIP_CHECK(hipMalloc(&d_offsets, (segments_count + 1) * sizeof(offset_type)));
-        HIP_CHECK(
-            hipMemcpy(
-                d_offsets, offsets.data(),
-                (segments_count + 1) * sizeof(offset_type),
-                hipMemcpyHostToDevice
-            )
-        );
+        HIP_CHECK(hipMemcpy(d_offsets,
+                            offsets.data(),
+                            (segments_count + 1) * sizeof(offset_type),
+                            hipMemcpyHostToDevice));
 
-        output_type * d_aggregates_output;
+        output_type* d_aggregates_output;
         HIP_CHECK(hipMalloc(&d_aggregates_output, segments_count * sizeof(output_type)));
 
         size_t temporary_storage_bytes;
 
-        HIP_CHECK(
-            hipcub::DeviceSegmentedReduce::Min(
-                nullptr, temporary_storage_bytes,
-                d_values_input, d_aggregates_output,
-                segments_count,
-                d_offsets, d_offsets + 1,
-                stream, debug_synchronous
-            )
-        );
+        HIP_CHECK(hipcub::DeviceSegmentedReduce::Min(nullptr,
+                                                     temporary_storage_bytes,
+                                                     d_values_input,
+                                                     d_aggregates_output,
+                                                     segments_count,
+                                                     d_offsets,
+                                                     d_offsets + 1,
+                                                     stream,
+                                                     debug_synchronous));
 
         ASSERT_GT(temporary_storage_bytes, 0U);
 
-        void * d_temporary_storage;
+        void* d_temporary_storage;
         HIP_CHECK(hipMalloc(&d_temporary_storage, temporary_storage_bytes));
 
-        HIP_CHECK(
-            hipcub::DeviceSegmentedReduce::Min(
-                d_temporary_storage, temporary_storage_bytes,
-                d_values_input, d_aggregates_output,
-                segments_count,
-                d_offsets, d_offsets + 1,
-                stream, debug_synchronous
-            )
-        );
+        HIP_CHECK(hipcub::DeviceSegmentedReduce::Min(d_temporary_storage,
+                                                     temporary_storage_bytes,
+                                                     d_values_input,
+                                                     d_aggregates_output,
+                                                     segments_count,
+                                                     d_offsets,
+                                                     d_offsets + 1,
+                                                     stream,
+                                                     debug_synchronous));
 
         HIP_CHECK(hipFree(d_temporary_storage));
 
         std::vector<output_type> aggregates_output(segments_count);
-        HIP_CHECK(
-            hipMemcpy(
-                aggregates_output.data(), d_aggregates_output,
-                segments_count * sizeof(output_type),
-                hipMemcpyDeviceToHost
-            )
-        );
+        HIP_CHECK(hipMemcpy(aggregates_output.data(),
+                            d_aggregates_output,
+                            segments_count * sizeof(output_type),
+                            hipMemcpyDeviceToHost));
 
         HIP_CHECK(hipFree(d_values_input));
         HIP_CHECK(hipFree(d_offsets));

--- a/test/hipcub/test_hipcub_device_select.cpp
+++ b/test/hipcub/test_hipcub_device_select.cpp
@@ -20,9 +20,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+#include <algorithm>
 #include <iostream>
 #include <vector>
-#include <algorithm>
 
 // Google Test
 #include <gtest/gtest.h>
@@ -37,41 +37,30 @@
 #define HIP_CHECK(error) ASSERT_EQ(static_cast<hipError_t>(error), hipSuccess)
 
 // Params for tests
-template<
-    class InputType,
-    class OutputType = InputType,
-    class FlagType = unsigned int
->
+template <class InputType, class OutputType = InputType, class FlagType = unsigned int>
 struct DeviceSelectParams
 {
-    using input_type = InputType;
+    using input_type  = InputType;
     using output_type = OutputType;
-    using flag_type = FlagType;
+    using flag_type   = FlagType;
 };
 
-template<class Params>
+template <class Params>
 class HipcubDeviceSelectTests : public ::testing::Test
 {
 public:
-    using input_type = typename Params::input_type;
-    using output_type = typename Params::output_type;
-    using flag_type = typename Params::flag_type;
+    using input_type             = typename Params::input_type;
+    using output_type            = typename Params::output_type;
+    using flag_type              = typename Params::flag_type;
     const bool debug_synchronous = false;
 };
 
-typedef ::testing::Types<
-    DeviceSelectParams<int, long>,
-    DeviceSelectParams<unsigned char, float>
-> HipcubDeviceSelectTestsParams;
+typedef ::testing::Types<DeviceSelectParams<int, long>, DeviceSelectParams<unsigned char, float>>
+    HipcubDeviceSelectTestsParams;
 
 std::vector<size_t> get_sizes()
 {
-    std::vector<size_t> sizes = {
-        2, 32, 64, 256,
-        1024, 2048,
-        3072, 4096,
-        27845, (1 << 18) + 1111
-    };
+    std::vector<size_t> sizes = {2, 32, 64, 256, 1024, 2048, 3072, 4096, 27845, (1 << 18) + 1111};
     const std::vector<size_t> random_sizes = test_utils::get_random_data<size_t>(2, 1, 16384);
     sizes.insert(sizes.end(), random_sizes.begin(), random_sizes.end());
     std::sort(sizes.begin(), sizes.end());
@@ -82,9 +71,9 @@ TYPED_TEST_CASE(HipcubDeviceSelectTests, HipcubDeviceSelectTestsParams);
 
 TYPED_TEST(HipcubDeviceSelectTests, Flagged)
 {
-    using T = typename TestFixture::input_type;
-    using U = typename TestFixture::output_type;
-    using F = typename TestFixture::flag_type;
+    using T                      = typename TestFixture::input_type;
+    using U                      = typename TestFixture::output_type;
+    using F                      = typename TestFixture::flag_type;
     const bool debug_synchronous = TestFixture::debug_synchronous;
 
     hipStream_t stream = 0; // default stream
@@ -98,28 +87,18 @@ TYPED_TEST(HipcubDeviceSelectTests, Flagged)
         std::vector<T> input = test_utils::get_random_data<T>(size, 1, 100);
         std::vector<F> flags = test_utils::get_random_data<F>(size, 0, 1);
 
-        T * d_input;
-        F * d_flags;
-        U * d_output;
-        unsigned int * d_selected_count_output;
+        T*            d_input;
+        F*            d_flags;
+        U*            d_output;
+        unsigned int* d_selected_count_output;
         HIP_CHECK(hipMalloc(&d_input, input.size() * sizeof(T)));
         HIP_CHECK(hipMalloc(&d_flags, flags.size() * sizeof(F)));
         HIP_CHECK(hipMalloc(&d_output, input.size() * sizeof(U)));
         HIP_CHECK(hipMalloc(&d_selected_count_output, sizeof(unsigned int)));
         HIP_CHECK(
-            hipMemcpy(
-                d_input, input.data(),
-                input.size() * sizeof(T),
-                hipMemcpyHostToDevice
-            )
-        );
+            hipMemcpy(d_input, input.data(), input.size() * sizeof(T), hipMemcpyHostToDevice));
         HIP_CHECK(
-            hipMemcpy(
-                d_flags, flags.data(),
-                flags.size() * sizeof(F),
-                hipMemcpyHostToDevice
-            )
-        );
+            hipMemcpy(d_flags, flags.data(), flags.size() * sizeof(F), hipMemcpyHostToDevice));
         HIP_CHECK(hipDeviceSynchronize());
 
         // Calculate expected results on host
@@ -136,66 +115,50 @@ TYPED_TEST(HipcubDeviceSelectTests, Flagged)
         // temp storage
         size_t temp_storage_size_bytes;
         // Get size of d_temp_storage
-        HIP_CHECK(
-            hipcub::DeviceSelect::Flagged(
-                nullptr,
-                temp_storage_size_bytes,
-                d_input,
-                d_flags,
-                d_output,
-                d_selected_count_output,
-                input.size(),
-                stream,
-                debug_synchronous
-            )
-        );
+        HIP_CHECK(hipcub::DeviceSelect::Flagged(nullptr,
+                                                temp_storage_size_bytes,
+                                                d_input,
+                                                d_flags,
+                                                d_output,
+                                                d_selected_count_output,
+                                                input.size(),
+                                                stream,
+                                                debug_synchronous));
         HIP_CHECK(hipDeviceSynchronize());
 
         // temp_storage_size_bytes must be >0
         ASSERT_GT(temp_storage_size_bytes, 0U);
 
         // allocate temporary storage
-        void * d_temp_storage = nullptr;
+        void* d_temp_storage = nullptr;
         HIP_CHECK(hipMalloc(&d_temp_storage, temp_storage_size_bytes));
         HIP_CHECK(hipDeviceSynchronize());
 
         // Run
-        HIP_CHECK(
-            hipcub::DeviceSelect::Flagged(
-                d_temp_storage,
-                temp_storage_size_bytes,
-                d_input,
-                d_flags,
-                d_output,
-                d_selected_count_output,
-                input.size(),
-                stream,
-                debug_synchronous
-            )
-        );
+        HIP_CHECK(hipcub::DeviceSelect::Flagged(d_temp_storage,
+                                                temp_storage_size_bytes,
+                                                d_input,
+                                                d_flags,
+                                                d_output,
+                                                d_selected_count_output,
+                                                input.size(),
+                                                stream,
+                                                debug_synchronous));
         HIP_CHECK(hipDeviceSynchronize());
 
         // Check if number of selected value is as expected
         unsigned int selected_count_output = 0;
-        HIP_CHECK(
-            hipMemcpy(
-                &selected_count_output, d_selected_count_output,
-                sizeof(unsigned int),
-                hipMemcpyDeviceToHost
-            )
-        );
+        HIP_CHECK(hipMemcpy(&selected_count_output,
+                            d_selected_count_output,
+                            sizeof(unsigned int),
+                            hipMemcpyDeviceToHost));
         HIP_CHECK(hipDeviceSynchronize());
         ASSERT_EQ(selected_count_output, expected.size());
 
         // Check if output values are as expected
         std::vector<U> output(input.size());
         HIP_CHECK(
-            hipMemcpy(
-                output.data(), d_output,
-                output.size() * sizeof(U),
-                hipMemcpyDeviceToHost
-            )
-        );
+            hipMemcpy(output.data(), d_output, output.size() * sizeof(U), hipMemcpyDeviceToHost));
         HIP_CHECK(hipDeviceSynchronize());
         for(size_t i = 0; i < expected.size(); i++)
         {
@@ -212,19 +175,19 @@ TYPED_TEST(HipcubDeviceSelectTests, Flagged)
 
 struct TestSelectOp
 {
-    template<class T>
-    __host__ __device__ inline
-    bool operator()(const T& value) const
+    template <class T>
+    __host__ __device__ inline bool operator()(const T& value) const
     {
-        if(value > T(50)) return true;
+        if(value > T(50))
+            return true;
         return false;
     }
 };
 
 TYPED_TEST(HipcubDeviceSelectTests, SelectOp)
 {
-    using T = typename TestFixture::input_type;
-    using U = typename TestFixture::output_type;
+    using T                      = typename TestFixture::input_type;
+    using U                      = typename TestFixture::output_type;
     const bool debug_synchronous = TestFixture::debug_synchronous;
 
     hipStream_t stream = 0; // default stream
@@ -239,19 +202,14 @@ TYPED_TEST(HipcubDeviceSelectTests, SelectOp)
         // Generate data
         std::vector<T> input = test_utils::get_random_data<T>(size, 0, 100);
 
-        T * d_input;
-        U * d_output;
-        unsigned int * d_selected_count_output;
+        T*            d_input;
+        U*            d_output;
+        unsigned int* d_selected_count_output;
         HIP_CHECK(hipMalloc(&d_input, input.size() * sizeof(T)));
         HIP_CHECK(hipMalloc(&d_output, input.size() * sizeof(U)));
         HIP_CHECK(hipMalloc(&d_selected_count_output, sizeof(unsigned int)));
         HIP_CHECK(
-            hipMemcpy(
-                d_input, input.data(),
-                input.size() * sizeof(T),
-                hipMemcpyHostToDevice
-            )
-        );
+            hipMemcpy(d_input, input.data(), input.size() * sizeof(T), hipMemcpyHostToDevice));
         HIP_CHECK(hipDeviceSynchronize());
 
         // Calculate expected results on host
@@ -268,66 +226,50 @@ TYPED_TEST(HipcubDeviceSelectTests, SelectOp)
         // temp storage
         size_t temp_storage_size_bytes;
         // Get size of d_temp_storage
-        HIP_CHECK(
-            hipcub::DeviceSelect::If(
-                nullptr,
-                temp_storage_size_bytes,
-                d_input,
-                d_output,
-                d_selected_count_output,
-                input.size(),
-                select_op,
-                stream,
-                debug_synchronous
-            )
-        );
+        HIP_CHECK(hipcub::DeviceSelect::If(nullptr,
+                                           temp_storage_size_bytes,
+                                           d_input,
+                                           d_output,
+                                           d_selected_count_output,
+                                           input.size(),
+                                           select_op,
+                                           stream,
+                                           debug_synchronous));
         HIP_CHECK(hipDeviceSynchronize());
 
         // temp_storage_size_bytes must be >0
         ASSERT_GT(temp_storage_size_bytes, 0U);
 
         // allocate temporary storage
-        void * d_temp_storage = nullptr;
+        void* d_temp_storage = nullptr;
         HIP_CHECK(hipMalloc(&d_temp_storage, temp_storage_size_bytes));
         HIP_CHECK(hipDeviceSynchronize());
 
         // Run
-        HIP_CHECK(
-            hipcub::DeviceSelect::If(
-                d_temp_storage,
-                temp_storage_size_bytes,
-                d_input,
-                d_output,
-                d_selected_count_output,
-                input.size(),
-                select_op,
-                stream,
-                debug_synchronous
-            )
-        );
+        HIP_CHECK(hipcub::DeviceSelect::If(d_temp_storage,
+                                           temp_storage_size_bytes,
+                                           d_input,
+                                           d_output,
+                                           d_selected_count_output,
+                                           input.size(),
+                                           select_op,
+                                           stream,
+                                           debug_synchronous));
         HIP_CHECK(hipDeviceSynchronize());
 
         // Check if number of selected value is as expected
         unsigned int selected_count_output = 0;
-        HIP_CHECK(
-            hipMemcpy(
-                &selected_count_output, d_selected_count_output,
-                sizeof(unsigned int),
-                hipMemcpyDeviceToHost
-            )
-        );
+        HIP_CHECK(hipMemcpy(&selected_count_output,
+                            d_selected_count_output,
+                            sizeof(unsigned int),
+                            hipMemcpyDeviceToHost));
         HIP_CHECK(hipDeviceSynchronize());
         ASSERT_EQ(selected_count_output, expected.size());
 
         // Check if output values are as expected
         std::vector<U> output(input.size());
         HIP_CHECK(
-            hipMemcpy(
-                output.data(), d_output,
-                output.size() * sizeof(U),
-                hipMemcpyDeviceToHost
-            )
-        );
+            hipMemcpy(output.data(), d_output, output.size() * sizeof(U), hipMemcpyDeviceToHost));
         HIP_CHECK(hipDeviceSynchronize());
         for(size_t i = 0; i < expected.size(); i++)
         {
@@ -343,21 +285,19 @@ TYPED_TEST(HipcubDeviceSelectTests, SelectOp)
 
 std::vector<float> get_discontinuity_probabilities()
 {
-    std::vector<float> probabilities = {
-        0.5, 0.25, 0.5, 0.75, 0.95
-    };
+    std::vector<float> probabilities = {0.5, 0.25, 0.5, 0.75, 0.95};
     return probabilities;
 }
 
 TYPED_TEST(HipcubDeviceSelectTests, Unique)
 {
-    using T = typename TestFixture::input_type;
-    using U = typename TestFixture::output_type;
+    using T                      = typename TestFixture::input_type;
+    using U                      = typename TestFixture::output_type;
     const bool debug_synchronous = TestFixture::debug_synchronous;
 
     hipStream_t stream = 0; // default stream
 
-    const auto sizes = get_sizes();
+    const auto sizes         = get_sizes();
     const auto probabilities = get_discontinuity_probabilities();
     for(auto size : sizes)
     {
@@ -371,24 +311,18 @@ TYPED_TEST(HipcubDeviceSelectTests, Unique)
             {
                 std::vector<T> input01 = test_utils::get_random_data01<T>(size, p);
                 test_utils::host_inclusive_scan(
-                    input01.begin(), input01.end(), input.begin(), hipcub::Sum()
-                );
+                    input01.begin(), input01.end(), input.begin(), hipcub::Sum());
             }
 
             // Allocate and copy to device
-            T * d_input;
-            U * d_output;
-            unsigned int * d_selected_count_output;
+            T*            d_input;
+            U*            d_output;
+            unsigned int* d_selected_count_output;
             HIP_CHECK(hipMalloc(&d_input, input.size() * sizeof(T)));
             HIP_CHECK(hipMalloc(&d_output, input.size() * sizeof(U)));
             HIP_CHECK(hipMalloc(&d_selected_count_output, sizeof(unsigned int)));
             HIP_CHECK(
-                hipMemcpy(
-                    d_input, input.data(),
-                    input.size() * sizeof(T),
-                    hipMemcpyHostToDevice
-                )
-            );
+                hipMemcpy(d_input, input.data(), input.size() * sizeof(T), hipMemcpyHostToDevice));
             HIP_CHECK(hipDeviceSynchronize());
 
             // Calculate expected results on host
@@ -397,7 +331,7 @@ TYPED_TEST(HipcubDeviceSelectTests, Unique)
             expected.push_back(input[0]);
             for(size_t i = 1; i < input.size(); i++)
             {
-                if(!(input[i-1] == input[i]))
+                if(!(input[i - 1] == input[i]))
                 {
                     expected.push_back(input[i]);
                 }
@@ -406,64 +340,48 @@ TYPED_TEST(HipcubDeviceSelectTests, Unique)
             // temp storage
             size_t temp_storage_size_bytes;
             // Get size of d_temp_storage
-            HIP_CHECK(
-                hipcub::DeviceSelect::Unique(
-                    nullptr,
-                    temp_storage_size_bytes,
-                    d_input,
-                    d_output,
-                    d_selected_count_output,
-                    input.size(),
-                    stream,
-                    debug_synchronous
-                )
-            );
+            HIP_CHECK(hipcub::DeviceSelect::Unique(nullptr,
+                                                   temp_storage_size_bytes,
+                                                   d_input,
+                                                   d_output,
+                                                   d_selected_count_output,
+                                                   input.size(),
+                                                   stream,
+                                                   debug_synchronous));
             HIP_CHECK(hipDeviceSynchronize());
 
             // temp_storage_size_bytes must be >0
             ASSERT_GT(temp_storage_size_bytes, 0U);
 
             // allocate temporary storage
-            void * d_temp_storage = nullptr;
+            void* d_temp_storage = nullptr;
             HIP_CHECK(hipMalloc(&d_temp_storage, temp_storage_size_bytes));
             HIP_CHECK(hipDeviceSynchronize());
 
             // Run
-            HIP_CHECK(
-                hipcub::DeviceSelect::Unique(
-                    d_temp_storage,
-                    temp_storage_size_bytes,
-                    d_input,
-                    d_output,
-                    d_selected_count_output,
-                    input.size(),
-                    stream,
-                    debug_synchronous
-                )
-            );
+            HIP_CHECK(hipcub::DeviceSelect::Unique(d_temp_storage,
+                                                   temp_storage_size_bytes,
+                                                   d_input,
+                                                   d_output,
+                                                   d_selected_count_output,
+                                                   input.size(),
+                                                   stream,
+                                                   debug_synchronous));
             HIP_CHECK(hipDeviceSynchronize());
 
             // Check if number of selected value is as expected
             unsigned int selected_count_output = 0;
-            HIP_CHECK(
-                hipMemcpy(
-                    &selected_count_output, d_selected_count_output,
-                    sizeof(unsigned int),
-                    hipMemcpyDeviceToHost
-                )
-            );
+            HIP_CHECK(hipMemcpy(&selected_count_output,
+                                d_selected_count_output,
+                                sizeof(unsigned int),
+                                hipMemcpyDeviceToHost));
             HIP_CHECK(hipDeviceSynchronize());
             ASSERT_EQ(selected_count_output, expected.size());
 
             // Check if output values are as expected
             std::vector<U> output(input.size());
-            HIP_CHECK(
-                hipMemcpy(
-                    output.data(), d_output,
-                    output.size() * sizeof(U),
-                    hipMemcpyDeviceToHost
-                )
-            );
+            HIP_CHECK(hipMemcpy(
+                output.data(), d_output, output.size() * sizeof(U), hipMemcpyDeviceToHost));
             HIP_CHECK(hipDeviceSynchronize());
             for(size_t i = 0; i < expected.size(); i++)
             {

--- a/test/hipcub/test_hipcub_util_ptx.cpp
+++ b/test/hipcub/test_hipcub_util_ptx.cpp
@@ -20,9 +20,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+#include <cmath>
 #include <iostream>
 #include <vector>
-#include <cmath>
 
 // Google Test
 #include <gtest/gtest.h>
@@ -36,9 +36,9 @@
 // Custom structure
 struct custom_notaligned
 {
-    short i;
-    double d;
-    float f;
+    short        i;
+    double       d;
+    float        f;
     unsigned int u;
 
     HIPCUB_HOST_DEVICE
@@ -48,19 +48,17 @@ struct custom_notaligned
 };
 
 HIPCUB_HOST_DEVICE
-inline bool operator==(const custom_notaligned& lhs,
-                       const custom_notaligned& rhs)
+inline bool operator==(const custom_notaligned& lhs, const custom_notaligned& rhs)
 {
-    return lhs.i == rhs.i && lhs.d == rhs.d
-        && lhs.f == rhs.f &&lhs.u == rhs.u;
+    return lhs.i == rhs.i && lhs.d == rhs.d && lhs.f == rhs.f && lhs.u == rhs.u;
 }
 
 // Custom structure aligned to 16 bytes
 struct custom_16aligned
 {
-    int i;
+    int          i;
     unsigned int u;
-    float f;
+    float        f;
 
     HIPCUB_HOST_DEVICE
     custom_16aligned() {};
@@ -68,125 +66,106 @@ struct custom_16aligned
     ~custom_16aligned() {};
 } __attribute__((aligned(16)));
 
-inline HIPCUB_HOST_DEVICE
-bool operator==(const custom_16aligned& lhs, const custom_16aligned& rhs)
+inline HIPCUB_HOST_DEVICE bool operator==(const custom_16aligned& lhs, const custom_16aligned& rhs)
 {
     return lhs.i == rhs.i && lhs.f == rhs.f && lhs.u == rhs.u;
 }
 
 // Params for tests
-template<class T, unsigned int LogicalWarpSize = HIPCUB_WARP_THREADS>
+template <class T, unsigned int LogicalWarpSize = HIPCUB_WARP_THREADS>
 struct params
 {
-    using type = T;
+    using type                                      = T;
     static constexpr unsigned int logical_warp_size = LogicalWarpSize;
 };
 
-template<class Params>
+template <class Params>
 class HipcubUtilPtxTests : public ::testing::Test
 {
 public:
-    using type = typename Params::type;
+    using type                                      = typename Params::type;
     static constexpr unsigned int logical_warp_size = Params::logical_warp_size;
 };
 
-typedef ::testing::Types<
-    params<int, 32>,
-    params<int, 16>,
-    params<int, 8>,
-    params<int, 4>,
-    params<int, 2>,
-    params<float>,
-    params<double>,
-    params<unsigned char>
-> UtilPtxTestParams;
+typedef ::testing::Types<params<int, 32>,
+                         params<int, 16>,
+                         params<int, 8>,
+                         params<int, 4>,
+                         params<int, 2>,
+                         params<float>,
+                         params<double>,
+                         params<unsigned char>>
+    UtilPtxTestParams;
 
 TYPED_TEST_CASE(HipcubUtilPtxTests, UtilPtxTestParams);
 
-template<unsigned int LOGICAL_WARP_THREADS, class T>
-__global__
-void shuffle_up_kernel(T* data, unsigned int src_offset)
+template <unsigned int LOGICAL_WARP_THREADS, class T>
+__global__ void shuffle_up_kernel(T* data, unsigned int src_offset)
 {
     const unsigned int index = (hipBlockIdx_x * hipBlockDim_x) + hipThreadIdx_x;
-    T value = data[index];
+    T                  value = data[index];
 
     // first_thread argument is ignored in hipCUB with rocPRIM-backend
     const unsigned int first_thread = 0;
     // Using mask is not supported in rocPRIM, so we don't test other masks
     const unsigned int member_mask = 0xffffffff;
-    value = hipcub::ShuffleUp<LOGICAL_WARP_THREADS>(
-        value, src_offset, first_thread, member_mask
-    );
+    value = hipcub::ShuffleUp<LOGICAL_WARP_THREADS>(value, src_offset, first_thread, member_mask);
 
     data[index] = value;
 }
 
 TYPED_TEST(HipcubUtilPtxTests, ShuffleUp)
 {
-    using T = typename TestFixture::type;
-    constexpr unsigned int logical_warp_size = TestFixture::logical_warp_size;
-    const size_t hardware_warp_size = HIPCUB_WARP_THREADS;
-    const size_t size = hardware_warp_size;
+    using T                                   = typename TestFixture::type;
+    constexpr unsigned int logical_warp_size  = TestFixture::logical_warp_size;
+    const size_t           hardware_warp_size = HIPCUB_WARP_THREADS;
+    const size_t           size               = hardware_warp_size;
 
     // Generate input
-    auto input = test_utils::get_random_data<T>(size, T(-100), T(100));
+    auto           input = test_utils::get_random_data<T>(size, T(-100), T(100));
     std::vector<T> output(input.size());
 
     auto src_offsets = test_utils::get_random_data<unsigned int>(
-        std::max<size_t>(1, logical_warp_size/2),
+        std::max<size_t>(1, logical_warp_size / 2),
         1U,
-        std::max<unsigned int>(1, logical_warp_size - 1)
-    );
+        std::max<unsigned int>(1, logical_warp_size - 1));
 
     T* device_data;
-    HIP_CHECK(
-        hipMalloc(
-            &device_data,
-            input.size() * sizeof(typename decltype(input)::value_type)
-        )
-    );
+    HIP_CHECK(hipMalloc(&device_data, input.size() * sizeof(typename decltype(input)::value_type)));
 
     for(auto src_offset : src_offsets)
     {
         SCOPED_TRACE(testing::Message() << "where src_offset = " << src_offset);
         // Calculate expected results on host
         std::vector<T> expected(size, 0);
-        for(size_t i = 0; i < input.size()/logical_warp_size; i++)
+        for(size_t i = 0; i < input.size() / logical_warp_size; i++)
         {
             for(size_t j = 0; j < logical_warp_size; j++)
             {
-                size_t index = j + logical_warp_size * i;
-                auto up_index = j > src_offset-1 ? index-src_offset : index;
+                size_t index    = j + logical_warp_size * i;
+                auto   up_index = j > src_offset - 1 ? index - src_offset : index;
                 expected[index] = input[up_index];
             }
         }
 
         // Writing to device memory
         HIP_CHECK(
-            hipMemcpy(
-                device_data, input.data(),
-                input.size() * sizeof(T),
-                hipMemcpyHostToDevice
-            )
-        );
+            hipMemcpy(device_data, input.data(), input.size() * sizeof(T), hipMemcpyHostToDevice));
 
         // Launching kernel
-        hipLaunchKernelGGL(
-            HIP_KERNEL_NAME(shuffle_up_kernel<logical_warp_size, T>),
-            dim3(1), dim3(hardware_warp_size), 0, 0,
-            device_data, src_offset
-        );
+        hipLaunchKernelGGL(HIP_KERNEL_NAME(shuffle_up_kernel<logical_warp_size, T>),
+                           dim3(1),
+                           dim3(hardware_warp_size),
+                           0,
+                           0,
+                           device_data,
+                           src_offset);
         HIP_CHECK(hipPeekAtLastError());
         HIP_CHECK(hipDeviceSynchronize());
 
         // Read from device memory
-        HIP_CHECK(
-            hipMemcpy(
-                output.data(), device_data,
-                output.size() * sizeof(T),
-                hipMemcpyDeviceToHost
-            )
-        );
+        HIP_CHECK(hipMemcpy(
+            output.data(), device_data, output.size() * sizeof(T), hipMemcpyDeviceToHost));
 
         for(size_t i = 0; i < output.size(); i++)
         {
@@ -196,90 +175,73 @@ TYPED_TEST(HipcubUtilPtxTests, ShuffleUp)
     hipFree(device_data);
 }
 
-template<unsigned int LOGICAL_WARP_THREADS, class T>
-__global__
-void shuffle_down_kernel(T* data, unsigned int src_offset)
+template <unsigned int LOGICAL_WARP_THREADS, class T>
+__global__ void shuffle_down_kernel(T* data, unsigned int src_offset)
 {
     const unsigned int index = (hipBlockIdx_x * hipBlockDim_x) + hipThreadIdx_x;
-    T value = data[index];
+    T                  value = data[index];
 
     // last_thread argument is ignored in hipCUB with rocPRIM-backend
     const unsigned int last_thread = LOGICAL_WARP_THREADS - 1;
     // Using mask is not supported in rocPRIM, so we don't test other masks
     const unsigned int member_mask = 0xffffffff;
-    value = hipcub::ShuffleDown<LOGICAL_WARP_THREADS>(
-        value, src_offset, last_thread, member_mask
-    );
+    value = hipcub::ShuffleDown<LOGICAL_WARP_THREADS>(value, src_offset, last_thread, member_mask);
 
     data[index] = value;
 }
 
 TYPED_TEST(HipcubUtilPtxTests, ShuffleDown)
 {
-    using T = typename TestFixture::type;
-    constexpr unsigned int logical_warp_size = TestFixture::logical_warp_size;
-    const size_t hardware_warp_size = HIPCUB_WARP_THREADS;
-    const size_t size = hardware_warp_size;
+    using T                                   = typename TestFixture::type;
+    constexpr unsigned int logical_warp_size  = TestFixture::logical_warp_size;
+    const size_t           hardware_warp_size = HIPCUB_WARP_THREADS;
+    const size_t           size               = hardware_warp_size;
 
     // Generate input
-    auto input = test_utils::get_random_data<T>(size, T(-100), T(100));
+    auto           input = test_utils::get_random_data<T>(size, T(-100), T(100));
     std::vector<T> output(input.size());
 
     auto src_offsets = test_utils::get_random_data<unsigned int>(
-        std::max<size_t>(1, logical_warp_size/2),
+        std::max<size_t>(1, logical_warp_size / 2),
         1U,
-        std::max<unsigned int>(1, logical_warp_size - 1)
-    );
+        std::max<unsigned int>(1, logical_warp_size - 1));
 
-    T * device_data;
-    HIP_CHECK(
-        hipMalloc(
-            &device_data,
-            input.size() * sizeof(typename decltype(input)::value_type)
-        )
-    );
+    T* device_data;
+    HIP_CHECK(hipMalloc(&device_data, input.size() * sizeof(typename decltype(input)::value_type)));
 
     for(auto src_offset : src_offsets)
     {
         SCOPED_TRACE(testing::Message() << "where src_offset = " << src_offset);
         // Calculate expected results on host
         std::vector<T> expected(size, 0);
-        for(size_t i = 0; i < input.size()/logical_warp_size; i++)
+        for(size_t i = 0; i < input.size() / logical_warp_size; i++)
         {
             for(size_t j = 0; j < logical_warp_size; j++)
             {
-                size_t index = j + logical_warp_size * i;
-                auto down_index = j+src_offset < logical_warp_size ? index+src_offset : index;
-                expected[index] = input[down_index];
+                size_t index      = j + logical_warp_size * i;
+                auto   down_index = j + src_offset < logical_warp_size ? index + src_offset : index;
+                expected[index]   = input[down_index];
             }
         }
 
         // Writing to device memory
         HIP_CHECK(
-            hipMemcpy(
-                device_data, input.data(),
-                input.size() * sizeof(T),
-                hipMemcpyHostToDevice
-            )
-        );
+            hipMemcpy(device_data, input.data(), input.size() * sizeof(T), hipMemcpyHostToDevice));
 
         // Launching kernel
-        hipLaunchKernelGGL(
-            HIP_KERNEL_NAME(shuffle_down_kernel<logical_warp_size, T>),
-            dim3(1), dim3(hardware_warp_size), 0, 0,
-            device_data, src_offset
-        );
+        hipLaunchKernelGGL(HIP_KERNEL_NAME(shuffle_down_kernel<logical_warp_size, T>),
+                           dim3(1),
+                           dim3(hardware_warp_size),
+                           0,
+                           0,
+                           device_data,
+                           src_offset);
         HIP_CHECK(hipPeekAtLastError());
         HIP_CHECK(hipDeviceSynchronize());
 
         // Read from device memory
-        HIP_CHECK(
-            hipMemcpy(
-                output.data(), device_data,
-                output.size() * sizeof(T),
-                hipMemcpyDeviceToHost
-            )
-        );
+        HIP_CHECK(hipMemcpy(
+            output.data(), device_data, output.size() * sizeof(T), hipMemcpyDeviceToHost));
 
         for(size_t i = 0; i < output.size(); i++)
         {
@@ -289,97 +251,77 @@ TYPED_TEST(HipcubUtilPtxTests, ShuffleDown)
     hipFree(device_data);
 }
 
-template<unsigned int LOGICAL_WARP_THREADS, class T>
-__global__
-void shuffle_index_kernel(T* data, int* src_offsets)
+template <unsigned int LOGICAL_WARP_THREADS, class T>
+__global__ void shuffle_index_kernel(T* data, int* src_offsets)
 {
     const unsigned int index = (hipBlockIdx_x * hipBlockDim_x) + hipThreadIdx_x;
-    T value = data[index];
+    T                  value = data[index];
 
     // Using mask is not supported in rocPRIM, so we don't test other masks
     const unsigned int member_mask = 0xffffffff;
-    value = hipcub::ShuffleIndex<LOGICAL_WARP_THREADS>(
-        value, src_offsets[hipThreadIdx_x/LOGICAL_WARP_THREADS], member_mask
-    );
+    value                          = hipcub::ShuffleIndex<LOGICAL_WARP_THREADS>(
+        value, src_offsets[hipThreadIdx_x / LOGICAL_WARP_THREADS], member_mask);
 
     data[index] = value;
 }
 
 TYPED_TEST(HipcubUtilPtxTests, ShuffleIndex)
 {
-    using T = typename TestFixture::type;
-    constexpr unsigned int logical_warp_size = TestFixture::logical_warp_size;
-    const size_t hardware_warp_size = HIPCUB_WARP_THREADS;
-    const size_t size = hardware_warp_size;
+    using T                                   = typename TestFixture::type;
+    constexpr unsigned int logical_warp_size  = TestFixture::logical_warp_size;
+    const size_t           hardware_warp_size = HIPCUB_WARP_THREADS;
+    const size_t           size               = hardware_warp_size;
 
     // Generate input
-    auto input = test_utils::get_random_data<T>(size, T(-100), T(100));
+    auto           input = test_utils::get_random_data<T>(size, T(-100), T(100));
     std::vector<T> output(input.size());
 
     auto src_offsets = test_utils::get_random_data<int>(
-        hardware_warp_size/logical_warp_size, 0, std::max<int>(1, logical_warp_size - 1)
-    );
+        hardware_warp_size / logical_warp_size, 0, std::max<int>(1, logical_warp_size - 1));
 
     // Calculate expected results on host
     std::vector<T> expected(size, 0);
-    for(size_t i = 0; i < input.size()/logical_warp_size; i++)
+    for(size_t i = 0; i < input.size() / logical_warp_size; i++)
     {
         int src_index = src_offsets[i];
         for(size_t j = 0; j < logical_warp_size; j++)
         {
             size_t index = j + logical_warp_size * i;
-            if(src_index >= int(logical_warp_size) || src_index < 0) src_index = index;
+            if(src_index >= int(logical_warp_size) || src_index < 0)
+                src_index = index;
             expected[index] = input[src_index + logical_warp_size * i];
         }
     }
 
     // Writing to device memory
-    T* device_data;
-    int * device_src_offsets;
-    HIP_CHECK(
-        hipMalloc(
-            &device_data,
-            input.size() * sizeof(typename decltype(input)::value_type)
-        )
-    );
-    HIP_CHECK(
-        hipMalloc(
-            &device_src_offsets,
-            src_offsets.size() * sizeof(typename decltype(src_offsets)::value_type)
-        )
-    );
-    HIP_CHECK(
-        hipMemcpy(
-            device_data, input.data(),
-            input.size() * sizeof(typename decltype(input)::value_type),
-            hipMemcpyHostToDevice
-        )
-    );
-    HIP_CHECK(
-        hipMemcpy(
-            device_src_offsets, src_offsets.data(),
-            src_offsets.size() * sizeof(typename decltype(src_offsets)::value_type),
-            hipMemcpyHostToDevice
-        )
-    );
+    T*   device_data;
+    int* device_src_offsets;
+    HIP_CHECK(hipMalloc(&device_data, input.size() * sizeof(typename decltype(input)::value_type)));
+    HIP_CHECK(hipMalloc(&device_src_offsets,
+                        src_offsets.size() * sizeof(typename decltype(src_offsets)::value_type)));
+    HIP_CHECK(hipMemcpy(device_data,
+                        input.data(),
+                        input.size() * sizeof(typename decltype(input)::value_type),
+                        hipMemcpyHostToDevice));
+    HIP_CHECK(hipMemcpy(device_src_offsets,
+                        src_offsets.data(),
+                        src_offsets.size() * sizeof(typename decltype(src_offsets)::value_type),
+                        hipMemcpyHostToDevice));
 
     // Launching kernel
-    hipLaunchKernelGGL(
-        HIP_KERNEL_NAME(shuffle_index_kernel<logical_warp_size, T>),
-        dim3(1), dim3(hardware_warp_size), 0, 0,
-        device_data, device_src_offsets
-    );
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(shuffle_index_kernel<logical_warp_size, T>),
+                       dim3(1),
+                       dim3(hardware_warp_size),
+                       0,
+                       0,
+                       device_data,
+                       device_src_offsets);
     HIP_CHECK(hipPeekAtLastError());
     HIP_CHECK(hipDeviceSynchronize());
 
     // Read from device memory
     HIP_CHECK(
-        hipMemcpy(
-            output.data(), device_data,
-            output.size() * sizeof(T),
-            hipMemcpyDeviceToHost
-        )
-    );
+        hipMemcpy(output.data(), device_data, output.size() * sizeof(T), hipMemcpyDeviceToHost));
 
     for(size_t i = 0; i < output.size(); i++)
     {
@@ -392,77 +334,63 @@ TYPED_TEST(HipcubUtilPtxTests, ShuffleIndex)
 
 TEST(HipcubUtilPtxTests, ShuffleUpCustomStruct)
 {
-    using T = custom_notaligned;
+    using T                                   = custom_notaligned;
     constexpr unsigned int hardware_warp_size = HIPCUB_WARP_THREADS;
-    constexpr unsigned int logical_warp_size = hardware_warp_size;
-    const size_t size = logical_warp_size;
+    constexpr unsigned int logical_warp_size  = hardware_warp_size;
+    const size_t           size               = logical_warp_size;
 
     // Generate data
     std::vector<double> random_data = test_utils::get_random_data<double>(4 * size, -100, 100);
-    std::vector<T> input(size);
-    std::vector<T> output(input.size());
-    for(size_t i = 0; i < 4 * input.size(); i+=4)
+    std::vector<T>      input(size);
+    std::vector<T>      output(input.size());
+    for(size_t i = 0; i < 4 * input.size(); i += 4)
     {
-        input[i/4].i = random_data[i];
-        input[i/4].d = random_data[i+1];
-        input[i/4].f = random_data[i+2];
-        input[i/4].u = random_data[i+3];
+        input[i / 4].i = random_data[i];
+        input[i / 4].d = random_data[i + 1];
+        input[i / 4].f = random_data[i + 2];
+        input[i / 4].u = random_data[i + 3];
     }
 
     auto src_offsets = test_utils::get_random_data<unsigned int>(
-        std::max<size_t>(1, logical_warp_size/2),
+        std::max<size_t>(1, logical_warp_size / 2),
         1U,
-        std::max<unsigned int>(1, logical_warp_size - 1)
-    );
+        std::max<unsigned int>(1, logical_warp_size - 1));
 
     T* device_data;
-    HIP_CHECK(
-        hipMalloc(
-            &device_data,
-            input.size() * sizeof(typename decltype(input)::value_type)
-        )
-    );
+    HIP_CHECK(hipMalloc(&device_data, input.size() * sizeof(typename decltype(input)::value_type)));
 
     for(auto src_offset : src_offsets)
     {
         // Calculate expected results on host
         std::vector<T> expected(size);
-        for(size_t i = 0; i < input.size()/logical_warp_size; i++)
+        for(size_t i = 0; i < input.size() / logical_warp_size; i++)
         {
             for(size_t j = 0; j < logical_warp_size; j++)
             {
-                size_t index = j + logical_warp_size * i;
-                auto up_index = j > src_offset-1 ? index-src_offset : index;
+                size_t index    = j + logical_warp_size * i;
+                auto   up_index = j > src_offset - 1 ? index - src_offset : index;
                 expected[index] = input[up_index];
             }
         }
 
         // Writing to device memory
         HIP_CHECK(
-            hipMemcpy(
-                device_data, input.data(),
-                input.size() * sizeof(T),
-                hipMemcpyHostToDevice
-            )
-        );
+            hipMemcpy(device_data, input.data(), input.size() * sizeof(T), hipMemcpyHostToDevice));
 
         // Launching kernel
-        hipLaunchKernelGGL(
-            HIP_KERNEL_NAME(shuffle_up_kernel<logical_warp_size, T>),
-            dim3(1), dim3(hardware_warp_size), 0, 0,
-            device_data, src_offset
-        );
+        hipLaunchKernelGGL(HIP_KERNEL_NAME(shuffle_up_kernel<logical_warp_size, T>),
+                           dim3(1),
+                           dim3(hardware_warp_size),
+                           0,
+                           0,
+                           device_data,
+                           src_offset);
         HIP_CHECK(hipPeekAtLastError());
         HIP_CHECK(hipDeviceSynchronize());
 
         // Read from device memory
-        HIP_CHECK(
-            hipMemcpy(
-                output.data(), device_data,
-                output.size() * sizeof(T),
-                hipMemcpyDeviceToHost
-            )
-        );
+        HIP_CHECK(hipMemcpy(
+            output.data(), device_data, output.size() * sizeof(T), hipMemcpyDeviceToHost));
 
         for(size_t i = 0; i < output.size(); i++)
         {
@@ -474,76 +402,62 @@ TEST(HipcubUtilPtxTests, ShuffleUpCustomStruct)
 
 TEST(HipcubUtilPtxTests, ShuffleUpCustomAlignedStruct)
 {
-    using T = custom_16aligned;
+    using T                                   = custom_16aligned;
     constexpr unsigned int hardware_warp_size = HIPCUB_WARP_THREADS;
-    constexpr unsigned int logical_warp_size = hardware_warp_size;
-    const size_t size = logical_warp_size;
+    constexpr unsigned int logical_warp_size  = hardware_warp_size;
+    const size_t           size               = logical_warp_size;
 
     // Generate data
     std::vector<double> random_data = test_utils::get_random_data<double>(3 * size, -100, 100);
-    std::vector<T> input(size);
-    std::vector<T> output(input.size());
-    for(size_t i = 0; i < 3 * input.size(); i+=3)
+    std::vector<T>      input(size);
+    std::vector<T>      output(input.size());
+    for(size_t i = 0; i < 3 * input.size(); i += 3)
     {
-        input[i/3].i = random_data[i];
-        input[i/3].u = random_data[i+1];
-        input[i/3].f = random_data[i+2];
+        input[i / 3].i = random_data[i];
+        input[i / 3].u = random_data[i + 1];
+        input[i / 3].f = random_data[i + 2];
     }
 
     auto src_offsets = test_utils::get_random_data<unsigned int>(
-        std::max<size_t>(1, logical_warp_size/2),
+        std::max<size_t>(1, logical_warp_size / 2),
         1U,
-        std::max<unsigned int>(1, logical_warp_size - 1)
-    );
+        std::max<unsigned int>(1, logical_warp_size - 1));
 
     T* device_data;
-    HIP_CHECK(
-        hipMalloc(
-            &device_data,
-            input.size() * sizeof(typename decltype(input)::value_type)
-        )
-    );
+    HIP_CHECK(hipMalloc(&device_data, input.size() * sizeof(typename decltype(input)::value_type)));
 
     for(auto src_offset : src_offsets)
     {
         // Calculate expected results on host
         std::vector<T> expected(size);
-        for(size_t i = 0; i < input.size()/logical_warp_size; i++)
+        for(size_t i = 0; i < input.size() / logical_warp_size; i++)
         {
             for(size_t j = 0; j < logical_warp_size; j++)
             {
-                size_t index = j + logical_warp_size * i;
-                auto up_index = j > src_offset-1 ? index-src_offset : index;
+                size_t index    = j + logical_warp_size * i;
+                auto   up_index = j > src_offset - 1 ? index - src_offset : index;
                 expected[index] = input[up_index];
             }
         }
 
         // Writing to device memory
         HIP_CHECK(
-            hipMemcpy(
-                device_data, input.data(),
-                input.size() * sizeof(T),
-                hipMemcpyHostToDevice
-            )
-        );
+            hipMemcpy(device_data, input.data(), input.size() * sizeof(T), hipMemcpyHostToDevice));
 
         // Launching kernel
-        hipLaunchKernelGGL(
-            HIP_KERNEL_NAME(shuffle_up_kernel<logical_warp_size, T>),
-            dim3(1), dim3(hardware_warp_size), 0, 0,
-            device_data, src_offset
-        );
+        hipLaunchKernelGGL(HIP_KERNEL_NAME(shuffle_up_kernel<logical_warp_size, T>),
+                           dim3(1),
+                           dim3(hardware_warp_size),
+                           0,
+                           0,
+                           device_data,
+                           src_offset);
         HIP_CHECK(hipPeekAtLastError());
         HIP_CHECK(hipDeviceSynchronize());
 
         // Read from device memory
-        HIP_CHECK(
-            hipMemcpy(
-                output.data(), device_data,
-                output.size() * sizeof(T),
-                hipMemcpyDeviceToHost
-            )
-        );
+        HIP_CHECK(hipMemcpy(
+            output.data(), device_data, output.size() * sizeof(T), hipMemcpyDeviceToHost));
 
         for(size_t i = 0; i < output.size(); i++)
         {
@@ -553,55 +467,41 @@ TEST(HipcubUtilPtxTests, ShuffleUpCustomAlignedStruct)
     hipFree(device_data);
 }
 
-__global__
-void warp_id_kernel(unsigned int* output)
+__global__ void warp_id_kernel(unsigned int* output)
 {
     const unsigned int index = (hipBlockIdx_x * hipBlockDim_x) + hipThreadIdx_x;
-    output[index] = hipcub::WarpId();
+    output[index]            = hipcub::WarpId();
 }
 
 TEST(HipcubUtilPtxTests, WarpId)
 {
     constexpr unsigned int hardware_warp_size = HIPCUB_WARP_THREADS;
-    const size_t block_size = 4 * hardware_warp_size;
-    const size_t size = 16 * block_size;
+    const size_t           block_size         = 4 * hardware_warp_size;
+    const size_t           size               = 16 * block_size;
 
     std::vector<unsigned int> output(size);
-    unsigned int* device_output;
-    HIP_CHECK(
-        hipMalloc(
-            &device_output,
-            output.size() * sizeof(unsigned int)
-        )
-    );
+    unsigned int*             device_output;
+    HIP_CHECK(hipMalloc(&device_output, output.size() * sizeof(unsigned int)));
 
     // Launching kernel
     hipLaunchKernelGGL(
-        warp_id_kernel,
-        dim3(size/block_size), dim3(block_size), 0, 0,
-        device_output
-    );
+        warp_id_kernel, dim3(size / block_size), dim3(block_size), 0, 0, device_output);
     HIP_CHECK(hipPeekAtLastError());
     HIP_CHECK(hipDeviceSynchronize());
 
     // Read from device memory
-    HIP_CHECK(
-        hipMemcpy(
-            output.data(), device_output,
-            output.size() * sizeof(unsigned int),
-            hipMemcpyDeviceToHost
-        )
-    );
+    HIP_CHECK(hipMemcpy(
+        output.data(), device_output, output.size() * sizeof(unsigned int), hipMemcpyDeviceToHost));
 
-    std::vector<size_t> warp_ids(block_size/hardware_warp_size, 0);
-    for(size_t i = 0; i < output.size()/hardware_warp_size; i++)
+    std::vector<size_t> warp_ids(block_size / hardware_warp_size, 0);
+    for(size_t i = 0; i < output.size() / hardware_warp_size; i++)
     {
         auto prev = output[i * hardware_warp_size];
         for(size_t j = 0; j < hardware_warp_size; j++)
         {
             auto index = j + i * hardware_warp_size;
             // less than number of warps in thread block
-            ASSERT_LT(output[index], block_size/hardware_warp_size);
+            ASSERT_LT(output[index], block_size / hardware_warp_size);
             ASSERT_GE(output[index], 0U); // > 0
             ASSERT_EQ(output[index], prev); // all in warp_ids in warp are the same
         }
@@ -610,6 +510,6 @@ TEST(HipcubUtilPtxTests, WarpId)
     // Check if each warp_id appears the same number of times.
     for(auto warp_id_no : warp_ids)
     {
-        ASSERT_EQ(warp_id_no, size/block_size);
+        ASSERT_EQ(warp_id_no, size / block_size);
     }
 }


### PR DESCRIPTION
Summary of proposed changes:
-  Changed clang formatter to /opt/rocm/hcc/bin/clang-format, which is clang-format-9
-  Needs to pass CI
- Format check still turned off