### PR TITLE
Fixing test build failure and deprecated warning

### DIFF
--- a/test/hipcub/test_hipcub_device_partition.cpp
+++ b/test/hipcub/test_hipcub_device_partition.cpp
@@ -76,7 +76,7 @@ std::vector<size_t> get_sizes(int seed_value)
     return sizes;
 }
 
-TYPED_TEST_CASE(HipcubDevicePartitionTests, HipcubDevicePartitionTestsParams);
+TYPED_TEST_SUITE(HipcubDevicePartitionTests, HipcubDevicePartitionTestsParams);
 
 TYPED_TEST(HipcubDevicePartitionTests, Flagged)
 {

--- a/test/hipcub/test_hipcub_device_select.cpp
+++ b/test/hipcub/test_hipcub_device_select.cpp
@@ -67,7 +67,7 @@ std::vector<size_t> get_sizes()
     return sizes;
 }
 
-TYPED_TEST_CASE(HipcubDeviceSelectTests, HipcubDeviceSelectTestsParams);
+TYPED_TEST_SUITE(HipcubDeviceSelectTests, HipcubDeviceSelectTestsParams);
 
 TYPED_TEST(HipcubDeviceSelectTests, Flagged)
 {

--- a/test/hipcub/test_hipcub_grid.cpp
+++ b/test/hipcub/test_hipcub_grid.cpp
@@ -66,7 +66,7 @@ TEST(HipcubGridTests, GridBarrier)
     HIP_CHECK(hipOccupancyMaxActiveBlocksPerMultiprocessor(
         &max_sm_occupancy,
         KernelGridBarrier,
-        HIPCUB_WARP_THREADS,
+        rocprim::host_warp_size(),
         0));
 
     int32_t occupancy = std::min((max_block_threads / block_size), max_sm_occupancy);


### PR DESCRIPTION
This will fix the build failures in the develop branch, it is from the gfx1030/navi21 PR.  Also gets rid of some googletest deprecation warnings, as we had to update to gtest 1.10.