### PR TITLE
Bump up breathe version to 4.33.1

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
-breathe<4.13.0
+breathe<4.33.1
 exhale


### PR DESCRIPTION
This should get hipCUB documentation building again.  Previous error was due to old version of breathe being used.