### PR TITLE
Replacing hipPeekAtLastError with GetLastError

### DIFF
--- a/hipcub/include/hipcub/backend/rocprim/device/device_spmv.hpp
+++ b/hipcub/include/hipcub/backend/rocprim/device/device_spmv.hpp
@@ -139,7 +139,7 @@ template <typename ValueT>
             size_t block_size = min(num_cols, DeviceSpmv::CsrMVKernel_MaxThreads);
             size_t grid_size = num_rows;
             CsrMVKernel<<<grid_size, block_size, 0, stream>>>(spmv_params);
-            status = hipPeekAtLastError();
+            status = hipGetLastError();
         }
         return status;
     }


### PR DESCRIPTION
See explanation at https://github.com/ROCmSoftwarePlatform/rocPRIM/pull/266