### PR TITLE
Hotfixes from release/rocm-rel-4.5 at release 4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,24 +2,21 @@
 
 See README.md on how to build the hipCUB documentation using Doxygen.
 
-## (Unreleased) hipCUB-2.10.12 for ROCm 4.5.0
+## hipCUB-2.10.12 for ROCm 4.5.0
 ### Addded
 - Initial HIP on Windows support. See README for instructions on how to build and install.
-### Changed
-- Packaging changed to a development package (called hipcub-dev for `.deb` packages, and hipcub-devel for `.rpm` packages). As hipCUB is a header-only library, there is no runtime package. To aid in the transition, the development package sets the "provides" field to provide the package hipcub, so that existing packages depending on hipcub can continue to work. This provides feature is introduced as a deprecated feature and will be removed in a future ROCm release.
-
-## [Unreleased hipCUB-2.10.11 for ROCm 4.4.0]
-### Added
 - gfx1030 support added.
 - Address Sanitizer build option
+### Changed
+- Packaging changed to a development package (called hipcub-dev for `.deb` packages, and hipcub-devel for `.rpm` packages). As hipCUB is a header-only library, there is no runtime package. To aid in the transition, the development package sets the "provides" field to provide the package hipcub, so that existing packages depending on hipcub can continue to work. This provides feature is introduced as a deprecated feature and will be removed in a future ROCm release.
 ### Fixed
 - BlockRadixRank unit test failure fixed.
 
-## [Unreleased hipCUB-2.10.10 for ROCm 4.3.0]
+## hipCUB-2.10.10 for ROCm 4.3.0
 ### Added
 - DiscardOutputIterator to backend header
 
-## [hipCUB-2.10.9 for ROCm 4.2.0]
+## hipCUB-2.10.9 for ROCm 4.2.0
 ### Added
 - Support for TexObjInputIterator and TexRefInputIterator
 - Support for DevicePartition
@@ -30,19 +27,19 @@ See README.md on how to build the hipCUB documentation using Doxygen.
 - Benchmark build fixed
 - nvcc build fixed
 
-## [hipCUB-2.10.8 for ROCm 4.1.0]
+## hipCUB-2.10.8 for ROCm 4.1.0
 ### Added
 - Support for DiscardOutputIterator
 
-## [hipCUB-2.10.7 for ROCm 4.0.0]
+## hipCUB-2.10.7 for ROCm 4.0.0
 ### Added
 - No new features
 
-## [hipCUB-2.10.6 for ROCm 3.10]
+## hipCUB-2.10.6 for ROCm 3.10
 ### Added
 - No new features
 
-## [hipCUB-2.10.5 for ROCm 3.9.0]
+## hipCUB-2.10.5 for ROCm 3.9.0
 ### Added
 - No new features
 
@@ -54,11 +51,11 @@ See README.md on how to build the hipCUB documentation using Doxygen.
 ### Added
 - No new features
 
-## [hipCUB-2.10.2 for ROCm 3.6.0]
+## hipCUB-2.10.2 for ROCm 3.6.0
 ### Added
 - No new features
 
-## [hipCUB-2.10.1 for ROCm 3.5.0]
+## hipCUB-2.10.1 for ROCm 3.5.0
 ### Added
 - Improved tests with fixed and random seeds for test data
 ### Changed


### PR DESCRIPTION
This is an autogenerated PR.
This is intended to pull any hotfixes for ROCm release 4.5 (including changelogs and documentation) back into develop.