### PR TITLE
Update changelog & fix rocm_export_targets_header_only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 See README.md on how to build the hipCUB documentation using Doxygen.
 
+## (Unreleased) hipCUB-2.10.12
+### Changed
+- Packaging split into a runtime package called hipcub and a development package called hipcub-devel. The development package depends on runtime. The runtime package suggests the development package for all supported OSes except CentOS 7 to aid in the transition. The suggests feature in packaging is introduced as a deprecated feature and will be removed in a future rocm release.
+    - As hipCUB is a header-only library, the runtime package is an empty placeholder used to aid in the transition. This package is also a deprecated feature and will be removed in a future rocm release.
+
 ## [Unreleased hipCUB-2.10.11 for ROCm 4.4.0]
 ### Added
 - gfx1030 support added.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,7 +107,7 @@ endif()
 include(cmake/Dependencies.cmake)
 
 # Setup VERSION
-set(VERSION_STRING "2.10.9")
+set(VERSION_STRING "2.10.12")
 rocm_setup_version(VERSION ${VERSION_STRING})
 
 # Print configuration summary

--- a/cmake/ROCMExportTargetsHeaderOnly.cmake
+++ b/cmake/ROCMExportTargetsHeaderOnly.cmake
@@ -97,7 +97,7 @@ function(rocm_export_targets_header_only)
     endif()
 
     foreach(INCLUDE ${PARSE_INCLUDE})
-        install(FILES ${INCLUDE} DESTINATION ${CONFIG_PACKAGE_INSTALL_DIR})
+        rocm_install(FILES ${INCLUDE} DESTINATION ${CONFIG_PACKAGE_INSTALL_DIR})
         get_filename_component(INCLUDE_BASE ${INCLUDE} NAME)
         rocm_write_package_template_function(${CONFIG_TEMPLATE} include "\${CMAKE_CURRENT_LIST_DIR}/${INCLUDE_BASE}")
     endforeach()
@@ -131,13 +131,13 @@ function(rocm_export_targets_header_only)
     if(PARSE_NAMESPACE)
         set(NAMESPACE_ARG "NAMESPACE;${PARSE_NAMESPACE}")
     endif()
-    install( EXPORT ${TARGET_FILE}
+    rocm_install( EXPORT ${TARGET_FILE}
         DESTINATION
         ${CONFIG_PACKAGE_INSTALL_DIR}
         ${NAMESPACE_ARG}
     )
 
-    install( FILES
+    rocm_install( FILES
         ${CMAKE_CURRENT_BINARY_DIR}/${CONFIG_NAME}.cmake
         ${CMAKE_CURRENT_BINARY_DIR}/${CONFIG_NAME}-version.cmake
         DESTINATION


### PR DESCRIPTION
Switch rocm_export_targets_header_only to use rocm_install rather than install.

#152 did not update documentation.