### PR TITLE
Hotfixes from release/rocm-rel-5.1 at release 5.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 See README.md on how to build the hipCUB documentation using Doxygen.
 
-## (Unreleased) hipCUB-2.11.0 for ROCm 5.1.0
+## hipCUB-2.11.0 for ROCm 5.1.0
 ### Added
 - Device segmented sort
 - Warp merge sort, WarpMask and thread sort from cub 1.15.0 supported in hipCUB
@@ -12,8 +12,6 @@ See README.md on how to build the hipCUB documentation using Doxygen.
   - This particularly changes behaviour of small-size input types with large-size output types (e.g. short input, int output).
   - And low-res input with high-res output (e.g. float input, double output)
   - Block merge sort no longer supports non power of two blocksizes
-### Known Issues
-  - grid unit test hanging on HIP on Windows
 
 ## hipCUB-2.10.13 for ROCm 5.0.0
 ### Fixed

--- a/hipcub/include/hipcub/backend/rocprim/thread/thread_load.hpp
+++ b/hipcub/include/hipcub/backend/rocprim/thread/thread_load.hpp
@@ -65,8 +65,10 @@ HIPCUB_DEVICE __forceinline__ T AsmThreadLoad(void * ptr)
     HIPCUB_DEVICE __forceinline__ type AsmThreadLoad<cache_modifier, type>(void * ptr)                        \
     {                                                                                                         \
         interim_type retval;                                                                                  \
-        asm volatile(#asm_operator " %0, %1 " llvm_cache_modifier : "=" #output_modifier(retval) : "v"(ptr)); \
-        asm volatile("s_waitcnt " wait_cmd "(%0)" : : "I"(0x00));                                             \
+        asm volatile(                                                                                         \
+            #asm_operator " %0, %1 " llvm_cache_modifier "\n"                                                 \
+            "\ts_waitcnt " wait_cmd "(0)" : "=" #output_modifier(retval) : "v"(ptr)                            \
+        );                                                                                                    \
         return retval;                                                                                        \
     }
 


### PR DESCRIPTION
This is an autogenerated PR.
 This is intended to pull any hotfixes for ROCm release 5.1.0 (including changelogs and documentation) back into develop.