### PR TITLE
Package building fix for PyTorch

### DIFF
--- a/cmake/ROCMExportTargetsHeaderOnly.cmake
+++ b/cmake/ROCMExportTargetsHeaderOnly.cmake
@@ -1,0 +1,140 @@
+# MIT License
+#
+# Copyright (c) 2017-2019 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+# This file is a worksaround for issues rocm-cmake packaging style and PyTorch.
+# TODO: remove when there is a fix for this issue in either rocm-cmake or PyTorch.
+
+include(CMakeParseArguments)
+include(GNUInstallDirs)
+include(ROCMPackageConfigHelpers)
+include(ROCMInstallTargets)
+
+set(ROCM_INSTALL_LIBDIR lib)
+
+
+function(rocm_export_targets_header_only)
+    set(options)
+    set(oneValueArgs NAMESPACE EXPORT NAME COMPATIBILITY PREFIX)
+    set(multiValueArgs TARGETS DEPENDS INCLUDE)
+
+    cmake_parse_arguments(PARSE "${options}" "${oneValueArgs}" "${multiValueArgs}"  ${ARGN})
+
+    set(PACKAGE_NAME ${PROJECT_NAME})
+    if(PARSE_NAME)
+        set(PACKAGE_NAME ${PARSE_NAME})
+    endif()
+
+    string(TOUPPER ${PACKAGE_NAME} PACKAGE_NAME_UPPER)
+    string(TOLOWER ${PACKAGE_NAME} PACKAGE_NAME_LOWER)
+
+    set(TARGET_FILE ${PACKAGE_NAME_LOWER}-targets)
+    if(PARSE_EXPORT)
+        set(TARGET_FILE ${PARSE_EXPORT})
+    endif()
+    set(CONFIG_NAME ${PACKAGE_NAME_LOWER}-config)
+    set(TARGET_VERSION ${PROJECT_VERSION})
+
+    if(PARSE_PREFIX)
+        set(PREFIX_DIR ${PARSE_PREFIX})
+        set(PREFIX_ARG PREFIX ${PREFIX_DIR})
+        set(BIN_INSTALL_DIR ${PREFIX_DIR}/${CMAKE_INSTALL_BINDIR})
+        set(LIB_INSTALL_DIR ${PREFIX_DIR}/${ROCM_INSTALL_LIBDIR})
+        set(INCLUDE_INSTALL_DIR ${PREFIX_DIR}/${CMAKE_INSTALL_INCLUDEDIR})
+    else()
+        set(BIN_INSTALL_DIR ${CMAKE_INSTALL_BINDIR})
+        set(LIB_INSTALL_DIR ${ROCM_INSTALL_LIBDIR})
+        set(INCLUDE_INSTALL_DIR ${CMAKE_INSTALL_INCLUDEDIR})
+    endif()
+    set(CONFIG_PACKAGE_INSTALL_DIR ${LIB_INSTALL_DIR}/cmake/${PACKAGE_NAME_LOWER})
+
+
+    set(CONFIG_TEMPLATE "${CMAKE_CURRENT_BINARY_DIR}/${PACKAGE_NAME_LOWER}-config.cmake.in")
+
+    file(WRITE ${CONFIG_TEMPLATE} "
+@PACKAGE_INIT@
+    ")
+
+    foreach(NAME ${PACKAGE_NAME} ${PACKAGE_NAME_UPPER} ${PACKAGE_NAME_LOWER})
+        rocm_write_package_template_function(${CONFIG_TEMPLATE} set_and_check ${NAME}_INCLUDE_DIR "@PACKAGE_INCLUDE_INSTALL_DIR@")
+        rocm_write_package_template_function(${CONFIG_TEMPLATE} set_and_check ${NAME}_INCLUDE_DIRS "@PACKAGE_INCLUDE_INSTALL_DIR@")
+    endforeach()
+    rocm_write_package_template_function(${CONFIG_TEMPLATE} set_and_check ${PACKAGE_NAME}_TARGET_FILE "@PACKAGE_CONFIG_PACKAGE_INSTALL_DIR@/${TARGET_FILE}.cmake")
+
+    if(PARSE_DEPENDS)
+        rocm_list_split(PARSE_DEPENDS PACKAGE DEPENDS_LIST)
+        foreach(DEPEND ${DEPENDS_LIST})
+            rocm_write_package_template_function(${CONFIG_TEMPLATE} find_dependency ${${DEPEND}})
+        endforeach()
+    endif()
+
+    foreach(INCLUDE ${PARSE_INCLUDE})
+        install(FILES ${INCLUDE} DESTINATION ${CONFIG_PACKAGE_INSTALL_DIR})
+        get_filename_component(INCLUDE_BASE ${INCLUDE} NAME)
+        rocm_write_package_template_function(${CONFIG_TEMPLATE} include "\${CMAKE_CURRENT_LIST_DIR}/${INCLUDE_BASE}")
+    endforeach()
+
+    if(PARSE_TARGETS)
+        rocm_write_package_template_function(${CONFIG_TEMPLATE} include "\${${PACKAGE_NAME}_TARGET_FILE}")
+# Disabled for PyTorch
+#        foreach(NAME ${PACKAGE_NAME} ${PACKAGE_NAME_UPPER} ${PACKAGE_NAME_LOWER})
+#            rocm_write_package_template_function(${CONFIG_TEMPLATE} set ${NAME}_LIBRARIES ${PARSE_TARGETS})
+#            rocm_write_package_template_function(${CONFIG_TEMPLATE} set ${NAME}_LIBRARY ${PARSE_TARGETS})
+#        endforeach()
+    endif()
+
+    rocm_configure_package_config_file(
+        ${CONFIG_TEMPLATE}
+        ${CMAKE_CURRENT_BINARY_DIR}/${CONFIG_NAME}.cmake
+        INSTALL_DESTINATION ${CONFIG_PACKAGE_INSTALL_DIR}
+        ${PREFIX_ARG}
+        PATH_VARS LIB_INSTALL_DIR INCLUDE_INSTALL_DIR CONFIG_PACKAGE_INSTALL_DIR
+    )
+    set(COMPATIBILITY_ARG SameMajorVersion)
+    if(PARSE_COMPATIBILITY)
+        set(COMPATIBILITY_ARG ${PARSE_COMPATIBILITY})
+    endif()
+    write_basic_package_version_file(
+        ${CMAKE_CURRENT_BINARY_DIR}/${CONFIG_NAME}-version.cmake
+        VERSION ${TARGET_VERSION}
+        COMPATIBILITY ${COMPATIBILITY_ARG}
+    )
+
+    set(NAMESPACE_ARG)
+    if(PARSE_NAMESPACE)
+        set(NAMESPACE_ARG "NAMESPACE;${PARSE_NAMESPACE}")
+    endif()
+    install( EXPORT ${TARGET_FILE}
+        DESTINATION
+        ${CONFIG_PACKAGE_INSTALL_DIR}
+        ${NAMESPACE_ARG}
+    )
+
+    install( FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/${CONFIG_NAME}.cmake
+        ${CMAKE_CURRENT_BINARY_DIR}/${CONFIG_NAME}-version.cmake
+        DESTINATION
+        ${CONFIG_PACKAGE_INSTALL_DIR})
+
+endfunction()
+
+

--- a/hipcub/CMakeLists.txt
+++ b/hipcub/CMakeLists.txt
@@ -82,8 +82,9 @@ install(
   PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ
 )
 
+include(ROCMExportTargetsHeaderOnly)
 # Export targets
-rocm_export_targets(
+rocm_export_targets_header_only(
   TARGETS hip::hipcub
   PREFIX hipcub
   NAMESPACE hip::


### PR DESCRIPTION
Fix for PyTorch Compile issue. This modifies the pacakges to remote interface targets for the library in the hipcub-config.cmake files