### PR TITLE
Remove RPATH/RUNPATH from ROCm libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "" "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
 endif()
 
-set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE CACHE BOOL "Add paths to linker search and installed rpath")
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH FALSE CACHE BOOL "Add paths to linker search and installed rpath")
 
 # rocm-cmake contains common cmake code for rocm projects to help
 # setup and install

--- a/install
+++ b/install
@@ -171,7 +171,7 @@ if [[ "${build_relocatable}" == true ]]; then
         -DCMAKE_PREFIX_PATH="${rocm_path} ${rocm_path}/hcc ${rocm_path}/hip" \
         -DCMAKE_MODULE_PATH="${rocm_path}/lib/cmake/hip ${rocm_path}/hip/cmake" \
         -Drocprim_DIR=${rocm_path}/rocprim \
-        -DCMAKE_SKIP_RPATH=TRUE \
+        -DCMAKE_SKIP_INSTALL_RPATH=TRUE \
         ${cmake_common_options} \
         ${build_tests} ${build_benchmarks} ${build_type} ../../. # or cmake-gui ../.
 else

--- a/install
+++ b/install
@@ -171,6 +171,7 @@ if [[ "${build_relocatable}" == true ]]; then
         -DCMAKE_PREFIX_PATH="${rocm_path} ${rocm_path}/hcc ${rocm_path}/hip" \
         -DCMAKE_MODULE_PATH="${rocm_path}/lib/cmake/hip ${rocm_path}/hip/cmake" \
         -Drocprim_DIR=${rocm_path}/rocprim \
+        -DCMAKE_SKIP_RPATH=TRUE \
         ${cmake_common_options} \
         ${build_tests} ${build_benchmarks} ${build_type} ../../. # or cmake-gui ../.
 else


### PR DESCRIPTION
Proposed Changes for:
- SWDEV-310152: 
- Single version package: add ldconfig, no RPATH/RUNPATH in either binaries or libraries
- Multi version package: use RPATH for binaries, no RPATH/RUNPATH for libraries
- amdclang/clang/hipcc compilers shall not add RPATH/RUNPATH to produced binaries or libraries unless explicitly requested by an option
- Versioning scripts will take care of adding rpath to binaries for multi version package