### PR TITLE
ENABLE ORIGINAL FILE DUMP IN VERSION HDR FILE WRAPPER FOR BKWDCOMP

### DIFF
--- a/hipcub/CMakeLists.txt
+++ b/hipcub/CMakeLists.txt
@@ -35,6 +35,7 @@ if(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY)
       "hipcub_version.hpp"
       WRAPPER_LOCATIONS cub/include/hipcub
       OUTPUT_LOCATIONS cub/wrapper/include/hipcub
+      ORIGINAL_FILES ${CMAKE_CURRENT_BINARY_DIR}/cub/include/hipcub/hipcub_version.hpp
   )
 endif()
 


### PR DESCRIPTION
Summary of proposed changes:

- Original Header File Dump enabled for version header file wrapper to support backward Compatibility for PT/TF
- Depends on wrapper functions of rocm-cmake version https://github.com/RadeonOpenCompute/rocm-cmake/commit/d108dbf05e029996d5d7bcbe258abb1166547a30Summary of proposed changes:

