### PR TITLE
move version header into hcc define

### DIFF
--- a/hipcub/include/hipcub/hipcub.hpp
+++ b/hipcub/include/hipcub/hipcub.hpp
@@ -29,10 +29,11 @@
 
 // Meta configuration for hipCUB
 #include "config.hpp"
-// Version
-#include "hipcub_version.hpp"
 
 #ifdef __HIP_PLATFORM_HCC__
+    // Version, only needed with HCC backend
+    #include "hipcub_version.hpp"
+
     #include "rocprim/hipcub.hpp"
 #elif defined(__HIP_PLATFORM_NVCC__)
     #include "cub/hipcub.hpp"


### PR DESCRIPTION
fixes #56 

not sure if this is the way you'd want to fix it, but it allows header-only inclusion of hipCUB with CUB backend without the need to cmake