### PR TITLE
WIP: Change dependency handle of rocPRIM

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,7 +30,7 @@ variables:
   # Local build options
   LOCAL_CXXFLAGS: ""
   LOCAL_CMAKE_OPTIONS: ""
-
+  ROCM_PATH: "/opt/rocm-3.1.0/"
 
 # hipCUB with rocPRIM backend
 
@@ -169,6 +169,7 @@ test:rocm_install:
     # (with heavy libraries, tools etc. that also require GUI and other packages)
     - apt-get download hip-nvcc
     - $SUDO_CMD dpkg -i --ignore-depends=cuda hip*.deb
+    - $SUDO_CMD ln -s $ROCM_PATH /opt/rocm
     - export PATH=$PATH:/opt/rocm/bin
     - hipconfig
     # cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
 
 # Build options
 option(BUILD_TEST "Build tests (requires googletest)" OFF)
+option(DOWNLOAD_ROCPRIM "Download rocPRIM and do not search for rocPRIM package" OFF)
 
 # Get dependencies
 include(cmake/Dependencies.cmake)

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ cd hipCUB; mkdir build; cd build
 # Configure hipCUB, setup options for your system.
 # Build options:
 #   BUILD_TEST - OFF by default,
+#   DOWNLOAD_ROCPRIM - OFF by default and at ON the rocPRIM will be downloaded to build folder,
 #
 # ! IMPORTANT !
 # On ROCm platform set C++ compiler to HCC. You can do it by adding 'CXX=<path-to-hcc>'

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -67,9 +67,21 @@ endif()
 
 # rocPRIM (only for ROCm platform)
 if(HIP_PLATFORM STREQUAL "hcc")
-  if(NOT DEFINED rocprim_DIR)
-    message(STATUS "Downloading and building rocPRIM.")
-    set(rocprim_DIR "${CMAKE_CURRENT_BINARY_DIR}/rocprim" CACHE PATH "")
+  if(NOT DOWNLOAD_ROCPRIM)
+    if(NOT DEFINED rocprim_DIR)
+      find_package(rocprim QUIET CONFIG PATHS /opt/rocm/rocprim)
+    else()
+      find_package(rocprim QUIET CONFIG PATHS "${rocprim_DIR}")
+    endif()
+  endif()
+
+  if(NOT rocprim_FOUND)
+    if(NOT DOWNLOAD_ROCPRIM)
+      message(WARNING "rocPRIM package could not be found")
+    endif()
+
+    set(rocprim_DIR "${CMAKE_CURRENT_BINARY_DIR}/rocprim" CACHE PATH "" FORCE)
+    message(${rocprim_DIR})
     download_project(
       PROJ                rocprim
       GIT_REPOSITORY      https://github.com/ROCmSoftwarePlatform/rocPRIM.git
@@ -83,8 +95,8 @@ if(HIP_PLATFORM STREQUAL "hcc")
       BUILD_PROJECT       TRUE
       UPDATE_DISCONNECTED TRUE # Never update automatically from the remote repository
     )
+    find_package(rocprim REQUIRED CONFIG PATHS "${rocprim_DIR}")
   endif()
-  find_package(rocprim REQUIRED CONFIG PATHS "${rocprim_DIR}")
 endif()
 
 # Test dependencies


### PR DESCRIPTION
This is one option. Our idea to remove the rocprim_DIR completely and use CMAKE_PREFIX_PATH