### PR TITLE
Rename rocprim-devel dependency on debian

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,7 @@ See README.md on how to build the hipCUB documentation using Doxygen.
 ### Addded
 - Initial HIP on Windows support. See README for instructions on how to build and install.
 ### Changed
-- Packaging split into a runtime package called hipcub and a development package called hipcub-devel. The development package depends on runtime. The runtime package suggests the development package for all supported OSes except CentOS 7 to aid in the transition. The suggests feature in packaging is introduced as a deprecated feature and will be removed in a future rocm release.
-    - As hipCUB is a header-only library, the runtime package is an empty placeholder used to aid in the transition. This package is also a deprecated feature and will be removed in a future rocm release.
+- Packaging changed to a development package (called hipcub-dev for Debian, and hipcub-devel for other OSes). As hipCUB is a header-only library, there is no runtime package. To aid in the transition, the development package sets the "provides" field to provide the package hipcub, so that existing packages depending on hipcub can continue to work. This provides feature is introduced as a deprecated feature and will be removed in a future ROCm release.
 
 ## [Unreleased hipCUB-2.10.11 for ROCm 4.4.0]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ See README.md on how to build the hipCUB documentation using Doxygen.
 ### Addded
 - Initial HIP on Windows support. See README for instructions on how to build and install.
 ### Changed
-- Packaging changed to a development package (called hipcub-dev for Debian, and hipcub-devel for other OSes). As hipCUB is a header-only library, there is no runtime package. To aid in the transition, the development package sets the "provides" field to provide the package hipcub, so that existing packages depending on hipcub can continue to work. This provides feature is introduced as a deprecated feature and will be removed in a future ROCm release.
+- Packaging changed to a development package (called hipcub-dev for `.deb` packages, and hipcub-devel for `.rpm` packages). As hipCUB is a header-only library, there is no runtime package. To aid in the transition, the development package sets the "provides" field to provide the package hipcub, so that existing packages depending on hipcub can continue to work. This provides feature is introduced as a deprecated feature and will be removed in a future ROCm release.
 
 ## [Unreleased hipCUB-2.10.11 for ROCm 4.4.0]
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,7 +147,7 @@ endif()
 
 # Package
 if(HIP_COMPILER STREQUAL "hcc" OR HIP_COMPILER STREQUAL "clang")
-  set(CPACK_DEBIAN_PACKAGE_DEPENDS "rocprim-devel (>= 2.10.1)")
+  set(CPACK_DEBIAN_PACKAGE_DEPENDS "rocprim-dev (>= 2.10.1)")
   set(CPACK_RPM_PACKAGE_REQUIRES "rocprim-devel >= 2.10.1")
   set(CPACK_DEBIAN_PACKAGE_REPLACES "cub-hip")
   set(CPACK_RPM_PACKAGE_OBSOLETES "cub-hip")


### PR DESCRIPTION
To match the industry-standard package naming, rocprim-devel is called rocprim-dev on Debian.