### PR TITLE
Disabling char datatype for block_run_length_decode unit test for Windows

### DIFF
--- a/test/hipcub/test_hipcub_block_run_length_decode.cpp
+++ b/test/hipcub/test_hipcub_block_run_length_decode.cpp
@@ -48,6 +48,22 @@ public:
     using params = Params;
 };
 
+// char not supported for std::uniform_int_distribution in VS C++
+#if defined(WIN32)
+using HipcubBlockRunLengthDecodeTestParams = ::testing::Types<
+    Params<int, int, 256, 4, 4>,
+    Params<float, int, 256, 4, 4>,
+
+    Params<int, int, 256, 8, 8>,
+    Params<float, int, 256, 8, 8>,
+
+    Params<int, int, 256, 1, 14>,
+    Params<float, int, 256, 1, 14>,
+
+    Params<int, int, 256, 9, 7>,
+    Params<float, int, 256, 9, 7>
+>;
+#else
 using HipcubBlockRunLengthDecodeTestParams = ::testing::Types<
     Params<int, int, 256, 4, 4>,
     Params<double, char, 256, 4, 4>,
@@ -69,6 +85,7 @@ using HipcubBlockRunLengthDecodeTestParams = ::testing::Types<
     Params<char, long long, 256, 9, 7>,
     Params<float, int, 256, 9, 7>
 >;
+#endif
 
 TYPED_TEST_SUITE(HipcubBlockRunLengthDecodeTest, HipcubBlockRunLengthDecodeTestParams);
 


### PR DESCRIPTION
According to https://en.cppreference.com/w/cpp/numeric/random/uniform_int_distribution, char is not on the list of supported datatypes for std::uniform_int_distribution.  I'm not sure how the test compiles on Linux, but with HIP on Windows the test fails to compile (see log below).  I've decided to remove the test params with char in them from Windows for now, but @neon60  you have recommendations for replacement test parameters let me know and I'll put them in.  

[1/75] Building CXX object test/hipcub/CMakeFiles/test_hip...gth_decode.dir/test_hipcub_block_run_length_decode.cpp.obj
FAILED: test/hipcub/CMakeFiles/test_hipcub_block_run_length_decode.dir/test_hipcub_block_run_length_decode.cpp.obj
C:\hip\bin\clang++.exe -DGTEST_LINKED_AS_SHARED_LIBRARY=1 -D__HIP_PLATFORM_AMD__=1 -D__HIP_PLATFORM_HCC__=1 -Ihipcub/include -Ihipcub/include/hipcub -I../../hipcub/include -isystem C:/Workspace/3rdparty/vcpkg/installed/x64-windows/include -isystem C:/hipSDK/include -isystem C:/hipSDK/rocprim/include -isystem C:/hip/lib/clang/14.0.0/include/.. -isystem C:/hip/include -IC:/hip/include -DWIN32 -D_CRT_SECURE_NO_WARNINGS -std=c++14 -fms-extensions -fms-compatibility -Wno-ignored-attributes -IC:/hip/include/hip -D__HIP_PLATFORM_AMD__ -D__HIP_ROCclr__ -DHIP_CLANG_HCC_COMPAT_MODE=1 -IC:/hip/include -DWIN32 -D_CRT_SECURE_NO_WARNINGS -std=c++14 -fms-extensions -fms-compatibility -Wno-ignored-attributes -IC:/hip/include/hip -D__HIP_PLATFORM_AMD__ -D__HIP_ROCclr__ -DHIP_CLANG_HCC_COMPAT_MODE=1 -Wall -Wextra -O3 -DNDEBUG -D_DLL -D_MT -Xclang --dependent-lib=msvcrt -mllvm -amdgpu-early-inline-all=true -mllvm -amdgpu-function-calls=false -x hip -fms-extensions -fms-compatibility --hip-device-lib-path=C:/hip/lib/bitcode --offload-arch=gfx906 --offload-arch=gfx1030 -std=c++14 -MD -MT test/hipcub/CMakeFiles/test_hipcub_block_run_length_decode.dir/test_hipcub_block_run_length_decode.cpp.obj -MF test\hipcub\CMakeFiles\test_hipcub_block_run_length_decode.dir\test_hipcub_block_run_length_decode.cpp.obj.d -o test/hipcub/CMakeFiles/test_hipcub_block_run_length_decode.dir/test_hipcub_block_run_length_decode.cpp.obj -c ../../test/hipcub/test_hipcub_block_run_length_decode.cpp
In file included from ../../test/hipcub/test_hipcub_block_run_length_decode.cpp:23:
In file included from ../../test/hipcub/common_test_header.hpp:30:
C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\include\random:1863:5: error: static_assert failed due to requirement '_Is_any_of_v<char, short, int, long, long long, unsigned short, unsigned int, unsigned long, unsigned long long>' "invalid template argument for uniform_int_distribution: N4659 29.6.1.1 [rand.req.genl]/1e requires one of short, int, long, long long, unsigned short, unsigned int, unsigned long, or unsigned long long"
    _RNG_REQUIRE_INTTYPE(uniform_int_distribution, _Ty);
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\include\random:41:5: note: expanded from macro '_RNG_REQUIRE_INTTYPE'
    static_assert(_Is_any_of_v<_CheckedType, short, int, long, long long, unsigned short, unsigned int, unsigned long, \    ^             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~../../test/hipcub/test_hipcub_block_run_length_decode.cpp:147:24: note: in instantiation of template class 'std::uniform_int_distribution<char>' requested here
                return ItemDistribution(
                       ^
C:/Workspace/3rdparty/vcpkg/installed/x64-windows/include\gtest/internal/gtest-internal.h:472:44: note: in instantiation of member function 'HipcubBlockRunLengthDecodeTest_TestDecode_Test<Params<char, long long, 256, 9, 7>>::TestBody' requested here
  Test* CreateTest() override { return new TestClass; }
                                           ^
C:/Workspace/3rdparty/vcpkg/installed/x64-windows/include\gtest/internal/gtest-internal.h:740:13: note: in instantiation of member function 'testing::internal::TestFactoryImpl<HipcubBlockRunLengthDecodeTest_TestDecode_Test<Params<char, long long, 256, 9, 7>>>::CreateTest' requested here
        new TestFactoryImpl<TestClass>);
            ^
C:/Workspace/3rdparty/vcpkg/installed/x64-windows/include\gtest/internal/gtest-internal.h:744:57: note: in instantiation of member function 'testing::internal::TypeParameterizedTest<HipcubBlockRunLengthDecodeTest, testing::internal::TemplateSel<HipcubBlockRunLengthDecodeTest_TestDecode_Test>, testing::internal::Types<Params<char, long long, 256, 9, 7>, Params<float, int, 256, 9, 7>>>::Register' requested here
                                 typename Types::Tail>::Register(prefix,
                                                        ^
C:/Workspace/3rdparty/vcpkg/installed/x64-windows/include\gtest/internal/gtest-internal.h:744:57: note: in instantiation of member function 'testing::internal::TypeParameterizedTest<HipcubBlockRunLengthDecodeTest, testing::internal::TemplateSel<HipcubBlockRunLengthDecodeTest_TestDecode_Test>, testing::internal::Types<Params<double, char, 256, 9, 7>, Params<char, long long, 256, 9, 7>, Params<float, int, 256, 9, 7>>>::Register' requested here
C:/Workspace/3rdparty/vcpkg/installed/x64-windows/include\gtest/internal/gtest-internal.h:744:57: note: (skipping 8 contexts in backtrace; use -ftemplate-backtrace-limit=0 to see all)
C:/Workspace/3rdparty/vcpkg/installed/x64-windows/include\gtest/internal/gtest-internal.h:744:57: note: in instantiation of member function 'testing::internal::TypeParameterizedTest<HipcubBlockRunLengthDecodeTest, testing::internal::TemplateSel<HipcubBlockRunLengthDecodeTest_TestDecode_Test>, testing::internal::Types<Params<int, int, 256, 8, 8>, Params<double, char, 256, 8, 8>, Params<char, long long, 256, 8, 8>, Params<float, int, 256, 8, 8>, Params<int, int, 256, 1, 14>, Params<double, char, 256, 1, 14>, Params<char, long long, 256, 1, 14>, Params<float, int, 256, 1, 14>, Params<int, int, 256, 9, 7>, Params<double, char, 256, 9, 7>, Params<char, long long, 256, 9, 7>, Params<float, int, 256, 9, 7>>>::Register' requested here
C:/Workspace/3rdparty/vcpkg/installed/x64-windows/include\gtest/internal/gtest-internal.h:744:57: note: in instantiation of member function 'testing::internal::TypeParameterizedTest<HipcubBlockRunLengthDecodeTest, testing::internal::TemplateSel<HipcubBlockRunLengthDecodeTest_TestDecode_Test>, testing::internal::Types<Params<float, int, 256, 4, 4>, Params<int, int, 256, 8, 8>, Params<double, char, 256, 8, 8>, Params<char, long long, 256, 8, 8>, Params<float, int, 256, 8, 8>, Params<int, int, 256, 1, 14>, Params<double, char, 256, 1, 14>, Params<char, long long, 256, 1, 14>, Params<float, int, 256, 1, 14>, Params<int, int, 256, 9, 7>, Params<double, char, 256, 9, 7>, Params<char, long long, 256, 9, 7>, Params<float, int, 256, 9, 7>>>::Register' requested here
C:/Workspace/3rdparty/vcpkg/installed/x64-windows/include\gtest/internal/gtest-internal.h:744:57: note: in instantiation of member function 'testing::internal::TypeParameterizedTest<HipcubBlockRunLengthDecodeTest, testing::internal::TemplateSel<HipcubBlockRunLengthDecodeTest_TestDecode_Test>, testing::internal::Types<Params<char, long long, 256, 4, 4>, Params<float, int, 256, 4, 4>, Params<int, int, 256, 8, 8>, Params<double, char, 256, 8, 8>, Params<char, long long, 256, 8, 8>, Params<float, int, 256, 8, 8>, Params<int, int, 256, 1, 14>, Params<double, char, 256, 1, 14>, Params<char, long long, 256, 1, 14>, Params<float, int, 256, 1, 14>, Params<int, int, 256, 9, 7>, Params<double, char, 256, 9, 7>, Params<char, long long, 256, 9, 7>, Params<float, int, 256, 9, 7>>>::Register' requested here
C:/Workspace/3rdparty/vcpkg/installed/x64-windows/include\gtest/internal/gtest-internal.h:744:57: note: in instantiation of member function 'testing::internal::TypeParameterizedTest<HipcubBlockRunLengthDecodeTest, testing::internal::TemplateSel<HipcubBlockRunLengthDecodeTest_TestDecode_Test>, testing::internal::Types<Params<double, char, 256, 4, 4>, Params<char, long long, 256, 4, 4>, Params<float, int, 256, 4, 4>, Params<int, int, 256, 8, 8>, Params<double, char, 256, 8, 8>, Params<char, long long, 256, 8, 8>, Params<float, int, 256, 8, 8>, Params<int, int, 256, 1, 14>, Params<double, char, 256, 1, 14>, Params<char, long long, 256, 1, 14>, Params<float, int, 256, 1, 14>, Params<int, int, 256, 9, 7>, Params<double, char, 256, 9, 7>, Params<char, long long, 256, 9, 7>, Params<float, int, 256, 9, 7>>>::Register' requested here
../../test/hipcub/test_hipcub_block_run_length_decode.cpp:124:1: note: in instantiation of member function 'testing::internal::TypeParameterizedTest<HipcubBlockRunLengthDecodeTest, testing::internal::TemplateSel<HipcubBlockRunLengthDecodeTest_TestDecode_Test>, testing::internal::Types<Params<int, int, 256, 4, 4>, Params<double, char, 256, 4, 4>, Params<char, long long, 256, 4, 4>, Params<float, int, 256, 4, 4>, Params<int, int, 256, 8, 8>, Params<double, char, 256, 8, 8>, Params<char, long long, 256, 8, 8>, Params<float, int, 256, 8, 8>, Params<int, int, 256, 1, 14>, Params<double, char, 256, 1, 14>, Params<char, long long, 256, 1, 14>, Params<float, int, 256, 1, 14>, Params<int, int, 256, 9, 7>, Params<double, char, 256, 9, 7>, Params<char, long long, 256, 9, 7>, Params<float, int, 256, 9, 7>>>::Register' requested here
TYPED_TEST(HipcubBlockRunLengthDecodeTest, TestDecode)
^
C:/Workspace/3rdparty/vcpkg/installed/x64-windows/include\gtest/gtest-typed-test.h:212:27: note: expanded from macro 'TYPED_TEST'
              CaseName)>::Register("",                                        \
                          ^
../../test/hipcub/test_hipcub_block_run_length_decode.cpp:166:48: error: no matching constructor for initialization of 'std::uniform_int_distribution<LengthT>' (aka 'uniform_int_distribution<char>')
        std::uniform_int_distribution<LengthT> run_length_dist(1, max_run_length);
                                               ^               ~~~~~~~~~~~~~~~~~
C:/Workspace/3rdparty/vcpkg/installed/x64-windows/include\gtest/internal/gtest-internal.h:472:44: note: in instantiation of member function 'HipcubBlockRunLengthDecodeTest_TestDecode_Test<Params<double, char, 256, 9, 7>>::TestBody' requested here
  Test* CreateTest() override { return new TestClass; }