### PR TITLE
Enabling HMM unit test support

### DIFF
--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -5,7 +5,6 @@ def runCompileCommand(platform, project, jobName, boolean debug=false, boolean s
 {
     project.paths.construct_build_prefix()
         
-    project.compiler.compiler_path = platform.jenkinsLabel.contains('hip-clang') ? '/opt/rocm/bin/hipcc' : '/opt/rocm/bin/hcc'        
     String buildTypeArg = debug ? '-DCMAKE_BUILD_TYPE=Debug' : '-DCMAKE_BUILD_TYPE=Release'
     String buildTypeDir = debug ? 'debug' : 'release'
     String cmake = platform.jenkinsLabel.contains('centos') ? 'cmake3' : 'cmake'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 See README.md on how to build the hipCUB documentation using Doxygen.
 
-## [hipCUB-2.10.10 for ROCm 4.3.0]
+## [Unreleased hipCUB-2.10.10 for ROCm 4.3.0]
 ### Added
 - DiscardOutputIterator to backend header
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ set(VERSION_STRING "2.10.7")
 rocm_setup_version(VERSION ${VERSION_STRING})
 
 # AMD targets
-set(AMDGPU_TARGETS gfx900:xnack-;gfx906:xnack-;gfx908:xnack- CACHE STRING "List of specific machine types for library to target")
+set(AMDGPU_TARGETS gfx900:xnack-;gfx906:xnack-;gfx908:xnack-;gfx908:xnack+ CACHE STRING "List of specific machine types for library to target")
 
 # Print configuration summary
 include(cmake/Summary.cmake)

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -75,7 +75,7 @@ if(HIP_COMPILER STREQUAL "hcc" OR HIP_COMPILER STREQUAL "clang")
     download_project(
       PROJ                rocprim
       GIT_REPOSITORY      https://github.com/ROCmSoftwarePlatform/rocPRIM.git
-      GIT_TAG             release/rocm-rel-4.3
+      GIT_TAG             develop
       INSTALL_DIR         ${CMAKE_CURRENT_BINARY_DIR}/deps/rocprim
       CMAKE_ARGS          -DBUILD_TEST=OFF -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR> -DCMAKE_PREFIX_PATH=/opt/rocm
       LOG_DOWNLOAD        TRUE

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -75,7 +75,7 @@ if(HIP_COMPILER STREQUAL "hcc" OR HIP_COMPILER STREQUAL "clang")
     download_project(
       PROJ                rocprim
       GIT_REPOSITORY      https://github.com/ROCmSoftwarePlatform/rocPRIM.git
-      GIT_TAG             develop
+      GIT_TAG             release/rocm-rel-4.3
       INSTALL_DIR         ${CMAKE_CURRENT_BINARY_DIR}/deps/rocprim
       CMAKE_ARGS          -DBUILD_TEST=OFF -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR> -DCMAKE_PREFIX_PATH=/opt/rocm
       LOG_DOWNLOAD        TRUE

--- a/test/hipcub/common_test_header.hpp
+++ b/test/hipcub/common_test_header.hpp
@@ -58,7 +58,16 @@ namespace test_common_utils
 
 bool use_hmm()
 {
-    return std::getenv("HIPCUB_USE_HMM");
+    if (getenv("HIPCUB_USE_HMM") == nullptr)
+    {
+        return false;
+    }
+
+    if (strcmp(getenv("HIPCUB_USE_HMM"), "1") == 0)
+    {
+        return true;
+    }
+    return false;
 }
 
 // Helper for HMM allocations: HMM is requested through HIPCUB_USE_HMM environment variable
@@ -67,7 +76,6 @@ hipError_t hipMallocHelper(T** devPtr, size_t size)
 {
     if (use_hmm())
     {
-        printf("using hmm\n");
         return hipMallocManaged((void**)devPtr, size);
     }
     else

--- a/test/hipcub/common_test_header.hpp
+++ b/test/hipcub/common_test_header.hpp
@@ -73,11 +73,11 @@ bool use_hmm()
 }
 
 // Helper for HMM allocations: if device supports managedMemory, and HMM is requested through
-// HIPCUB_MALLOC_MANAGED environment variable
+// HIPCUB_USE_HMM environment variable
 template <class T>
 hipError_t hipMallocHelper(T** devPtr, size_t size)
 {
-    if (supports_hmm() && use_hmm())
+    if (use_hmm())
     {
         return hipMallocManaged((void**)devPtr, size);
     }

--- a/test/hipcub/common_test_header.hpp
+++ b/test/hipcub/common_test_header.hpp
@@ -77,7 +77,7 @@ bool use_hmm()
 template <class T>
 hipError_t hipMallocHelper(T** devPtr, size_t size)
 {
-    if (use_hmm())
+    if (use_hmm() && supports_hmm())
     {
         return hipMallocManaged((void**)devPtr, size);
     }

--- a/test/hipcub/common_test_header.hpp
+++ b/test/hipcub/common_test_header.hpp
@@ -48,7 +48,7 @@
 {                                    \
     hipError_t error = condition;    \
     if(error != hipSuccess){         \
-        std::cout << "HIP error: " << error << " line: " << __LINE__ << std::endl; \
+        std::cout << "HIP error: " << hipGetErrorString(error) << " line: " << __LINE__ << std::endl; \
         exit(error); \
     } \
 }
@@ -56,29 +56,18 @@
 namespace test_common_utils
 {
 
-bool supports_hmm()
-{
-    hipDeviceProp_t device_prop;
-    int device_id;
-    HIP_CHECK(hipGetDevice(&device_id));
-    HIP_CHECK(hipGetDeviceProperties(&device_prop, device_id));
-    if (device_prop.managedMemory == 1) return true;
-
-    return false;
-}
-
 bool use_hmm()
 {
     return std::getenv("HIPCUB_USE_HMM");
 }
 
-// Helper for HMM allocations: if device supports managedMemory, and HMM is requested through
-// HIPCUB_USE_HMM environment variable
+// Helper for HMM allocations: HMM is requested through HIPCUB_USE_HMM environment variable
 template <class T>
 hipError_t hipMallocHelper(T** devPtr, size_t size)
 {
-    if (use_hmm() && supports_hmm())
+    if (use_hmm())
     {
+        printf("using hmm\n");
         return hipMallocManaged((void**)devPtr, size);
     }
     else

--- a/test/hipcub/test_hipcub_block_discontinuity.cpp
+++ b/test/hipcub/test_hipcub_block_discontinuity.cpp
@@ -237,9 +237,9 @@ TYPED_TEST(HipcubBlockDiscontinuity, FlagHeads)
 
         // Preparing Device
         type* device_input;
-        HIP_CHECK(hipMalloc(&device_input, input.size() * sizeof(typename decltype(input)::value_type)));
+        HIP_CHECK(test_common_utils::hipMallocHelper(&device_input, input.size() * sizeof(typename decltype(input)::value_type)));
         long long* device_heads;
-        HIP_CHECK(hipMalloc(&device_heads, heads.size() * sizeof(typename decltype(heads)::value_type)));
+        HIP_CHECK(test_common_utils::hipMallocHelper(&device_heads, heads.size() * sizeof(typename decltype(heads)::value_type)));
 
         HIP_CHECK(
             hipMemcpy(
@@ -373,9 +373,9 @@ TYPED_TEST(HipcubBlockDiscontinuity, FlagTails)
 
         // Preparing Device
         type* device_input;
-        HIP_CHECK(hipMalloc(&device_input, input.size() * sizeof(typename decltype(input)::value_type)));
+        HIP_CHECK(test_common_utils::hipMallocHelper(&device_input, input.size() * sizeof(typename decltype(input)::value_type)));
         long long* device_tails;
-        HIP_CHECK(hipMalloc(&device_tails, tails.size() * sizeof(typename decltype(tails)::value_type)));
+        HIP_CHECK(test_common_utils::hipMallocHelper(&device_tails, tails.size() * sizeof(typename decltype(tails)::value_type)));
 
         HIP_CHECK(
             hipMemcpy(
@@ -535,11 +535,11 @@ TYPED_TEST(HipcubBlockDiscontinuity, FlagHeadsAndTails)
 
         // Preparing Device
         type* device_input;
-        HIP_CHECK(hipMalloc(&device_input, input.size() * sizeof(typename decltype(input)::value_type)));
+        HIP_CHECK(test_common_utils::hipMallocHelper(&device_input, input.size() * sizeof(typename decltype(input)::value_type)));
         long long* device_heads;
-        HIP_CHECK(hipMalloc(&device_heads, tails.size() * sizeof(typename decltype(heads)::value_type)));
+        HIP_CHECK(test_common_utils::hipMallocHelper(&device_heads, tails.size() * sizeof(typename decltype(heads)::value_type)));
         long long* device_tails;
-        HIP_CHECK(hipMalloc(&device_tails, tails.size() * sizeof(typename decltype(tails)::value_type)));
+        HIP_CHECK(test_common_utils::hipMallocHelper(&device_tails, tails.size() * sizeof(typename decltype(tails)::value_type)));
 
         HIP_CHECK(
             hipMemcpy(

--- a/test/hipcub/test_hipcub_block_exchange.cpp
+++ b/test/hipcub/test_hipcub_block_exchange.cpp
@@ -157,9 +157,9 @@ TYPED_TEST(HipcubBlockExchangeTests, BlockedToStriped)
 
     // Preparing device
     type* device_input;
-    HIP_CHECK(hipMalloc(&device_input, input.size() * sizeof(typename decltype(input)::value_type)));
+    HIP_CHECK(test_common_utils::hipMallocHelper(&device_input, input.size() * sizeof(typename decltype(input)::value_type)));
     output_type* device_output;
-    HIP_CHECK(hipMalloc(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
+    HIP_CHECK(test_common_utils::hipMallocHelper(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
 
     HIP_CHECK(
         hipMemcpy(
@@ -260,9 +260,9 @@ TYPED_TEST(HipcubBlockExchangeTests, StripedToBlocked)
 
     // Preparing device
     type* device_input;
-    HIP_CHECK(hipMalloc(&device_input, input.size() * sizeof(typename decltype(input)::value_type)));
+    HIP_CHECK(test_common_utils::hipMallocHelper(&device_input, input.size() * sizeof(typename decltype(input)::value_type)));
     output_type* device_output;
-    HIP_CHECK(hipMalloc(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
+    HIP_CHECK(test_common_utils::hipMallocHelper(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
 
     HIP_CHECK(
         hipMemcpy(
@@ -381,9 +381,9 @@ TYPED_TEST(HipcubBlockExchangeTests, BlockedToWarpStriped)
 
     // Preparing device
     type* device_input;
-    HIP_CHECK(hipMalloc(&device_input, input.size() * sizeof(typename decltype(input)::value_type)));
+    HIP_CHECK(test_common_utils::hipMallocHelper(&device_input, input.size() * sizeof(typename decltype(input)::value_type)));
     output_type* device_output;
-    HIP_CHECK(hipMalloc(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
+    HIP_CHECK(test_common_utils::hipMallocHelper(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
 
     HIP_CHECK(
         hipMemcpy(
@@ -504,9 +504,9 @@ TYPED_TEST(HipcubBlockExchangeTests, WarpStripedToBlocked)
 
     // Preparing device
     type* device_input;
-    HIP_CHECK(hipMalloc(&device_input, input.size() * sizeof(typename decltype(input)::value_type)));
+    HIP_CHECK(test_common_utils::hipMallocHelper(&device_input, input.size() * sizeof(typename decltype(input)::value_type)));
     output_type* device_output;
-    HIP_CHECK(hipMalloc(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
+    HIP_CHECK(test_common_utils::hipMallocHelper(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
 
     HIP_CHECK(
         hipMemcpy(
@@ -616,11 +616,11 @@ TYPED_TEST(HipcubBlockExchangeTests, ScatterToBlocked)
 
     // Preparing device
     type* device_input;
-    HIP_CHECK(hipMalloc(&device_input, input.size() * sizeof(typename decltype(input)::value_type)));
+    HIP_CHECK(test_common_utils::hipMallocHelper(&device_input, input.size() * sizeof(typename decltype(input)::value_type)));
     output_type* device_output;
-    HIP_CHECK(hipMalloc(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
+    HIP_CHECK(test_common_utils::hipMallocHelper(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
     unsigned int* device_ranks;
-    HIP_CHECK(hipMalloc(&device_ranks, ranks.size() * sizeof(typename decltype(ranks)::value_type)));
+    HIP_CHECK(test_common_utils::hipMallocHelper(&device_ranks, ranks.size() * sizeof(typename decltype(ranks)::value_type)));
 
     HIP_CHECK(
         hipMemcpy(
@@ -741,11 +741,11 @@ TYPED_TEST(HipcubBlockExchangeTests, ScatterToStriped)
 
     // Preparing device
     type* device_input;
-    HIP_CHECK(hipMalloc(&device_input, input.size() * sizeof(typename decltype(input)::value_type)));
+    HIP_CHECK(test_common_utils::hipMallocHelper(&device_input, input.size() * sizeof(typename decltype(input)::value_type)));
     output_type* device_output;
-    HIP_CHECK(hipMalloc(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
+    HIP_CHECK(test_common_utils::hipMallocHelper(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
     unsigned int* device_ranks;
-    HIP_CHECK(hipMalloc(&device_ranks, ranks.size() * sizeof(typename decltype(ranks)::value_type)));
+    HIP_CHECK(test_common_utils::hipMallocHelper(&device_ranks, ranks.size() * sizeof(typename decltype(ranks)::value_type)));
 
     HIP_CHECK(
         hipMemcpy(

--- a/test/hipcub/test_hipcub_block_histogram.cpp
+++ b/test/hipcub/test_hipcub_block_histogram.cpp
@@ -172,9 +172,9 @@ TYPED_TEST(HipcubBlockHistogramInputArrayTests, Histogram)
 
         // Preparing device
         T* device_output;
-        HIP_CHECK(hipMalloc(&device_output, output.size() * sizeof(T)));
+        HIP_CHECK(test_common_utils::hipMallocHelper(&device_output, output.size() * sizeof(T)));
         T* device_output_bin;
-        HIP_CHECK(hipMalloc(&device_output_bin, output_bin.size() * sizeof(T)));
+        HIP_CHECK(test_common_utils::hipMallocHelper(&device_output_bin, output_bin.size() * sizeof(T)));
 
         HIP_CHECK(
             hipMemcpy(

--- a/test/hipcub/test_hipcub_block_load_store.cpp
+++ b/test/hipcub/test_hipcub_block_load_store.cpp
@@ -226,9 +226,9 @@ TYPED_TEST(HipcubBlockLoadStoreClassTests, LoadStoreClass)
 
         // Preparing device
         Type* device_input;
-        HIP_CHECK(hipMalloc(&device_input, input.size() * sizeof(typename decltype(input)::value_type)));
+        HIP_CHECK(test_common_utils::hipMallocHelper(&device_input, input.size() * sizeof(typename decltype(input)::value_type)));
         Type* device_output;
-        HIP_CHECK(hipMalloc(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
+        HIP_CHECK(test_common_utils::hipMallocHelper(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
 
         HIP_CHECK(
             hipMemcpy(
@@ -331,9 +331,9 @@ TYPED_TEST(HipcubBlockLoadStoreClassTests, LoadStoreClassValid)
 
         // Preparing device
         Type* device_input;
-        HIP_CHECK(hipMalloc(&device_input, input.size() * sizeof(typename decltype(input)::value_type)));
+        HIP_CHECK(test_common_utils::hipMallocHelper(&device_input, input.size() * sizeof(typename decltype(input)::value_type)));
         Type* device_output;
-        HIP_CHECK(hipMalloc(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
+        HIP_CHECK(test_common_utils::hipMallocHelper(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
 
         HIP_CHECK(
             hipMemcpy(
@@ -446,9 +446,9 @@ TYPED_TEST(HipcubBlockLoadStoreClassTests, LoadStoreClassDefault)
 
         // Preparing device
         Type* device_input;
-        HIP_CHECK(hipMalloc(&device_input, input.size() * sizeof(typename decltype(input)::value_type)));
+        HIP_CHECK(test_common_utils::hipMallocHelper(&device_input, input.size() * sizeof(typename decltype(input)::value_type)));
         Type* device_output;
-        HIP_CHECK(hipMalloc(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
+        HIP_CHECK(test_common_utils::hipMallocHelper(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
 
         HIP_CHECK(
             hipMemcpy(
@@ -611,11 +611,11 @@ TYPED_TEST(HipcubBlockLoadStoreClassTests, LoadStoreDiscardIterator)
 
         // Preparing device
         Type* device_input;
-        HIP_CHECK(hipMalloc(&device_input, input.size() * sizeof(typename decltype(input)::value_type)));
+        HIP_CHECK(test_common_utils::hipMallocHelper(&device_input, input.size() * sizeof(typename decltype(input)::value_type)));
         Type* device_guarded_elements;
-        HIP_CHECK(hipMalloc(&device_guarded_elements, guarded_expected.size() * sizeof(typename decltype(unguarded)::value_type)));
+        HIP_CHECK(test_common_utils::hipMallocHelper(&device_guarded_elements, guarded_expected.size() * sizeof(typename decltype(unguarded)::value_type)));
         Type* device_unguarded_elements;
-        HIP_CHECK(hipMalloc(&device_unguarded_elements, unguarded_expected.size() * sizeof(typename decltype(guarded)::value_type)));
+        HIP_CHECK(test_common_utils::hipMallocHelper(&device_unguarded_elements, unguarded_expected.size() * sizeof(typename decltype(guarded)::value_type)));
 
         HIP_CHECK(
             hipMemcpy(

--- a/test/hipcub/test_hipcub_block_radix_sort.cpp
+++ b/test/hipcub/test_hipcub_block_radix_sort.cpp
@@ -241,7 +241,7 @@ TYPED_TEST(HipcubBlockRadixSort, SortKeys)
 
         // Preparing device
         key_type* device_keys_output;
-        HIP_CHECK(hipMalloc(&device_keys_output, keys_output.size() * sizeof(key_type)));
+        HIP_CHECK(test_common_utils::hipMallocHelper(&device_keys_output, keys_output.size() * sizeof(key_type)));
 
         HIP_CHECK(
             hipMemcpy(
@@ -411,9 +411,9 @@ TYPED_TEST(HipcubBlockRadixSort, SortKeysValues)
         }
 
         key_type* device_keys_output;
-        HIP_CHECK(hipMalloc(&device_keys_output, keys_output.size() * sizeof(key_type)));
+        HIP_CHECK(test_common_utils::hipMallocHelper(&device_keys_output, keys_output.size() * sizeof(key_type)));
         value_type* device_values_output;
-        HIP_CHECK(hipMalloc(&device_values_output, values_output.size() * sizeof(value_type)));
+        HIP_CHECK(test_common_utils::hipMallocHelper(&device_values_output, values_output.size() * sizeof(value_type)));
 
         HIP_CHECK(
             hipMemcpy(

--- a/test/hipcub/test_hipcub_block_reduce.cpp
+++ b/test/hipcub/test_hipcub_block_reduce.cpp
@@ -155,9 +155,9 @@ TYPED_TEST(HipcubBlockReduceSingleValueTests, Reduce)
 
         // Preparing device
         T* device_output;
-        HIP_CHECK(hipMalloc(&device_output, output.size() * sizeof(T)));
+        HIP_CHECK(test_common_utils::hipMallocHelper(&device_output, output.size() * sizeof(T)));
         T* device_output_reductions;
-        HIP_CHECK(hipMalloc(&device_output_reductions, output_reductions.size() * sizeof(T)));
+        HIP_CHECK(test_common_utils::hipMallocHelper(&device_output_reductions, output_reductions.size() * sizeof(T)));
 
         HIP_CHECK(
             hipMemcpy(
@@ -266,9 +266,9 @@ TYPED_TEST(HipcubBlockReduceSingleValueTests, ReduceValid)
 
         // Preparing device
         T* device_output;
-        HIP_CHECK(hipMalloc(&device_output, output.size() * sizeof(T)));
+        HIP_CHECK(test_common_utils::hipMallocHelper(&device_output, output.size() * sizeof(T)));
         T* device_output_reductions;
-        HIP_CHECK(hipMalloc(&device_output_reductions, output_reductions.size() * sizeof(T)));
+        HIP_CHECK(test_common_utils::hipMallocHelper(&device_output_reductions, output_reductions.size() * sizeof(T)));
 
         HIP_CHECK(
             hipMemcpy(
@@ -418,9 +418,9 @@ TYPED_TEST(HipcubBlockReduceInputArrayTests, Reduce)
 
         // Preparing device
         T* device_output;
-        HIP_CHECK(hipMalloc(&device_output, output.size() * sizeof(T)));
+        HIP_CHECK(test_common_utils::hipMallocHelper(&device_output, output.size() * sizeof(T)));
         T* device_output_reductions;
-        HIP_CHECK(hipMalloc(&device_output_reductions, output_reductions.size() * sizeof(T)));
+        HIP_CHECK(test_common_utils::hipMallocHelper(&device_output_reductions, output_reductions.size() * sizeof(T)));
 
         HIP_CHECK(
             hipMemcpy(

--- a/test/hipcub/test_hipcub_block_scan.cpp
+++ b/test/hipcub/test_hipcub_block_scan.cpp
@@ -145,7 +145,7 @@ TYPED_TEST(HipcubBlockScanSingleValueTests, InclusiveScan)
 
         // Writing to device memory
         T* device_output;
-        HIP_CHECK(hipMalloc(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
+        HIP_CHECK(test_common_utils::hipMallocHelper(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
 
         HIP_CHECK(
             hipMemcpy(
@@ -245,10 +245,10 @@ TYPED_TEST(HipcubBlockScanSingleValueTests, InclusiveScanReduce)
 
         // Writing to device memory
         T* device_output;
-        HIP_CHECK(hipMalloc(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
+        HIP_CHECK(test_common_utils::hipMallocHelper(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
         T* device_output_reductions;
         HIP_CHECK(
-            hipMalloc(
+            test_common_utils::hipMallocHelper(
                   &device_output_reductions,
                   output_reductions.size() * sizeof(typename decltype(output_reductions)::value_type)
             )
@@ -387,10 +387,10 @@ TYPED_TEST(HipcubBlockScanSingleValueTests, InclusiveScanPrefixCallback)
 
         // Writing to device memory
         T* device_output;
-        HIP_CHECK(hipMalloc(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
+        HIP_CHECK(test_common_utils::hipMallocHelper(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
         T* device_output_bp;
         HIP_CHECK(
-            hipMalloc(
+            test_common_utils::hipMallocHelper(
                   &device_output_bp,
                   output_block_prefixes.size() * sizeof(typename decltype(output_block_prefixes)::value_type)
             )
@@ -506,7 +506,7 @@ TYPED_TEST(HipcubBlockScanSingleValueTests, ExclusiveScan)
 
         // Writing to device memory
         T* device_output;
-        HIP_CHECK(hipMalloc(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
+        HIP_CHECK(test_common_utils::hipMallocHelper(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
 
         HIP_CHECK(
           hipMemcpy(
@@ -619,10 +619,10 @@ TYPED_TEST(HipcubBlockScanSingleValueTests, ExclusiveScanReduce)
 
         // Writing to device memory
         T* device_output;
-        HIP_CHECK(hipMalloc(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
+        HIP_CHECK(test_common_utils::hipMallocHelper(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
         T* device_output_reductions;
         HIP_CHECK(
-            hipMalloc(
+            test_common_utils::hipMallocHelper(
                   &device_output_reductions,
                   output_reductions.size() * sizeof(typename decltype(output_reductions)::value_type)
             )
@@ -767,10 +767,10 @@ TYPED_TEST(HipcubBlockScanSingleValueTests, ExclusiveScanPrefixCallback)
 
         // Writing to device memory
         T* device_output;
-        HIP_CHECK(hipMalloc(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
+        HIP_CHECK(test_common_utils::hipMallocHelper(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
         T* device_output_bp;
         HIP_CHECK(
-            hipMalloc(
+            test_common_utils::hipMallocHelper(
                   &device_output_bp,
                   output_block_prefixes.size() * sizeof(typename decltype(output_block_prefixes)::value_type)
             )
@@ -873,7 +873,7 @@ TYPED_TEST(HipcubBlockScanSingleValueTests, CustomStruct)
 
         // Writing to device memory
         T* device_output;
-        HIP_CHECK(hipMalloc(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
+        HIP_CHECK(test_common_utils::hipMallocHelper(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
 
         HIP_CHECK(
             hipMemcpy(
@@ -1022,7 +1022,7 @@ TYPED_TEST(HipcubBlockScanInputArrayTests, InclusiveScan)
 
         // Writing to device memory
         T* device_output;
-        HIP_CHECK(hipMalloc(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
+        HIP_CHECK(test_common_utils::hipMallocHelper(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
 
         HIP_CHECK(
             hipMemcpy(
@@ -1143,10 +1143,10 @@ TYPED_TEST(HipcubBlockScanInputArrayTests, InclusiveScanReduce)
 
         // Writing to device memory
         T* device_output;
-        HIP_CHECK(hipMalloc(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
+        HIP_CHECK(test_common_utils::hipMallocHelper(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
         T* device_output_reductions;
         HIP_CHECK(
-            hipMalloc(
+            test_common_utils::hipMallocHelper(
                   &device_output_reductions,
                   output_reductions.size() * sizeof(typename decltype(output_reductions)::value_type)
             )
@@ -1304,10 +1304,10 @@ TYPED_TEST(HipcubBlockScanInputArrayTests, InclusiveScanPrefixCallback)
 
         // Writing to device memory
         T* device_output;
-        HIP_CHECK(hipMalloc(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
+        HIP_CHECK(test_common_utils::hipMallocHelper(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
         T* device_output_bp;
         HIP_CHECK(
-            hipMalloc(
+            test_common_utils::hipMallocHelper(
                   &device_output_bp,
                   output_block_prefixes.size() * sizeof(typename decltype(output_block_prefixes)::value_type)
             )
@@ -1453,7 +1453,7 @@ TYPED_TEST(HipcubBlockScanInputArrayTests, ExclusiveScan)
 
         // Writing to device memory
         T* device_output;
-        HIP_CHECK(hipMalloc(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
+        HIP_CHECK(test_common_utils::hipMallocHelper(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
 
         HIP_CHECK(
             hipMemcpy(
@@ -1582,10 +1582,10 @@ TYPED_TEST(HipcubBlockScanInputArrayTests, ExclusiveScanReduce)
 
         // Writing to device memory
         T* device_output;
-        HIP_CHECK(hipMalloc(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
+        HIP_CHECK(test_common_utils::hipMallocHelper(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
         T* device_output_reductions;
         HIP_CHECK(
-            hipMalloc(
+            test_common_utils::hipMallocHelper(
                   &device_output_reductions,
                   output_reductions.size() * sizeof(typename decltype(output_reductions)::value_type)
             )
@@ -1751,10 +1751,10 @@ TYPED_TEST(HipcubBlockScanInputArrayTests, ExclusiveScanPrefixCallback)
 
         // Writing to device memory
         T* device_output;
-        HIP_CHECK(hipMalloc(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
+        HIP_CHECK(test_common_utils::hipMallocHelper(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
         T* device_output_bp;
         HIP_CHECK(
-            hipMalloc(
+            test_common_utils::hipMallocHelper(
                   &device_output_bp,
                   output_block_prefixes.size() * sizeof(typename decltype(output_block_prefixes)::value_type)
             )

--- a/test/hipcub/test_hipcub_device_histogram.cpp
+++ b/test/hipcub/test_hipcub_device_histogram.cpp
@@ -184,8 +184,8 @@ TYPED_TEST(HipcubDeviceHistogramEven, Even)
 
             sample_type * d_input;
             counter_type * d_histogram;
-            HIP_CHECK(hipMalloc(&d_input, size * sizeof(sample_type)));
-            HIP_CHECK(hipMalloc(&d_histogram, bins * sizeof(counter_type)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_input, size * sizeof(sample_type)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_histogram, bins * sizeof(counter_type)));
             HIP_CHECK(
                 hipMemcpy(
                     d_input, input.data(),
@@ -240,7 +240,7 @@ TYPED_TEST(HipcubDeviceHistogramEven, Even)
             ASSERT_GT(temporary_storage_bytes, 0U);
 
             void * d_temporary_storage;
-            HIP_CHECK(hipMalloc(&d_temporary_storage, temporary_storage_bytes));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
             if(rows == 1)
             {
@@ -385,9 +385,9 @@ TYPED_TEST(HipcubDeviceHistogramRange, Range)
             sample_type * d_input;
             level_type * d_levels;
             counter_type * d_histogram;
-            HIP_CHECK(hipMalloc(&d_input, size * sizeof(sample_type)));
-            HIP_CHECK(hipMalloc(&d_levels, (bins + 1) * sizeof(level_type)));
-            HIP_CHECK(hipMalloc(&d_histogram, bins * sizeof(counter_type)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_input, size * sizeof(sample_type)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_levels, (bins + 1) * sizeof(level_type)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_histogram, bins * sizeof(counter_type)));
             HIP_CHECK(
                 hipMemcpy(
                     d_input, input.data(),
@@ -448,7 +448,7 @@ TYPED_TEST(HipcubDeviceHistogramRange, Range)
             ASSERT_GT(temporary_storage_bytes, 0U);
 
             void * d_temporary_storage;
-            HIP_CHECK(hipMalloc(&d_temporary_storage, temporary_storage_bytes));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
             if(rows == 1)
             {
@@ -637,10 +637,10 @@ TYPED_TEST(HipcubDeviceHistogramMultiEven, MultiEven)
 
             sample_type * d_input;
             counter_type * d_histogram[active_channels];
-            HIP_CHECK(hipMalloc(&d_input, size * sizeof(sample_type)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_input, size * sizeof(sample_type)));
             for(unsigned int channel = 0; channel < active_channels; channel++)
             {
-                HIP_CHECK(hipMalloc(&d_histogram[channel], bins[channel] * sizeof(counter_type)));
+                HIP_CHECK(test_common_utils::hipMallocHelper(&d_histogram[channel], bins[channel] * sizeof(counter_type)));
             }
             HIP_CHECK(
                 hipMemcpy(
@@ -708,7 +708,7 @@ TYPED_TEST(HipcubDeviceHistogramMultiEven, MultiEven)
             ASSERT_GT(temporary_storage_bytes, 0U);
 
             void * d_temporary_storage;
-            HIP_CHECK(hipMalloc(&d_temporary_storage, temporary_storage_bytes));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
             if(rows == 1)
             {
@@ -920,11 +920,11 @@ TYPED_TEST(HipcubDeviceHistogramMultiRange, MultiRange)
             sample_type * d_input;
             level_type * d_levels[active_channels];
             counter_type * d_histogram[active_channels];
-            HIP_CHECK(hipMalloc(&d_input, size * sizeof(sample_type)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_input, size * sizeof(sample_type)));
             for(unsigned int channel = 0; channel < active_channels; channel++)
             {
-                HIP_CHECK(hipMalloc(&d_levels[channel], num_levels[channel] * sizeof(level_type)));
-                HIP_CHECK(hipMalloc(&d_histogram[channel], bins[channel] * sizeof(counter_type)));
+                HIP_CHECK(test_common_utils::hipMallocHelper(&d_levels[channel], num_levels[channel] * sizeof(level_type)));
+                HIP_CHECK(test_common_utils::hipMallocHelper(&d_histogram[channel], bins[channel] * sizeof(counter_type)));
             }
             HIP_CHECK(
                 hipMemcpy(
@@ -1000,7 +1000,7 @@ TYPED_TEST(HipcubDeviceHistogramMultiRange, MultiRange)
             ASSERT_GT(temporary_storage_bytes, 0U);
 
             void * d_temporary_storage;
-            HIP_CHECK(hipMalloc(&d_temporary_storage, temporary_storage_bytes));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
             if(rows == 1)
             {

--- a/test/hipcub/test_hipcub_device_radix_sort.cpp
+++ b/test/hipcub/test_hipcub_device_radix_sort.cpp
@@ -176,8 +176,8 @@ TYPED_TEST(HipcubDeviceRadixSort, SortKeys)
 
             key_type * d_keys_input;
             key_type * d_keys_output;
-            HIP_CHECK(hipMalloc(&d_keys_input, size * sizeof(key_type)));
-            HIP_CHECK(hipMalloc(&d_keys_output, size * sizeof(key_type)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_keys_input, size * sizeof(key_type)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_keys_output, size * sizeof(key_type)));
             HIP_CHECK(
                 hipMemcpy(
                     d_keys_input, keys_input.data(),
@@ -202,7 +202,7 @@ TYPED_TEST(HipcubDeviceRadixSort, SortKeys)
             ASSERT_GT(temporary_storage_bytes, 0U);
 
             void * d_temporary_storage;
-            HIP_CHECK(hipMalloc(&d_temporary_storage, temporary_storage_bytes));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
             if(descending)
             {
@@ -299,8 +299,8 @@ TYPED_TEST(HipcubDeviceRadixSort, SortPairs)
 
             key_type * d_keys_input;
             key_type * d_keys_output;
-            HIP_CHECK(hipMalloc(&d_keys_input, size * sizeof(key_type)));
-            HIP_CHECK(hipMalloc(&d_keys_output, size * sizeof(key_type)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_keys_input, size * sizeof(key_type)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_keys_output, size * sizeof(key_type)));
             HIP_CHECK(
                 hipMemcpy(
                     d_keys_input, keys_input.data(),
@@ -311,8 +311,8 @@ TYPED_TEST(HipcubDeviceRadixSort, SortPairs)
 
             value_type * d_values_input;
             value_type * d_values_output;
-            HIP_CHECK(hipMalloc(&d_values_input, size * sizeof(value_type)));
-            HIP_CHECK(hipMalloc(&d_values_output, size * sizeof(value_type)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_values_input, size * sizeof(value_type)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_values_output, size * sizeof(value_type)));
             HIP_CHECK(
                 hipMemcpy(
                     d_values_input, values_input.data(),
@@ -346,7 +346,7 @@ TYPED_TEST(HipcubDeviceRadixSort, SortPairs)
 
             ASSERT_GT(temporary_storage_bytes, 0U);
 
-            HIP_CHECK(hipMalloc(&d_temporary_storage, temporary_storage_bytes));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
             if(descending)
             {
@@ -451,8 +451,8 @@ TYPED_TEST(HipcubDeviceRadixSort, SortKeysDoubleBuffer)
 
             key_type * d_keys_input;
             key_type * d_keys_output;
-            HIP_CHECK(hipMalloc(&d_keys_input, size * sizeof(key_type)));
-            HIP_CHECK(hipMalloc(&d_keys_output, size * sizeof(key_type)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_keys_input, size * sizeof(key_type)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_keys_output, size * sizeof(key_type)));
             HIP_CHECK(
                 hipMemcpy(
                     d_keys_input, keys_input.data(),
@@ -479,7 +479,7 @@ TYPED_TEST(HipcubDeviceRadixSort, SortKeysDoubleBuffer)
             ASSERT_GT(temporary_storage_bytes, 0U);
 
             void * d_temporary_storage;
-            HIP_CHECK(hipMalloc(&d_temporary_storage, temporary_storage_bytes));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
             if(descending)
             {
@@ -576,8 +576,8 @@ TYPED_TEST(HipcubDeviceRadixSort, SortPairsDoubleBuffer)
 
             key_type * d_keys_input;
             key_type * d_keys_output;
-            HIP_CHECK(hipMalloc(&d_keys_input, size * sizeof(key_type)));
-            HIP_CHECK(hipMalloc(&d_keys_output, size * sizeof(key_type)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_keys_input, size * sizeof(key_type)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_keys_output, size * sizeof(key_type)));
             HIP_CHECK(
                 hipMemcpy(
                     d_keys_input, keys_input.data(),
@@ -588,8 +588,8 @@ TYPED_TEST(HipcubDeviceRadixSort, SortPairsDoubleBuffer)
 
             value_type * d_values_input;
             value_type * d_values_output;
-            HIP_CHECK(hipMalloc(&d_values_input, size * sizeof(value_type)));
-            HIP_CHECK(hipMalloc(&d_values_output, size * sizeof(value_type)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_values_input, size * sizeof(value_type)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_values_output, size * sizeof(value_type)));
             HIP_CHECK(
                 hipMemcpy(
                     d_values_input, values_input.data(),
@@ -626,7 +626,7 @@ TYPED_TEST(HipcubDeviceRadixSort, SortPairsDoubleBuffer)
 
             ASSERT_GT(temporary_storage_bytes, 0U);
 
-            HIP_CHECK(hipMalloc(&d_temporary_storage, temporary_storage_bytes));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
             if(descending)
             {

--- a/test/hipcub/test_hipcub_device_reduce.cpp
+++ b/test/hipcub/test_hipcub_device_reduce.cpp
@@ -106,8 +106,8 @@ TYPED_TEST(HipcubDeviceReduceTests, Reduce)
 
             T * d_input;
             U * d_output;
-            HIP_CHECK(hipMalloc(&d_input, input.size() * sizeof(T)));
-            HIP_CHECK(hipMalloc(&d_output, output.size() * sizeof(U)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_input, input.size() * sizeof(T)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_output, output.size() * sizeof(U)));
             HIP_CHECK(
                 hipMemcpy(
                     d_input, input.data(),
@@ -140,7 +140,7 @@ TYPED_TEST(HipcubDeviceReduceTests, Reduce)
             ASSERT_GT(temp_storage_size_bytes, 0U);
 
             // allocate temporary storage
-            HIP_CHECK(hipMalloc(&d_temp_storage, temp_storage_size_bytes));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
             HIP_CHECK(hipDeviceSynchronize());
 
             // Run
@@ -197,8 +197,8 @@ TYPED_TEST(HipcubDeviceReduceTests, ReduceMinimum)
 
             T * d_input;
             U * d_output;
-            HIP_CHECK(hipMalloc(&d_input, input.size() * sizeof(T)));
-            HIP_CHECK(hipMalloc(&d_output, output.size() * sizeof(U)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_input, input.size() * sizeof(T)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_output, output.size() * sizeof(U)));
             HIP_CHECK(
                 hipMemcpy(
                     d_input, input.data(),
@@ -232,7 +232,7 @@ TYPED_TEST(HipcubDeviceReduceTests, ReduceMinimum)
             ASSERT_GT(temp_storage_size_bytes, 0U);
 
             // allocate temporary storage
-            HIP_CHECK(hipMalloc(&d_temp_storage, temp_storage_size_bytes));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
             HIP_CHECK(hipDeviceSynchronize());
 
             // Run
@@ -290,8 +290,8 @@ TYPED_TEST(HipcubDeviceReduceTests, ReduceArgMinimum)
 
             T * d_input;
             key_value * d_output;
-            HIP_CHECK(hipMalloc(&d_input, input.size() * sizeof(T)));
-            HIP_CHECK(hipMalloc(&d_output, output.size() * sizeof(key_value)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_input, input.size() * sizeof(T)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_output, output.size() * sizeof(key_value)));
             HIP_CHECK(
                 hipMemcpy(
                     d_input, input.data(),
@@ -322,7 +322,7 @@ TYPED_TEST(HipcubDeviceReduceTests, ReduceArgMinimum)
             ASSERT_GT(temp_storage_size_bytes, 0U);
 
             // allocate temporary storage
-            HIP_CHECK(hipMalloc(&d_temp_storage, temp_storage_size_bytes));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
             HIP_CHECK(hipDeviceSynchronize());
 
             // Run
@@ -381,8 +381,8 @@ TYPED_TEST(HipcubDeviceReduceTests, ReduceArgMaximum)
 
             T * d_input;
             key_value * d_output;
-            HIP_CHECK(hipMalloc(&d_input, input.size() * sizeof(T)));
-            HIP_CHECK(hipMalloc(&d_output, output.size() * sizeof(key_value)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_input, input.size() * sizeof(T)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_output, output.size() * sizeof(key_value)));
             HIP_CHECK(
                 hipMemcpy(
                     d_input, input.data(),
@@ -413,7 +413,7 @@ TYPED_TEST(HipcubDeviceReduceTests, ReduceArgMaximum)
             ASSERT_GT(temp_storage_size_bytes, 0U);
 
             // allocate temporary storage
-            HIP_CHECK(hipMalloc(&d_temp_storage, temp_storage_size_bytes));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
             HIP_CHECK(hipDeviceSynchronize());
 
             // Run

--- a/test/hipcub/test_hipcub_device_reduce_by_key.cpp
+++ b/test/hipcub/test_hipcub_device_reduce_by_key.cpp
@@ -167,8 +167,8 @@ TYPED_TEST(HipcubDeviceReduceByKey, ReduceByKey)
 
             key_type * d_keys_input;
             value_type * d_values_input;
-            HIP_CHECK(hipMalloc(&d_keys_input, size * sizeof(key_type)));
-            HIP_CHECK(hipMalloc(&d_values_input, size * sizeof(value_type)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_keys_input, size * sizeof(key_type)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_values_input, size * sizeof(value_type)));
             HIP_CHECK(
                 hipMemcpy(
                     d_keys_input, keys_input.data(),
@@ -187,9 +187,9 @@ TYPED_TEST(HipcubDeviceReduceByKey, ReduceByKey)
             key_type * d_unique_output;
             aggregate_type * d_aggregates_output;
             unsigned int * d_unique_count_output;
-            HIP_CHECK(hipMalloc(&d_unique_output, unique_count_expected * sizeof(key_type)));
-            HIP_CHECK(hipMalloc(&d_aggregates_output, unique_count_expected * sizeof(aggregate_type)));
-            HIP_CHECK(hipMalloc(&d_unique_count_output, sizeof(unsigned int)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_unique_output, unique_count_expected * sizeof(key_type)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_aggregates_output, unique_count_expected * sizeof(aggregate_type)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_unique_count_output, sizeof(unsigned int)));
 
             size_t temporary_storage_bytes = 0;
 
@@ -207,7 +207,7 @@ TYPED_TEST(HipcubDeviceReduceByKey, ReduceByKey)
             ASSERT_GT(temporary_storage_bytes, 0U);
 
             void * d_temporary_storage;
-            HIP_CHECK(hipMalloc(&d_temporary_storage, temporary_storage_bytes));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
             HIP_CHECK(
                 hipcub::DeviceReduce::ReduceByKey(

--- a/test/hipcub/test_hipcub_device_run_length_encode.cpp
+++ b/test/hipcub/test_hipcub_device_run_length_encode.cpp
@@ -147,7 +147,7 @@ TYPED_TEST(HipcubDeviceRunLengthEncode, Encode)
             }
 
             key_type * d_input;
-            HIP_CHECK(hipMalloc(&d_input, size * sizeof(key_type)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_input, size * sizeof(key_type)));
             HIP_CHECK(
                 hipMemcpy(
                     d_input, input.data(),
@@ -159,9 +159,9 @@ TYPED_TEST(HipcubDeviceRunLengthEncode, Encode)
             key_type * d_unique_output;
             count_type * d_counts_output;
             count_type * d_runs_count_output;
-            HIP_CHECK(hipMalloc(&d_unique_output, runs_count_expected * sizeof(key_type)));
-            HIP_CHECK(hipMalloc(&d_counts_output, runs_count_expected * sizeof(count_type)));
-            HIP_CHECK(hipMalloc(&d_runs_count_output, sizeof(count_type)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_unique_output, runs_count_expected * sizeof(key_type)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_counts_output, runs_count_expected * sizeof(count_type)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_runs_count_output, sizeof(count_type)));
 
             size_t temporary_storage_bytes = 0;
 
@@ -178,7 +178,7 @@ TYPED_TEST(HipcubDeviceRunLengthEncode, Encode)
             ASSERT_GT(temporary_storage_bytes, 0U);
 
             void * d_temporary_storage;
-            HIP_CHECK(hipMalloc(&d_temporary_storage, temporary_storage_bytes));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
             HIP_CHECK(
                 hipcub::DeviceRunLengthEncode::Encode(
@@ -314,7 +314,7 @@ TYPED_TEST(HipcubDeviceRunLengthEncode, NonTrivialRuns)
             }
 
             key_type * d_input;
-            HIP_CHECK(hipMalloc(&d_input, size * sizeof(key_type)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_input, size * sizeof(key_type)));
             HIP_CHECK(
                 hipMemcpy(
                     d_input, input.data(),
@@ -326,9 +326,9 @@ TYPED_TEST(HipcubDeviceRunLengthEncode, NonTrivialRuns)
             offset_type * d_offsets_output;
             count_type * d_counts_output;
             count_type * d_runs_count_output;
-            HIP_CHECK(hipMalloc(&d_offsets_output, std::max<size_t>(1, runs_count_expected) * sizeof(offset_type)));
-            HIP_CHECK(hipMalloc(&d_counts_output, std::max<size_t>(1, runs_count_expected) * sizeof(count_type)));
-            HIP_CHECK(hipMalloc(&d_runs_count_output, sizeof(count_type)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_offsets_output, std::max<size_t>(1, runs_count_expected) * sizeof(offset_type)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_counts_output, std::max<size_t>(1, runs_count_expected) * sizeof(count_type)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_runs_count_output, sizeof(count_type)));
 
             size_t temporary_storage_bytes = 0;
 
@@ -345,7 +345,7 @@ TYPED_TEST(HipcubDeviceRunLengthEncode, NonTrivialRuns)
             ASSERT_GT(temporary_storage_bytes, 0U);
 
             void * d_temporary_storage;
-            HIP_CHECK(hipMalloc(&d_temporary_storage, temporary_storage_bytes));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
             HIP_CHECK(
                 hipcub::DeviceRunLengthEncode::NonTrivialRuns(

--- a/test/hipcub/test_hipcub_device_scan.cpp
+++ b/test/hipcub/test_hipcub_device_scan.cpp
@@ -99,8 +99,8 @@ TYPED_TEST(HipcubDeviceScanTests, InclusiveScan)
 
             T * d_input;
             U * d_output;
-            HIP_CHECK(hipMalloc(&d_input, input.size() * sizeof(T)));
-            HIP_CHECK(hipMalloc(&d_output, output.size() * sizeof(U)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_input, input.size() * sizeof(T)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_output, output.size() * sizeof(U)));
             HIP_CHECK(
                 hipMemcpy(
                     d_input, input.data(),
@@ -149,7 +149,7 @@ TYPED_TEST(HipcubDeviceScanTests, InclusiveScan)
             ASSERT_GT(temp_storage_size_bytes, 0U);
 
             // allocate temporary storage
-            HIP_CHECK(hipMalloc(&d_temp_storage, temp_storage_size_bytes));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
             HIP_CHECK(hipDeviceSynchronize());
 
             // Run
@@ -225,8 +225,8 @@ TYPED_TEST(HipcubDeviceScanTests, ExclusiveScan)
 
             T * d_input;
             U * d_output;
-            HIP_CHECK(hipMalloc(&d_input, input.size() * sizeof(T)));
-            HIP_CHECK(hipMalloc(&d_output, output.size() * sizeof(U)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_input, input.size() * sizeof(T)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_output, output.size() * sizeof(U)));
             HIP_CHECK(
                 hipMemcpy(
                     d_input, input.data(),
@@ -280,7 +280,7 @@ TYPED_TEST(HipcubDeviceScanTests, ExclusiveScan)
             ASSERT_GT(temp_storage_size_bytes, 0U);
 
             // allocate temporary storage
-            HIP_CHECK(hipMalloc(&d_temp_storage, temp_storage_size_bytes));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
             HIP_CHECK(hipDeviceSynchronize());
 
             // Run

--- a/test/hipcub/test_hipcub_device_segmented_radix_sort.cpp
+++ b/test/hipcub/test_hipcub_device_segmented_radix_sort.cpp
@@ -199,8 +199,8 @@ TYPED_TEST(HipcubDeviceSegmentedRadixSort, SortKeys)
 
             key_type * d_keys_input;
             key_type * d_keys_output;
-            HIP_CHECK(hipMalloc(&d_keys_input, size * sizeof(key_type)));
-            HIP_CHECK(hipMalloc(&d_keys_output, size * sizeof(key_type)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_keys_input, size * sizeof(key_type)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_keys_output, size * sizeof(key_type)));
             HIP_CHECK(
                 hipMemcpy(
                     d_keys_input, keys_input.data(),
@@ -210,7 +210,7 @@ TYPED_TEST(HipcubDeviceSegmentedRadixSort, SortKeys)
             );
 
             offset_type * d_offsets;
-            HIP_CHECK(hipMalloc(&d_offsets, (segments_count + 1) * sizeof(offset_type)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_offsets, (segments_count + 1) * sizeof(offset_type)));
             HIP_CHECK(
                 hipMemcpy(
                     d_offsets, offsets.data(),
@@ -243,7 +243,7 @@ TYPED_TEST(HipcubDeviceSegmentedRadixSort, SortKeys)
             ASSERT_GT(temporary_storage_bytes, 0U);
 
             void * d_temporary_storage;
-            HIP_CHECK(hipMalloc(&d_temporary_storage, temporary_storage_bytes));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
             if(descending)
             {
@@ -361,8 +361,8 @@ TYPED_TEST(HipcubDeviceSegmentedRadixSort, SortPairs)
 
             key_type * d_keys_input;
             key_type * d_keys_output;
-            HIP_CHECK(hipMalloc(&d_keys_input, size * sizeof(key_type)));
-            HIP_CHECK(hipMalloc(&d_keys_output, size * sizeof(key_type)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_keys_input, size * sizeof(key_type)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_keys_output, size * sizeof(key_type)));
             HIP_CHECK(
                 hipMemcpy(
                     d_keys_input, keys_input.data(),
@@ -373,8 +373,8 @@ TYPED_TEST(HipcubDeviceSegmentedRadixSort, SortPairs)
 
             value_type * d_values_input;
             value_type * d_values_output;
-            HIP_CHECK(hipMalloc(&d_values_input, size * sizeof(value_type)));
-            HIP_CHECK(hipMalloc(&d_values_output, size * sizeof(value_type)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_values_input, size * sizeof(value_type)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_values_output, size * sizeof(value_type)));
             HIP_CHECK(
                 hipMemcpy(
                     d_values_input, values_input.data(),
@@ -384,7 +384,7 @@ TYPED_TEST(HipcubDeviceSegmentedRadixSort, SortPairs)
             );
 
             offset_type * d_offsets;
-            HIP_CHECK(hipMalloc(&d_offsets, (segments_count + 1) * sizeof(offset_type)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_offsets, (segments_count + 1) * sizeof(offset_type)));
             HIP_CHECK(
                 hipMemcpy(
                     d_offsets, offsets.data(),
@@ -423,7 +423,7 @@ TYPED_TEST(HipcubDeviceSegmentedRadixSort, SortPairs)
 
             ASSERT_GT(temporary_storage_bytes, 0U);
 
-            HIP_CHECK(hipMalloc(&d_temporary_storage, temporary_storage_bytes));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
             if(descending)
             {
@@ -549,8 +549,8 @@ TYPED_TEST(HipcubDeviceSegmentedRadixSort, SortKeysDoubleBuffer)
 
             key_type * d_keys_input;
             key_type * d_keys_output;
-            HIP_CHECK(hipMalloc(&d_keys_input, size * sizeof(key_type)));
-            HIP_CHECK(hipMalloc(&d_keys_output, size * sizeof(key_type)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_keys_input, size * sizeof(key_type)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_keys_output, size * sizeof(key_type)));
             HIP_CHECK(
                 hipMemcpy(
                     d_keys_input, keys_input.data(),
@@ -560,7 +560,7 @@ TYPED_TEST(HipcubDeviceSegmentedRadixSort, SortKeysDoubleBuffer)
             );
 
             offset_type * d_offsets;
-            HIP_CHECK(hipMalloc(&d_offsets, (segments_count + 1) * sizeof(offset_type)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_offsets, (segments_count + 1) * sizeof(offset_type)));
             HIP_CHECK(
                 hipMemcpy(
                     d_offsets, offsets.data(),
@@ -595,7 +595,7 @@ TYPED_TEST(HipcubDeviceSegmentedRadixSort, SortKeysDoubleBuffer)
             ASSERT_GT(temporary_storage_bytes, 0U);
 
             void * d_temporary_storage;
-            HIP_CHECK(hipMalloc(&d_temporary_storage, temporary_storage_bytes));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
             if(descending)
             {
@@ -713,8 +713,8 @@ TYPED_TEST(HipcubDeviceSegmentedRadixSort, SortPairsDoubleBuffer)
 
             key_type * d_keys_input;
             key_type * d_keys_output;
-            HIP_CHECK(hipMalloc(&d_keys_input, size * sizeof(key_type)));
-            HIP_CHECK(hipMalloc(&d_keys_output, size * sizeof(key_type)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_keys_input, size * sizeof(key_type)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_keys_output, size * sizeof(key_type)));
             HIP_CHECK(
                 hipMemcpy(
                     d_keys_input, keys_input.data(),
@@ -725,8 +725,8 @@ TYPED_TEST(HipcubDeviceSegmentedRadixSort, SortPairsDoubleBuffer)
 
             value_type * d_values_input;
             value_type * d_values_output;
-            HIP_CHECK(hipMalloc(&d_values_input, size * sizeof(value_type)));
-            HIP_CHECK(hipMalloc(&d_values_output, size * sizeof(value_type)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_values_input, size * sizeof(value_type)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_values_output, size * sizeof(value_type)));
             HIP_CHECK(
                 hipMemcpy(
                     d_values_input, values_input.data(),
@@ -736,7 +736,7 @@ TYPED_TEST(HipcubDeviceSegmentedRadixSort, SortPairsDoubleBuffer)
             );
 
             offset_type * d_offsets;
-            HIP_CHECK(hipMalloc(&d_offsets, (segments_count + 1) * sizeof(offset_type)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_offsets, (segments_count + 1) * sizeof(offset_type)));
             HIP_CHECK(
                 hipMemcpy(
                     d_offsets, offsets.data(),
@@ -778,7 +778,7 @@ TYPED_TEST(HipcubDeviceSegmentedRadixSort, SortPairsDoubleBuffer)
 
             ASSERT_GT(temporary_storage_bytes, 0U);
 
-            HIP_CHECK(hipMalloc(&d_temporary_storage, temporary_storage_bytes));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
             if(descending)
             {

--- a/test/hipcub/test_hipcub_device_segmented_reduce.cpp
+++ b/test/hipcub/test_hipcub_device_segmented_reduce.cpp
@@ -139,7 +139,7 @@ TYPED_TEST(HipcubDeviceSegmentedReduceOp, Reduce)
             offsets.push_back(size);
 
             input_type * d_values_input;
-            HIP_CHECK(hipMalloc(&d_values_input, size * sizeof(input_type)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_values_input, size * sizeof(input_type)));
             HIP_CHECK(
                 hipMemcpy(
                     d_values_input, values_input.data(),
@@ -149,7 +149,7 @@ TYPED_TEST(HipcubDeviceSegmentedReduceOp, Reduce)
             );
 
             offset_type * d_offsets;
-            HIP_CHECK(hipMalloc(&d_offsets, (segments_count + 1) * sizeof(offset_type)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_offsets, (segments_count + 1) * sizeof(offset_type)));
             HIP_CHECK(
                 hipMemcpy(
                     d_offsets, offsets.data(),
@@ -159,7 +159,7 @@ TYPED_TEST(HipcubDeviceSegmentedReduceOp, Reduce)
             );
 
             output_type * d_aggregates_output;
-            HIP_CHECK(hipMalloc(&d_aggregates_output, segments_count * sizeof(output_type)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_aggregates_output, segments_count * sizeof(output_type)));
 
             size_t temporary_storage_bytes;
 
@@ -177,7 +177,7 @@ TYPED_TEST(HipcubDeviceSegmentedReduceOp, Reduce)
             ASSERT_GT(temporary_storage_bytes, 0U);
 
             void * d_temporary_storage;
-            HIP_CHECK(hipMalloc(&d_temporary_storage, temporary_storage_bytes));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
             HIP_CHECK(
                 hipcub::DeviceSegmentedReduce::Reduce(
@@ -318,7 +318,7 @@ TYPED_TEST(HipcubDeviceSegmentedReduce, Sum)
             offsets.push_back(size);
 
             input_type * d_values_input;
-            HIP_CHECK(hipMalloc(&d_values_input, size * sizeof(input_type)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_values_input, size * sizeof(input_type)));
             HIP_CHECK(
                 hipMemcpy(
                     d_values_input, values_input.data(),
@@ -328,7 +328,7 @@ TYPED_TEST(HipcubDeviceSegmentedReduce, Sum)
             );
 
             offset_type * d_offsets;
-            HIP_CHECK(hipMalloc(&d_offsets, (segments_count + 1) * sizeof(offset_type)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_offsets, (segments_count + 1) * sizeof(offset_type)));
             HIP_CHECK(
                 hipMemcpy(
                     d_offsets, offsets.data(),
@@ -338,7 +338,7 @@ TYPED_TEST(HipcubDeviceSegmentedReduce, Sum)
             );
 
             output_type * d_aggregates_output;
-            HIP_CHECK(hipMalloc(&d_aggregates_output, segments_count * sizeof(output_type)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_aggregates_output, segments_count * sizeof(output_type)));
 
             size_t temporary_storage_bytes;
 
@@ -355,7 +355,7 @@ TYPED_TEST(HipcubDeviceSegmentedReduce, Sum)
             ASSERT_GT(temporary_storage_bytes, 0U);
 
             void * d_temporary_storage;
-            HIP_CHECK(hipMalloc(&d_temporary_storage, temporary_storage_bytes));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
             HIP_CHECK(
                 hipcub::DeviceSegmentedReduce::Sum(
@@ -463,7 +463,7 @@ TYPED_TEST(HipcubDeviceSegmentedReduce, Min)
             offsets.push_back(size);
 
             input_type * d_values_input;
-            HIP_CHECK(hipMalloc(&d_values_input, size * sizeof(input_type)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_values_input, size * sizeof(input_type)));
             HIP_CHECK(
                 hipMemcpy(
                     d_values_input, values_input.data(),
@@ -473,7 +473,7 @@ TYPED_TEST(HipcubDeviceSegmentedReduce, Min)
             );
 
             offset_type * d_offsets;
-            HIP_CHECK(hipMalloc(&d_offsets, (segments_count + 1) * sizeof(offset_type)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_offsets, (segments_count + 1) * sizeof(offset_type)));
             HIP_CHECK(
                 hipMemcpy(
                     d_offsets, offsets.data(),
@@ -483,7 +483,7 @@ TYPED_TEST(HipcubDeviceSegmentedReduce, Min)
             );
 
             output_type * d_aggregates_output;
-            HIP_CHECK(hipMalloc(&d_aggregates_output, segments_count * sizeof(output_type)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_aggregates_output, segments_count * sizeof(output_type)));
 
             size_t temporary_storage_bytes;
 
@@ -500,7 +500,7 @@ TYPED_TEST(HipcubDeviceSegmentedReduce, Min)
             ASSERT_GT(temporary_storage_bytes, 0U);
 
             void * d_temporary_storage;
-            HIP_CHECK(hipMalloc(&d_temporary_storage, temporary_storage_bytes));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
             HIP_CHECK(
                 hipcub::DeviceSegmentedReduce::Min(

--- a/test/hipcub/test_hipcub_device_select.cpp
+++ b/test/hipcub/test_hipcub_device_select.cpp
@@ -100,10 +100,10 @@ TYPED_TEST(HipcubDeviceSelectTests, Flagged)
             F * d_flags;
             U * d_output;
             unsigned int * d_selected_count_output;
-            HIP_CHECK(hipMalloc(&d_input, input.size() * sizeof(T)));
-            HIP_CHECK(hipMalloc(&d_flags, flags.size() * sizeof(F)));
-            HIP_CHECK(hipMalloc(&d_output, input.size() * sizeof(U)));
-            HIP_CHECK(hipMalloc(&d_selected_count_output, sizeof(unsigned int)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_input, input.size() * sizeof(T)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_flags, flags.size() * sizeof(F)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_output, input.size() * sizeof(U)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_selected_count_output, sizeof(unsigned int)));
             HIP_CHECK(
                 hipMemcpy(
                     d_input, input.data(),
@@ -154,7 +154,7 @@ TYPED_TEST(HipcubDeviceSelectTests, Flagged)
 
             // allocate temporary storage
             void * d_temp_storage = nullptr;
-            HIP_CHECK(hipMalloc(&d_temp_storage, temp_storage_size_bytes));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
             HIP_CHECK(hipDeviceSynchronize());
 
             // Run
@@ -245,9 +245,9 @@ TYPED_TEST(HipcubDeviceSelectTests, SelectOp)
             T * d_input;
             U * d_output;
             unsigned int * d_selected_count_output;
-            HIP_CHECK(hipMalloc(&d_input, input.size() * sizeof(T)));
-            HIP_CHECK(hipMalloc(&d_output, input.size() * sizeof(U)));
-            HIP_CHECK(hipMalloc(&d_selected_count_output, sizeof(unsigned int)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_input, input.size() * sizeof(T)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_output, input.size() * sizeof(U)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_selected_count_output, sizeof(unsigned int)));
             HIP_CHECK(
                 hipMemcpy(
                     d_input, input.data(),
@@ -291,7 +291,7 @@ TYPED_TEST(HipcubDeviceSelectTests, SelectOp)
 
             // allocate temporary storage
             void * d_temp_storage = nullptr;
-            HIP_CHECK(hipMalloc(&d_temp_storage, temp_storage_size_bytes));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
             HIP_CHECK(hipDeviceSynchronize());
 
             // Run
@@ -387,9 +387,9 @@ TYPED_TEST(HipcubDeviceSelectTests, Unique)
                 T * d_input;
                 U * d_output;
                 unsigned int * d_selected_count_output;
-                HIP_CHECK(hipMalloc(&d_input, input.size() * sizeof(T)));
-                HIP_CHECK(hipMalloc(&d_output, input.size() * sizeof(U)));
-                HIP_CHECK(hipMalloc(&d_selected_count_output, sizeof(unsigned int)));
+                HIP_CHECK(test_common_utils::hipMallocHelper(&d_input, input.size() * sizeof(T)));
+                HIP_CHECK(test_common_utils::hipMallocHelper(&d_output, input.size() * sizeof(U)));
+                HIP_CHECK(test_common_utils::hipMallocHelper(&d_selected_count_output, sizeof(unsigned int)));
                 HIP_CHECK(
                     hipMemcpy(
                         d_input, input.data(),
@@ -433,7 +433,7 @@ TYPED_TEST(HipcubDeviceSelectTests, Unique)
 
                 // allocate temporary storage
                 void * d_temp_storage = nullptr;
-                HIP_CHECK(hipMalloc(&d_temp_storage, temp_storage_size_bytes));
+                HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
                 HIP_CHECK(hipDeviceSynchronize());
 
                 // Run

--- a/test/hipcub/test_hipcub_util_ptx.cpp
+++ b/test/hipcub/test_hipcub_util_ptx.cpp
@@ -135,7 +135,7 @@ TYPED_TEST(HipcubUtilPtxTests, ShuffleUp)
 
         T* device_data;
         HIP_CHECK(
-            hipMalloc(
+            test_common_utils::hipMallocHelper(
                 &device_data,
                 input.size() * sizeof(typename decltype(input)::value_type)
             )
@@ -235,7 +235,7 @@ TYPED_TEST(HipcubUtilPtxTests, ShuffleDown)
 
         T * device_data;
         HIP_CHECK(
-            hipMalloc(
+            test_common_utils::hipMallocHelper(
                 &device_data,
                 input.size() * sizeof(typename decltype(input)::value_type)
             )
@@ -348,13 +348,13 @@ TYPED_TEST(HipcubUtilPtxTests, ShuffleIndex)
         T* device_data;
         int * device_src_offsets;
         HIP_CHECK(
-            hipMalloc(
+            test_common_utils::hipMallocHelper(
                 &device_data,
                 input.size() * sizeof(typename decltype(input)::value_type)
             )
         );
         HIP_CHECK(
-            hipMalloc(
+            test_common_utils::hipMallocHelper(
                 &device_src_offsets,
                 src_offsets.size() * sizeof(typename decltype(src_offsets)::value_type)
             )
@@ -440,7 +440,7 @@ TEST(HipcubUtilPtxTests, ShuffleUpCustomStruct)
 
         T* device_data;
         HIP_CHECK(
-            hipMalloc(
+            test_common_utils::hipMallocHelper(
                 &device_data,
                 input.size() * sizeof(typename decltype(input)::value_type)
             )
@@ -533,7 +533,7 @@ TEST(HipcubUtilPtxTests, ShuffleUpCustomAlignedStruct)
 
         T* device_data;
         HIP_CHECK(
-            hipMalloc(
+            test_common_utils::hipMallocHelper(
                 &device_data,
                 input.size() * sizeof(typename decltype(input)::value_type)
             )
@@ -605,7 +605,7 @@ TEST(HipcubUtilPtxTests, WarpId)
     std::vector<unsigned int> output(size);
     unsigned int* device_output;
     HIP_CHECK(
-        hipMalloc(
+        test_common_utils::hipMallocHelper(
             &device_output,
             output.size() * sizeof(unsigned int)
         )

--- a/test/hipcub/test_hipcub_warp_reduce.cpp
+++ b/test/hipcub/test_hipcub_warp_reduce.cpp
@@ -152,9 +152,9 @@ TYPED_TEST(HipcubWarpReduceTests, Reduce)
 
         // Writing to device memory
         T* device_input;
-        HIP_CHECK(hipMalloc(&device_input, input.size() * sizeof(typename decltype(input)::value_type)));
+        HIP_CHECK(test_common_utils::hipMallocHelper(&device_input, input.size() * sizeof(typename decltype(input)::value_type)));
         T* device_output;
-        HIP_CHECK(hipMalloc(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
+        HIP_CHECK(test_common_utils::hipMallocHelper(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
 
         HIP_CHECK(
             hipMemcpy(
@@ -265,9 +265,9 @@ TYPED_TEST(HipcubWarpReduceTests, ReduceValid)
 
         // Writing to device memory
         T* device_input;
-        HIP_CHECK(hipMalloc(&device_input, input.size() * sizeof(typename decltype(input)::value_type)));
+        HIP_CHECK(test_common_utils::hipMallocHelper(&device_input, input.size() * sizeof(typename decltype(input)::value_type)));
         T* device_output;
-        HIP_CHECK(hipMalloc(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
+        HIP_CHECK(test_common_utils::hipMallocHelper(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
 
         HIP_CHECK(
             hipMemcpy(
@@ -387,9 +387,9 @@ TYPED_TEST(HipcubWarpReduceTests, HeadSegmentedReduceSum)
         T* device_input;
         flag_type* device_flags;
         T* device_output;
-        HIP_CHECK(hipMalloc(&device_input, input.size() * sizeof(typename decltype(input)::value_type)));
-        HIP_CHECK(hipMalloc(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
-        HIP_CHECK(hipMalloc(&device_flags, flags.size() * sizeof(typename decltype(flags)::value_type)));
+        HIP_CHECK(test_common_utils::hipMallocHelper(&device_input, input.size() * sizeof(typename decltype(input)::value_type)));
+        HIP_CHECK(test_common_utils::hipMallocHelper(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
+        HIP_CHECK(test_common_utils::hipMallocHelper(&device_flags, flags.size() * sizeof(typename decltype(flags)::value_type)));
         HIP_CHECK(
             hipMemcpy(
                 device_input, input.data(),
@@ -542,9 +542,9 @@ TYPED_TEST(HipcubWarpReduceTests, TailSegmentedReduceSum)
         T* device_input;
         flag_type* device_flags;
         T* device_output;
-        HIP_CHECK(hipMalloc(&device_input, input.size() * sizeof(typename decltype(input)::value_type)));
-        HIP_CHECK(hipMalloc(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
-        HIP_CHECK(hipMalloc(&device_flags, flags.size() * sizeof(typename decltype(flags)::value_type)));
+        HIP_CHECK(test_common_utils::hipMallocHelper(&device_input, input.size() * sizeof(typename decltype(input)::value_type)));
+        HIP_CHECK(test_common_utils::hipMallocHelper(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
+        HIP_CHECK(test_common_utils::hipMallocHelper(&device_flags, flags.size() * sizeof(typename decltype(flags)::value_type)));
         HIP_CHECK(
             hipMemcpy(
                 device_input, input.data(),

--- a/test/hipcub/test_hipcub_warp_scan.cpp
+++ b/test/hipcub/test_hipcub_warp_scan.cpp
@@ -154,9 +154,9 @@ TYPED_TEST(HipcubWarpScanTests, InclusiveScan)
 
         // Writing to device memory
         T* device_input;
-        HIP_CHECK(hipMalloc(&device_input, input.size() * sizeof(typename decltype(input)::value_type)));
+        HIP_CHECK(test_common_utils::hipMallocHelper(&device_input, input.size() * sizeof(typename decltype(input)::value_type)));
         T* device_output;
-        HIP_CHECK(hipMalloc(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
+        HIP_CHECK(test_common_utils::hipMallocHelper(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
 
         HIP_CHECK(
             hipMemcpy(
@@ -288,12 +288,12 @@ TYPED_TEST(HipcubWarpScanTests, InclusiveScanReduce)
 
         // Writing to device memory
         T* device_input;
-        HIP_CHECK(hipMalloc(&device_input, input.size() * sizeof(typename decltype(input)::value_type)));
+        HIP_CHECK(test_common_utils::hipMallocHelper(&device_input, input.size() * sizeof(typename decltype(input)::value_type)));
         T* device_output;
-        HIP_CHECK(hipMalloc(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
+        HIP_CHECK(test_common_utils::hipMallocHelper(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
         T* device_output_reductions;
         HIP_CHECK(
-            hipMalloc(
+            test_common_utils::hipMallocHelper(
                 &device_output_reductions,
                 output_reductions.size() * sizeof(typename decltype(output_reductions)::value_type)
             )
@@ -433,9 +433,9 @@ TYPED_TEST(HipcubWarpScanTests, ExclusiveScan)
 
         // Writing to device memory
         T* device_input;
-        HIP_CHECK(hipMalloc(&device_input, input.size() * sizeof(typename decltype(input)::value_type)));
+        HIP_CHECK(test_common_utils::hipMallocHelper(&device_input, input.size() * sizeof(typename decltype(input)::value_type)));
         T* device_output;
-        HIP_CHECK(hipMalloc(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
+        HIP_CHECK(test_common_utils::hipMallocHelper(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
 
         HIP_CHECK(
             hipMemcpy(
@@ -569,12 +569,12 @@ TYPED_TEST(HipcubWarpScanTests, ExclusiveReduceScan)
 
         // Writing to device memory
         T* device_input;
-        HIP_CHECK(hipMalloc(&device_input, input.size() * sizeof(typename decltype(input)::value_type)));
+        HIP_CHECK(test_common_utils::hipMallocHelper(&device_input, input.size() * sizeof(typename decltype(input)::value_type)));
         T* device_output;
-        HIP_CHECK(hipMalloc(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
+        HIP_CHECK(test_common_utils::hipMallocHelper(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
         T* device_output_reductions;
         HIP_CHECK(
-          hipMalloc(
+          test_common_utils::hipMallocHelper(
             &device_output_reductions,
             output_reductions.size() * sizeof(typename decltype(output_reductions)::value_type)
           )
@@ -727,17 +727,17 @@ TYPED_TEST(HipcubWarpScanTests, Scan)
 
         // Writing to device memory
         T* device_input;
-        HIP_CHECK(hipMalloc(&device_input, input.size() * sizeof(typename decltype(input)::value_type)));
+        HIP_CHECK(test_common_utils::hipMallocHelper(&device_input, input.size() * sizeof(typename decltype(input)::value_type)));
         T* device_inclusive_output;
         HIP_CHECK(
-            hipMalloc(
+            test_common_utils::hipMallocHelper(
                 &device_inclusive_output,
                 output_inclusive.size() * sizeof(typename decltype(output_inclusive)::value_type)
             )
         );
         T* device_exclusive_output;
         HIP_CHECK(
-            hipMalloc(
+            test_common_utils::hipMallocHelper(
                 &device_exclusive_output,
                 output_exclusive.size() * sizeof(typename decltype(output_exclusive)::value_type)
             )
@@ -859,9 +859,9 @@ TYPED_TEST(HipcubWarpScanTests, InclusiveScanCustomType)
 
         // Writing to device memory
         T* device_input;
-        HIP_CHECK(hipMalloc(&device_input, input.size() * sizeof(typename decltype(input)::value_type)));
+        HIP_CHECK(test_common_utils::hipMallocHelper(&device_input, input.size() * sizeof(typename decltype(input)::value_type)));
         T* device_output;
-        HIP_CHECK(hipMalloc(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
+        HIP_CHECK(test_common_utils::hipMallocHelper(&device_output, output.size() * sizeof(typename decltype(output)::value_type)));
 
         HIP_CHECK(
             hipMemcpy(


### PR DESCRIPTION
To enable, run tests with HIPCUB_USE_HMM=1 environment variable set on supported hardware.