### PR TITLE
Hotfixes from release/rocm-rel-5.2 at release 5.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Change Log for hipCUB
 
 See README.md on how to build the hipCUB documentation using Doxygen.
-## (Unreleased) hipCUB-2.11.1 for ROCm 5.2.0
+## (Released) hipCUB-2.11.1 for ROCm 5.2.0
 ### Added
 - Packages for tests and benchmark executable on all supported OSes using CPack.
-## (Unreleased) hipCUB-2.11.0 for ROCm 5.1.0
+
+## (Released) hipCUB-2.11.0 for ROCm 5.1.0
 ### Added
 - Device segmented sort
 - Warp merge sort, WarpMask and thread sort from cub 1.15.0 supported in hipCUB

--- a/hipcub/CMakeLists.txt
+++ b/hipcub/CMakeLists.txt
@@ -35,7 +35,6 @@ if(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY)
       "hipcub_version.hpp"
       WRAPPER_LOCATIONS cub/include/hipcub
       OUTPUT_LOCATIONS cub/wrapper/include/hipcub
-      ORIGINAL_FILES ${CMAKE_CURRENT_BINARY_DIR}/cub/include/hipcub/hipcub_version.hpp
   )
 endif()
 

--- a/hipcub/CMakeLists.txt
+++ b/hipcub/CMakeLists.txt
@@ -35,6 +35,7 @@ if(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY)
       "hipcub_version.hpp"
       WRAPPER_LOCATIONS cub/include/hipcub
       OUTPUT_LOCATIONS cub/wrapper/include/hipcub
+      ORIGINAL_FILES ${CMAKE_CURRENT_BINARY_DIR}/cub/include/hipcub/hipcub_version.hpp
   )
 endif()
 


### PR DESCRIPTION
This is an autogenerated PR.
 This is intended to pull any hotfixes for ROCm release 5.2.0 (including changelogs and documentation) back into develop.