### PR TITLE
Adding discard output iterator to backend header

### DIFF
--- a/hipcub/include/hipcub/backend/rocprim/hipcub.hpp
+++ b/hipcub/include/hipcub/backend/rocprim/hipcub.hpp
@@ -42,6 +42,7 @@
 #include "iterator/counting_input_iterator.hpp"
 #include "iterator/tex_obj_input_iterator.hpp"
 #include "iterator/transform_input_iterator.hpp"
+#include "iterator/discard_output_iterator.hpp"
 
 // Warp
 #include "warp/warp_reduce.hpp"


### PR DESCRIPTION
Customer request to have discard output iterator added to the backend header.  I don't see any downside to this?