### PR TITLE
Fixed hang in test_hipcub_grid on gfx1030

### DIFF
--- a/hipcub/include/hipcub/backend/rocprim/thread/thread_load.hpp
+++ b/hipcub/include/hipcub/backend/rocprim/thread/thread_load.hpp
@@ -65,8 +65,10 @@ HIPCUB_DEVICE __forceinline__ T AsmThreadLoad(void * ptr)
     HIPCUB_DEVICE __forceinline__ type AsmThreadLoad<cache_modifier, type>(void * ptr)                        \
     {                                                                                                         \
         interim_type retval;                                                                                  \
-        asm volatile(#asm_operator " %0, %1 " llvm_cache_modifier : "=" #output_modifier(retval) : "v"(ptr)); \
-        asm volatile("s_waitcnt " wait_cmd "(%0)" : : "I"(0x00));                                             \
+        asm volatile(                                                                                         \
+            #asm_operator " %0, %1 " llvm_cache_modifier "\n"                                                 \
+            "\ts_waitcnt " wait_cmd "(0)" : "=" #output_modifier(retval) : "v"(ptr)                            \
+        );                                                                                                    \
         return retval;                                                                                        \
     }
 


### PR DESCRIPTION
- `grid_barrier` uses `thread_load` for loading values from global memory.
- `thread_load` was previously implemented with two inline assembly statements. This gave opportunity to the compiler to inject instructions between the two, in our case it injected the comparison **before** the `s_waitcnt`.
- Changed it to a single assembly statement, thereby no instruction can be inserted between the load and the wait.