### PR TITLE
Remove runtime package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,8 +147,8 @@ endif()
 
 # Package
 if(HIP_COMPILER STREQUAL "hcc" OR HIP_COMPILER STREQUAL "clang")
-  set(CPACK_DEBIAN_PACKAGE_DEPENDS "rocprim (>= 2.10.1)")
-  set(CPACK_RPM_PACKAGE_REQUIRES "rocprim >= 2.10.1")
+  set(CPACK_DEBIAN_PACKAGE_DEPENDS "rocprim-devel (>= 2.10.1)")
+  set(CPACK_RPM_PACKAGE_REQUIRES "rocprim-devel >= 2.10.1")
   set(CPACK_DEBIAN_PACKAGE_REPLACES "cub-hip")
   set(CPACK_RPM_PACKAGE_OBSOLETES "cub-hip")
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,11 +167,13 @@ if(HIP_COMPILER STREQUAL "hcc" OR HIP_COMPILER STREQUAL "clang")
     NAME hipcub
     DESCRIPTION "hipCUB (rocPRIM backend)"
     MAINTAINER "hipcub-maintainer@amd.com"
+    HEADER_ONLY
   )
 else()
   rocm_create_package(
     NAME hipcub_nvcc
     DESCRIPTION "hipCUB (CUB backend)"
     MAINTAINER "hipcub-maintainer@amd.com"
+    HEADER_ONLY
   )
 endif()


### PR DESCRIPTION
As hipCUB is a header-only library, use the HEADER_ONLY option to rocm_create_package in the latest version of rocm-cmake to prevent generation of an empty runtime package. Also update the dependency on rocprim to be a dependency on rocprim-devel.