### PR TITLE
HIP Bin prefix path updated to rocm_path as per reorg structure

### DIFF
--- a/toolchain-linux.cmake
+++ b/toolchain-linux.cmake
@@ -4,9 +4,9 @@
 #set(CMAKE_GENERATOR_PLATFORM x64)
 
 if (DEFINED ENV{ROCM_PATH})
-  set(rocm_bin "$ENV{ROCM_PATH}/hip/bin")
+  set(rocm_bin "$ENV{ROCM_PATH}/bin")
 else()
-  set(rocm_bin "/opt/rocm/hip/bin")
+  set(rocm_bin "/opt/rocm/bin")
 endif()
 
 


### PR DESCRIPTION
Proposed Changes:
- Update HIP bin prefix path to rocm_path (rocm_path/bin will be used for hipcc as per the reorg structure)