### PR TITLE
Develop stream 2021 11 18

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,15 +28,15 @@ stages:
 variables:
   SUDO_CMD: "" # Must be "sudo" on images which don't use root user
   DEPS_DIR: "$CI_PROJECT_DIR/__dependencies"
-  CMAKE_ROCM_MINIMUM_URL: "https://cmake.org/files/v3.10/cmake-3.10.2-Linux-x86_64.tar.gz"
-  CMAKE_NVIDIA_MINIMUM_URL: "https://cmake.org/files/v3.15/cmake-3.15.7-Linux-x86_64.tar.gz"
+  CMAKE_ROCM_MINIMUM_URL: "https://cmake.org/files/v3.16/cmake-3.16.9-Linux-x86_64.tar.gz"
+  CMAKE_NVIDIA_MINIMUM_URL: "https://cmake.org/files/v3.16/cmake-3.16.9-Linux-x86_64.tar.gz"
   # General build flags
   CXXFLAGS: ""
   CMAKE_OPTIONS: ""
   # Local build options
   LOCAL_CXXFLAGS: ""
   LOCAL_CMAKE_OPTIONS: ""
-  ROCM_LATEST_PATH: "/opt/rocm-4.3.0/"
+  ROCM_LATEST_PATH: "/opt/rocm-4.5.0/"
   ROCPRIM_GIT_BRANCH: "develop_stream"
 
 # hipCUB with rocPRIM backend
@@ -86,7 +86,6 @@ variables:
     - git clone -b $branch_name https://gitlab-ci-token:${CI_JOB_TOKEN}@${ROCPRIM_GIT_URL}
     - cd rocPRIM
     - mkdir build
-    - cd build
     - cmake
       -G Ninja
       -D CMAKE_CXX_COMPILER=hipcc
@@ -95,7 +94,11 @@ variables:
       -D BUILD_EXAMPLE=OFF
       -D ROCM_DEP_ROCMCORE=OFF
       -B build
-      ../.
+      -S ./
+    - $SUDO_CMD cmake
+      --build build
+      --target install
+    - cd build
     - $SUDO_CMD cpack
       -G "DEB"
     - $SUDO_CMD dpkg -i rocprim*.deb
@@ -105,9 +108,6 @@ build:rocm:
   extends: .rocm:build
   stage: build
   script:
-    - if [ ! -d "build" ] ; then mkdir build;
-    - fi;
-    - cd build
     - cmake
       -G Ninja
       -D CMAKE_CXX_COMPILER=hipcc
@@ -116,9 +116,10 @@ build:rocm:
       -D BUILD_EXAMPLE=ON
       -D AMDGPU_TARGETS="gfx803;gfx900;gfx906"
       -B build
-      ../.
+      -S ./
     - cmake
-      --build ./
+      --build build
+    - cd build
     - $SUDO_CMD cpack
       -G "DEB;ZIP"
   artifacts:
@@ -142,9 +143,6 @@ build:rocm-benchmark:
     - develop
     - master
   script:
-    - if [ ! -d "build" ] ; then mkdir build;
-    - fi;
-    - cd build
     # Build hipCUB benchmark
     - cmake
       -G Ninja
@@ -152,9 +150,9 @@ build:rocm-benchmark:
       -D CMAKE_BUILD_TYPE=Release
       -D BUILD_BENCHMARK=ON
       -B build
-      ../.
+      -S ./
     - cmake
-      --build ./
+      --build build
   artifacts:
     paths:
       - build/benchmark/*
@@ -324,16 +322,13 @@ test:rocm_install:
   image: nvidia/cuda:11.3.1-devel-ubuntu18.04
   before_script:
     - nvidia-smi
-    # HIP-nvcc
     - $SUDO_CMD apt-get update -qq
     - $SUDO_CMD apt-get install -y -qq libnuma-dev libunwind-dev git wget tar xz-utils bzip2 build-essential pkg-config ninja-build protobuf-compiler gcc-8 g++-8 libidn11 ca-certificates
     - $SUDO_CMD wget -q -O - https://repo.radeon.com/rocm/rocm.gpg.key | $SUDO_CMD apt-key add -
     - $SUDO_CMD echo 'deb [arch=amd64] https://repo.radeon.com/rocm/apt/debian/ ubuntu main' | $SUDO_CMD tee /etc/apt/sources.list.d/rocm.list
     - $SUDO_CMD apt-get update -qq
     - $SUDO_CMD apt-get install -y hip-base
-    # Install hip-nvcc ignoring dependencies because it depends on cuda metapackage
-    # (with heavy libraries, tools etc. that also require GUI and other packages)
-    - apt-get download hip-nvcc rocm-cmake
+    - apt-get download hip-runtime-nvidia rocm-cmake hip-dev
     - $SUDO_CMD dpkg -i --ignore-depends=cuda hip*.deb
     - $SUDO_CMD ls -d /opt/*
     - $SUDO_CMD ln -s $ROCM_LATEST_PATH /opt/rocm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ See README.md on how to build the hipCUB documentation using Doxygen.
 - API update to CUB 1.14.0
 ### Changed
 - The SetupNVCC.cmake automatic target selector select all of the capabalities of all available card for NVIDIA backend.
+- Device_scan and device_segmented_scan: inclusive_scan now uses the input-type as accumulator-type, exclusive_scan uses initial-value-type.
+  - This particularly changes behaviour of small-size input types with large-size output types (e.g. short input, int output).
+  - And low-res input with high-res output (e.g. float input, double output)
+
 
 ## (Unreleased) hipCUB-2.10.12 for ROCm 4.5.0
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.16.9 FATAL_ERROR)
 
 # Install prefix
 set(CMAKE_INSTALL_PREFIX "/opt/rocm" CACHE PATH "Install path prefix, prepended onto install directories")
@@ -153,8 +153,8 @@ if(HIP_COMPILER STREQUAL "hcc" OR HIP_COMPILER STREQUAL "clang")
   set(CPACK_DEBIAN_PACKAGE_REPLACES "cub-hip")
   set(CPACK_RPM_PACKAGE_OBSOLETES "cub-hip")
 else()
-  set(CPACK_DEBIAN_PACKAGE_DEPENDS "hip-nvcc (>= 1.5)")
-  set(CPACK_RPM_PACKAGE_REQUIRES "hip-nvcc >= 1.5")
+  set(CPACK_DEBIAN_PACKAGE_DEPENDS "hip-dev (>= 4.4)")
+  set(CPACK_RPM_PACKAGE_REQUIRES "hip-dev >= 4.4")
 endif()
 set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE.txt")
 # if(NOT CPACK_PACKAGING_INSTALL_PREFIX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-cmake_minimum_required(VERSION 3.16.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
+cmake_policy(VERSION 3.16...3.21)
 
 # Install prefix
 set(CMAKE_INSTALL_PREFIX "/opt/rocm" CACHE PATH "Install path prefix, prepended onto install directories")

--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ environment, hipCUB uses the rocPRIM library as the backend.  However, on CUDA p
 ## Requirements
 
 * Git
-* CMake (3.10.2 or later)
+* CMake (3.16.9 or later)
 * For AMD GPUs:
   * AMD [ROCm](https://rocm.github.io/install.html) platform (1.8.0 or later)
     * Including [HIP-clang](https://github.com/ROCm-Developer-Tools/HIP/blob/master/INSTALL.md#hip-clang) compiler, which must be
       set as C++ compiler on ROCm platform.
   * [rocPRIM](https://github.com/ROCmSoftwarePlatform/rocPRIM) library
     * Automatically downloaded and built by CMake script.
-    * Requires CMake 3.10.2 or later.
+    * Requires CMake 3.16.9 or later.
 * For NVIDIA GPUs:
   * CUDA Toolkit
   * CUB library

--- a/hipcub/include/hipcub/backend/rocprim/device/device_scan.hpp
+++ b/hipcub/include/hipcub/backend/rocprim/device/device_scan.hpp
@@ -79,7 +79,7 @@ public:
         return ::rocprim::inclusive_scan(
             d_temp_storage, temp_storage_bytes,
             d_in, d_out, num_items,
-            ::hipcub::detail::convert_result_type<InputIteratorT, OutputIteratorT>(scan_op),
+            scan_op,
             stream, debug_synchronous
         );
     }
@@ -125,7 +125,7 @@ public:
         return ::rocprim::exclusive_scan(
             d_temp_storage, temp_storage_bytes,
             d_in, d_out, init_value, num_items,
-            ::hipcub::detail::convert_result_type<InputIteratorT, OutputIteratorT>(scan_op),
+            scan_op,
             stream, debug_synchronous
         );
     }

--- a/hipcub/include/hipcub/backend/rocprim/thread/thread_operators.hpp
+++ b/hipcub/include/hipcub/backend/rocprim/thread/thread_operators.hpp
@@ -135,7 +135,7 @@ struct ArgMin
 namespace detail
 {
 
-// CUB uses value_type of OutputIteratorT (if not void) as a type of intermediate results in scan and reduce,
+// CUB uses value_type of OutputIteratorT (if not void) as a type of intermediate results in reduce,
 // for example:
 //
 // /// The output value type

--- a/test/extra/CMakeLists.txt
+++ b/test/extra/CMakeLists.txt
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.16.9 FATAL_ERROR)
 
 # This project includes tests that should be run after
 # hipCUB is installed from package or using `make install`

--- a/test/extra/CMakeLists.txt
+++ b/test/extra/CMakeLists.txt
@@ -20,7 +20,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-cmake_minimum_required(VERSION 3.16.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
+cmake_policy(VERSION 3.16...3.21)
 
 # This project includes tests that should be run after
 # hipCUB is installed from package or using `make install`

--- a/test/hipcub/test_hipcub_device_scan.cpp
+++ b/test/hipcub/test_hipcub_device_scan.cpp
@@ -333,6 +333,9 @@ TYPED_TEST(HipcubDeviceScanTests, ExclusiveScan)
     }
 }
 
+// CUB does not support large indices in inclusive and exclusive scans
+#ifndef __HIP_PLATFORM_NVIDIA__
+
 TEST(HipcubDeviceScanTests, LargeIndicesInclusiveScan)
 {
     using T = unsigned int;
@@ -502,3 +505,5 @@ TEST(HipcubDeviceScanTests, LargeIndicesExclusiveScan)
     hipFree(d_output);
     hipFree(d_temp_storage);
 }
+
+#endif


### PR DESCRIPTION
- Update cmake minimum
- Disabled large scan tests at NVIDIA and updated at AMD platform
- Updated gitlab CI
- Replaced hip-nvcc dependecy with hip-devel
- Added device scan mixed type update