### PR TITLE
Develop Stream 2023-05-12

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -188,6 +188,11 @@ test:rocm:
       --benchmark_gpu_name "${GPU}"
       --benchmark_filename_regex "${BENCHMARK_FILENAME_REGEX}"
       --benchmark_filter_regex "${BENCHMARK_FILTER_REGEX}"
+      --no_upload
+  artifacts:
+    paths:
+      - ${CI_PROJECT_DIR}/build/benchmark/*.json
+    expire_in: 1 week
 
 benchmark:rocm:
   extends:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 See README.md on how to build the hipCUB documentation using Doxygen.
 
+## (Unreleased) hipCUB-2.13.1 for ROCm 6.0.0
+### Changed
+- CUB backend references CUB and Thrust version 2.0.1.
+### Known Issues
+- `debug_synchronous` no longer works on CUDA platform. `CUB_DEBUG_SYNC` should be used to enable those checks.
+- `DeviceReduce::Sum` does not compile on CUDA platform for mixed extended-floating-point/floating-point InputT and OutputT types.
+- `DeviceHistogram::HistogramEven` fails on CUDA platform for `[LevelT, SampleIteratorT] = [int, int]`.
+- `DeviceHistogram::MultiHistogramEven` fails on CUDA platform for `[LevelT, SampleIteratorT] = [int, int/unsigned short/float/double]` and `[LevelT, SampleIteratorT] = [float, double]`.
+
 ## (Unreleased) hipCUB-2.13.1 for ROCm 5.5.0
 ### Added
 - Benchmarks for `BlockShuffle`, `BlockLoad`, and `BlockStore`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ See README.md on how to build the hipCUB documentation using Doxygen.
 ## (Unreleased) hipCUB-2.13.1 for ROCm 6.0.0
 ### Changed
 - CUB backend references CUB and Thrust version 2.0.1.
+- Fixed `DeviceSegmentedReduce::ArgMin` and `DeviceSegmentedReduce::ArgMax` by returning the segment-relative index instead of the absolute one.
+- Fixed `DeviceSegmentedReduce::ArgMin` for inputs where the segment minimum is smaller than the value returned for empty segments. An equivalent fix is applied to `DeviceSegmentedReduce::ArgMax`.
 ### Known Issues
 - `debug_synchronous` no longer works on CUDA platform. `CUB_DEBUG_SYNC` should be used to enable those checks.
 - `DeviceReduce::Sum` does not compile on CUDA platform for mixed extended-floating-point/floating-point InputT and OutputT types.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ See README.md on how to build the hipCUB documentation using Doxygen.
 ### Changed
 - CUB backend references CUB and Thrust version 1.17.2.
 - Improved benchmark coverage of `BlockScan` by adding `ExclusiveScan`, benchmark coverage of `BlockRadixSort` by adding `SortBlockedToStriped`, and benchmark coverage of `WarpScan` by adding `Broadcast`.
-- Updated `docs` directory structure to match the standard of [rocm-docs-core](https://github.com/RadeonOpenCompute/rocm-docs-core).
+- Removed references to and workarounds for deprecated hcc
 ### Known Issues
 - `BlockRadixRankMatch` is currently broken under the rocPRIM backend.
 - `BlockRadixRankMatch` with a warp size that does not exactly divide the block size is broken under the CUB backend.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,7 +156,7 @@ if(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY AND NOT WIN32)
 endif()
 
 # Package
-if(HIP_COMPILER STREQUAL "hcc" OR HIP_COMPILER STREQUAL "clang")
+if(HIP_COMPILER STREQUAL "clang")
   rocm_package_add_deb_dependencies(DEPENDS "rocprim-dev >= 2.10.1")
   rocm_package_add_rpm_dependencies(DEPENDS "rocprim-devel >= 2.10.1")
   set(CPACK_DEBIAN_PACKAGE_REPLACES "cub-hip")

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ cd hipCUB; mkdir build; cd build
 #   DOWNLOAD_ROCPRIM - OFF by default and at ON the rocPRIM will be downloaded to build folder,
 #
 # ! IMPORTANT !
-# Set C++ compiler to HCC or HIP-clang. You can do it by adding 'CXX=<path-to-compiler>'
+# Set C++ compiler to HIP-aware clang. You can do it by adding 'CXX=<path-to-compiler>'
 # before 'cmake' or setting cmake option 'CMAKE_CXX_COMPILER' to path to the compiler.
 #
 [CXX=hipcc] cmake ../. # or cmake-gui ../.

--- a/benchmark/benchmark_block_radix_rank.cpp
+++ b/benchmark/benchmark_block_radix_rank.cpp
@@ -71,9 +71,9 @@ __global__ __launch_bounds__(BlockSize) void rank_kernel(const T* keys_input, in
                                BenchmarkKind == RadixRankAlgorithm::RADIX_RANK_MEMOIZE>>;
 
 #pragma unroll
-    for(unsigned int KEY = 0; KEY < ItemsPerThread; KEY++)
+    for(unsigned int key = 0; key < ItemsPerThread; key++)
     {
-        unsigned_keys[KEY] = KeyTraits::TwiddleIn(unsigned_keys[KEY]);
+        unsigned_keys[key] = KeyTraits::TwiddleIn(unsigned_keys[key]);
     }
 
     int ranks[ItemsPerThread];

--- a/benchmark/benchmark_utils.hpp
+++ b/benchmark/benchmark_utils.hpp
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -306,17 +306,8 @@ template<class T>
 inline auto get_random_data(size_t size, T min, T max, size_t max_random_size = 1024 * 1024)
     -> typename std::enable_if<!is_custom_type<T>::value && !std::is_same<decltype(max.x), void>::value, std::vector<T>>::type
 {
-    // NOTE 1: post-increment operator required, because HIP has different typedefs for vector field types
-    //         when using HCC or HIP-Clang. Using HIP-Clang members are accessed as fields of a struct via
-    //         a union, but in HCC mode they are proxy types (Scalar_accessor). STL algorithms don't
-    //         always tolerate proxies. Unfortunately, Scalar_accessor doesn't have any member typedefs to
-    //         conveniently obtain the inner stored type. All operations on it (operator+, operator+=,
-    //         CTOR, etc.) return a reference to an accessor, it is only the post-increment operator that
-    //         returns a copy of the stored type, hence we take the decltype of that.
-    //
-    // NOTE 2: decltype() is unevaluated context. We don't really modify max, just compute the type of the
-    //         expression if we were to actually call it.
-    using field_type = decltype(max.x++);
+
+    using field_type = decltype(max.x);
     std::vector<T> data(size);
     auto field_data = get_random_data<field_type>(size, min.x, max.x, max_random_size);
     for(size_t i = 0; i < size; i++)

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2017-2022 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2017-2023 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -40,54 +40,54 @@ if(HIP_COMPILER STREQUAL "nvcc")
 
   if(NOT DEFINED CUB_INCLUDE_DIR)
     file(
-      DOWNLOAD https://github.com/NVIDIA/cub/archive/1.17.2.zip
-      ${CMAKE_CURRENT_BINARY_DIR}/cub-1.17.2.zip
+      DOWNLOAD https://github.com/NVIDIA/cub/archive/2.0.1.zip
+      ${CMAKE_CURRENT_BINARY_DIR}/cub-2.0.1.zip
       STATUS cub_download_status LOG cub_download_log
     )
     list(GET cub_download_status 0 cub_download_error_code)
     if(cub_download_error_code)
       message(FATAL_ERROR "Error: downloading "
-        "https://github.com/NVIDIA/cub/archive/1.17.2.zip failed "
+        "https://github.com/NVIDIA/cub/archive/2.0.1.zip failed "
         "error_code: ${cub_download_error_code} "
         "log: ${cub_download_log} "
       )
     endif()
 
     execute_process(
-      COMMAND ${CMAKE_COMMAND} -E tar xzf ${CMAKE_CURRENT_BINARY_DIR}/cub-1.17.2.zip
+      COMMAND ${CMAKE_COMMAND} -E tar xzf ${CMAKE_CURRENT_BINARY_DIR}/cub-2.0.1.zip
       WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
       RESULT_VARIABLE cub_unpack_error_code
     )
     if(cub_unpack_error_code)
-      message(FATAL_ERROR "Error: unpacking ${CMAKE_CURRENT_BINARY_DIR}/cub-1.17.2.zip failed")
+      message(FATAL_ERROR "Error: unpacking ${CMAKE_CURRENT_BINARY_DIR}/cub-2.0.1.zip failed")
     endif()
-    set(CUB_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/cub-1.17.2/ CACHE PATH "")
+    set(CUB_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/cub-2.0.1/ CACHE PATH "")
   endif()
 
   if(NOT DEFINED THRUST_INCLUDE_DIR)
     file(
-      DOWNLOAD https://github.com/NVIDIA/thrust/archive/1.17.2.zip
-      ${CMAKE_CURRENT_BINARY_DIR}/thrust-1.17.2.zip
+      DOWNLOAD https://github.com/NVIDIA/thrust/archive/2.0.1.zip
+      ${CMAKE_CURRENT_BINARY_DIR}/thrust-2.0.1.zip
       STATUS thrust_download_status LOG thrust_download_log
     )
     list(GET thrust_download_status 0 thrust_download_error_code)
     if(thrust_download_error_code)
       message(FATAL_ERROR "Error: downloading "
-        "https://github.com/NVIDIA/thrust/archive/1.17.2.zip failed "
+        "https://github.com/NVIDIA/thrust/archive/2.0.1.zip failed "
         "error_code: ${thrust_download_error_code} "
         "log: ${thrust_download_log} "
       )
     endif()
 
     execute_process(
-      COMMAND ${CMAKE_COMMAND} -E tar xzf ${CMAKE_CURRENT_BINARY_DIR}/thrust-1.17.2.zip
+      COMMAND ${CMAKE_COMMAND} -E tar xzf ${CMAKE_CURRENT_BINARY_DIR}/thrust-2.0.1.zip
       WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
       RESULT_VARIABLE thrust_unpack_error_code
     )
     if(thrust_unpack_error_code)
-      message(FATAL_ERROR "Error: unpacking ${CMAKE_CURRENT_BINARY_DIR}/thrust-1.17.2.zip failed")
+      message(FATAL_ERROR "Error: unpacking ${CMAKE_CURRENT_BINARY_DIR}/thrust-2.0.1.zip failed")
     endif()
-    set(THRUST_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/thrust-1.17.2/ CACHE PATH "")
+    set(THRUST_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/thrust-2.0.1/ CACHE PATH "")
   endif()
 else()
   # rocPRIM (only for ROCm platform)

--- a/cmake/SetupNVCC.cmake
+++ b/cmake/SetupNVCC.cmake
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2018-2021 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2018-2023 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -20,10 +20,10 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-# Find the HIP package and verify that the correct C++ compiler was selected.
-# On the ROCm platform, both host and device code is compiled by the same
-# compiler: clang. On CUDA, host code can be compiled by any C++ compiler
-# while device code is compiled by the nvcc compiler.
+# Find HIP package and verify that correct C++ compiler was selected for available
+# platform. On ROCm platform host and device code is compiled by the same compiler:
+# hipcc or clang. On CUDA host can be compiled by any C++ compiler while device 
+# code is compiled by nvcc compiler (CMake's CUDA package handles this).
 
 # A function for automatic detection of the CC of the installed NV GPUs
 function(hip_cuda_detect_cc out_variable)

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -1,0 +1,46 @@
+
+*************
+Introduction
+*************
+
+.. toctree::
+   :maxdepth: 4
+   :caption: Contents:
+
+Overview
+==================
+
+hipCUB is a thin wrapper library on top of rocPRIM or CUB. It enables developers to port project
+using CUB library to the `HIP <https://github.com/ROCm-Developer-Tools/HIP>`_ layer and to run them
+on AMD hardware. In the `ROCm <https://rocmdocs.amd.com/en/latest/>`_ environment, hipCUB uses
+rocPRIM library as the backend, however, on CUDA platforms it uses CUB instead.
+
+- When using hipCUB you should only include ``<hipcub/hipcub.hpp>`` header.
+- When rocPRIM is used as backend ``HIPCUB_ROCPRIM_API`` is defined.
+- When CUB is used as backend ``HIPCUB_CUB_API`` is defined.
+- Backends are automaticaly selected based on platform detected by HIP layer
+  (``__HIP_PLATFORM_AMD__``, ``__HIP_PLATFORM_NVIDIA__``).
+
+rocPRIM backend
+====================================
+
+hipCUB with rocPRIM backend may not support all function and features CUB has because of the
+differences between ROCm (HIP) platform and CUDA platform.
+
+Not-supported features and differences:
+
+- Functions, classes and macros which are not in the public API or not documented are not
+  supported.
+- Device-wide primitives can't be called from kernels (dynamic parallelism is not supported in HIP
+  on ROCm).
+- Storage management and debug functions:
+
+  - ``Debug``, ``PtxVersion``, ``SmVersion`` functions and ``CubDebug``, ``CubDebugExit``,
+    ``_CubLog`` macros are not supported.
+- Intrinsics:
+
+  - ``ThreadExit``, ``ThreadTrap`` - not supported.
+  - Warp thread masks (when used) are 64-bit unsigned integers.
+  - ``member_mask`` input argument is ignored in ``WARP_*`` functions.
+  - Arguments ``first_thread``, ``last_thread``, and ``member_mask`` are ignored in ``Shuffle*``
+    functions.

--- a/docs/introduction.rst.orig
+++ b/docs/introduction.rst.orig
@@ -1,0 +1,46 @@
+
+*************
+Introduction
+*************
+
+.. toctree::
+   :maxdepth: 4
+   :caption: Contents:
+
+Overview
+==================
+
+hipCUB is a thin wrapper library on top of rocPRIM or CUB. It enables developers to port project
+using CUB library to the `HIP <https://github.com/ROCm-Developer-Tools/HIP>`_ layer and to run them
+on AMD hardware. In the `ROCm <https://rocmdocs.amd.com/en/latest/>`_ environment, hipCUB uses
+rocPRIM library as the backend, however, on CUDA platforms it uses CUB instead.
+
+- When using hipCUB you should only include ``<hipcub/hipcub.hpp>`` header.
+- When rocPRIM is used as backend ``HIPCUB_ROCPRIM_API`` is defined.
+- When CUB is used as backend ``HIPCUB_CUB_API`` is defined.
+- Backends are automaticaly selected based on platform detected by HIP layer
+  (``__HIP_PLATFORM_AMD__``, ``__HIP_PLATFORM_NVIDIA__``).
+
+rocPRIM backend
+====================================
+
+hipCUB with rocPRIM backend may not support all function and features CUB has because of the
+differences between ROCm (HIP) platform and CUDA platform.
+
+Not-supported features and differences:
+
+- Functions, classes and macros which are not in the public API or not documented are not
+  supported.
+- Device-wide primitives can't be called from kernels (dynamic parallelism is not supported in HIP
+  on ROCm).
+- Storage management and debug functions:
+
+  - ``Debug``, ``PtxVersion``, ``SmVersion`` functions and ``CubDebug``, ``CubDebugExit``,
+    ``_CubLog`` macros are not supported.
+- Intrinsics:
+
+  - ``ThreadExit``, ``ThreadTrap`` - not supported.
+  - Warp thread masks (when used) are 64-bit unsigned integers.
+  - ``member_mask`` input argument is ignored in ``WARP_*`` functions.
+  - Arguments ``first_thread``, ``last_thread``, and ``member_mask`` are ignored in ``Shuffle*``
+    functions.

--- a/docs/mainpage.dox
+++ b/docs/mainpage.dox
@@ -1,0 +1,37 @@
+/**
+@brief The hipCUB project main page.
+@author
+@file
+*/
+
+/**
+@mainpage hipCUB Documentation
+
+@section overview Overview
+
+hipCUB is a thin wrapper library on top of rocPRIM or CUB. It enables developers to port project using CUB library to the
+[HIP](https://github.com/ROCm-Developer-Tools/HIP) layer and to run them on AMD hardware. In [ROCm](https://rocm.github.io/)
+environment hipCUB uses rocPRIM library as the backend, however, on CUDA platforms it uses CUB instead.
+
+- When using hipCUB you should only include `<hipcub/hipcub.hpp>` header.
+- When rocPRIM is used as backend `HIPCUB_ROCPRIM_API` is defined.
+- When CUB is used as backend `HIPCUB_CUB_API` is defined.
+- Backends are automaticaly selected based on platform detected by HIP layer (`__HIP_PLATFORM_AMD__`, `__HIP_PLATFORM_NVIDIA__`).
+
+@section hipcub_rocprim rocPRIM backend
+
+hipCUB with rocPRIM backend may not support all function and features CUB has because of the differences
+between ROCm (HIP) platform and CUDA platform.
+
+Not-supported features and differences:
+- Functions, classes and macros which are not in the public API or not documented are not supported.
+- Device-wide primitives can't be called from kernels (dynamic parallelism is not supported in HIP on ROCm).
+- Storage management and debug functions:
+    - `Debug`, `PtxVersion`, `SmVersion` functions and `CubDebug`, `CubDebugExit`, `_CubLog` macros are not supported.
+- Intrinsics:
+    - `ThreadExit`, `ThreadTrap` - not supported.
+    - Warp thread masks (when used) are 64-bit unsigned integers.
+    - `member_mask` input argument is ignored in `WARP_*` functions.
+    - Arguments `first_thread`, `last_thread`, and `member_mask` are ignored in `Shuffle*` functions.
+
+*/

--- a/docs/mainpage.dox.orig
+++ b/docs/mainpage.dox.orig
@@ -1,0 +1,37 @@
+/**
+@brief The hipCUB project main page.
+@author
+@file
+*/
+
+/**
+@mainpage hipCUB Documentation
+
+@section overview Overview
+
+hipCUB is a thin wrapper library on top of rocPRIM or CUB. It enables developers to port project using CUB library to the
+[HIP](https://github.com/ROCm-Developer-Tools/HIP) layer and to run them on AMD hardware. In [ROCm](https://rocm.github.io/)
+environment hipCUB uses rocPRIM library as the backend, however, on CUDA platforms it uses CUB instead.
+
+- When using hipCUB you should only include `<hipcub/hipcub.hpp>` header.
+- When rocPRIM is used as backend `HIPCUB_ROCPRIM_API` is defined.
+- When CUB is used as backend `HIPCUB_CUB_API` is defined.
+- Backends are automaticaly selected based on platform detected by HIP layer (`__HIP_PLATFORM_AMD__`, `__HIP_PLATFORM_NVIDIA__`).
+
+@section hipcub_rocprim rocPRIM backend
+
+hipCUB with rocPRIM backend may not support all function and features CUB has because of the differences
+between ROCm (HIP) platform and CUDA platform.
+
+Not-supported features and differences:
+- Functions, classes and macros which are not in the public API or not documented are not supported.
+- Device-wide primitives can't be called from kernels (dynamic parallelism is not supported in HIP on ROCm).
+- Storage management and debug functions:
+    - `Debug`, `PtxVersion`, `SmVersion` functions and `CubDebug`, `CubDebugExit`, `_CubLog` macros are not supported.
+- Intrinsics:
+    - `ThreadExit`, `ThreadTrap` - not supported.
+    - Warp thread masks (when used) are 64-bit unsigned integers.
+    - `member_mask` input argument is ignored in `WARP_*` functions.
+    - Arguments `first_thread`, `last_thread`, and `member_mask` are ignored in `Shuffle*` functions.
+
+*/

--- a/hipcub/CMakeLists.txt
+++ b/hipcub/CMakeLists.txt
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2018 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2018-2023 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -49,7 +49,7 @@ target_include_directories(hipcub
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/>
 )
 
-if(HIP_COMPILER STREQUAL "hcc" OR HIP_COMPILER STREQUAL "clang")
+if(HIP_COMPILER STREQUAL "clang")
   target_link_libraries(hipcub
     INTERFACE
       roc::rocprim_hip
@@ -103,7 +103,7 @@ endif()
 include(ROCMExportTargetsHeaderOnly)
 
 # Export targets
-if(HIP_COMPILER STREQUAL "hcc" OR HIP_COMPILER STREQUAL "clang")
+if(HIP_COMPILER STREQUAL "clang")
   rocm_export_targets_header_only(
     TARGETS hip::hipcub
     DEPENDS PACKAGE rocprim

--- a/hipcub/include/hipcub/backend/cub/device/device_adjacent_difference.hpp
+++ b/hipcub/include/hipcub/backend/cub/device/device_adjacent_difference.hpp
@@ -1,6 +1,6 @@
 /******************************************************************************
  * Copyright (c) 2011-2021, NVIDIA CORPORATION.  All rights reserved.
- * Modifications Copyright (c) 2022, Advanced Micro Devices, Inc.  All rights reserved.
+ * Modifications Copyright (c) 2022-2023, Advanced Micro Devices, Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -50,12 +50,15 @@ struct DeviceAdjacentDifference
                                                                hipStream_t     stream        = 0,
                                                                bool debug_synchronous = false)
     {
+        (void)debug_synchronous;
         return hipCUDAErrorTohipError(
-            ::cub::DeviceAdjacentDifference::SubtractLeftCopy(
-                d_temp_storage, temp_storage_bytes, d_input, d_output,
-                num_items, difference_op, stream, debug_synchronous
-            )
-        );
+            ::cub::DeviceAdjacentDifference::SubtractLeftCopy(d_temp_storage,
+                                                              temp_storage_bytes,
+                                                              d_input,
+                                                              d_output,
+                                                              num_items,
+                                                              difference_op,
+                                                              stream));
     }
 
     template<typename RandomAccessIteratorT,
@@ -69,12 +72,14 @@ struct DeviceAdjacentDifference
                                                            hipStream_t           stream        = 0,
                                                            bool debug_synchronous = false)
     {
+        (void)debug_synchronous;
         return hipCUDAErrorTohipError(
-            ::cub::DeviceAdjacentDifference::SubtractLeft(
-                d_temp_storage, temp_storage_bytes, d_input,
-                num_items, difference_op, stream, debug_synchronous
-            )
-        );
+            ::cub::DeviceAdjacentDifference::SubtractLeft(d_temp_storage,
+                                                          temp_storage_bytes,
+                                                          d_input,
+                                                          num_items,
+                                                          difference_op,
+                                                          stream));
     }
 
     template<typename InputIteratorT,
@@ -90,12 +95,15 @@ struct DeviceAdjacentDifference
                                                                 hipStream_t     stream        = 0,
                                                                 bool debug_synchronous = false)
     {
+        (void)debug_synchronous;
         return hipCUDAErrorTohipError(
-            ::cub::DeviceAdjacentDifference::SubtractRightCopy(
-                d_temp_storage, temp_storage_bytes, d_input, d_output,
-                num_items, difference_op, stream, debug_synchronous
-            )
-        );
+            ::cub::DeviceAdjacentDifference::SubtractRightCopy(d_temp_storage,
+                                                               temp_storage_bytes,
+                                                               d_input,
+                                                               d_output,
+                                                               num_items,
+                                                               difference_op,
+                                                               stream));
     }
 
     template<typename RandomAccessIteratorT,
@@ -109,12 +117,14 @@ struct DeviceAdjacentDifference
                                                             hipStream_t   stream            = 0,
                                                             bool          debug_synchronous = false)
     {
+        (void)debug_synchronous;
         return hipCUDAErrorTohipError(
-            ::cub::DeviceAdjacentDifference::SubtractRight(
-                d_temp_storage, temp_storage_bytes, d_input,
-                num_items, difference_op, stream, debug_synchronous
-            )
-        );
+            ::cub::DeviceAdjacentDifference::SubtractRight(d_temp_storage,
+                                                           temp_storage_bytes,
+                                                           d_input,
+                                                           num_items,
+                                                           difference_op,
+                                                           stream));
     }
 };
 

--- a/hipcub/include/hipcub/backend/cub/device/device_histogram.hpp
+++ b/hipcub/include/hipcub/backend/cub/device/device_histogram.hpp
@@ -1,7 +1,7 @@
 /******************************************************************************
  * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
  * Copyright (c) 2011-2018, NVIDIA CORPORATION.  All rights reserved.
- * Modifications Copyright (c) 2017-2020, Advanced Micro Devices, Inc.  All rights reserved.
+ * Modifications Copyright (c) 2017-2023, Advanced Micro Devices, Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -56,16 +56,16 @@ struct DeviceHistogram
                              hipStream_t stream = 0,
                              bool debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceHistogram::HistogramEven(
-                d_temp_storage, temp_storage_bytes,
-                d_samples,
-                d_histogram,
-                num_levels, lower_level, upper_level,
-                num_samples,
-                stream, debug_synchronous
-            )
-        );
+        (void)debug_synchronous;
+        return hipCUDAErrorTohipError(::cub::DeviceHistogram::HistogramEven(d_temp_storage,
+                                                                            temp_storage_bytes,
+                                                                            d_samples,
+                                                                            d_histogram,
+                                                                            num_levels,
+                                                                            lower_level,
+                                                                            upper_level,
+                                                                            num_samples,
+                                                                            stream));
     }
 
     template<
@@ -88,16 +88,18 @@ struct DeviceHistogram
                              hipStream_t stream = 0,
                              bool debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceHistogram::HistogramEven(
-                d_temp_storage, temp_storage_bytes,
-                d_samples,
-                d_histogram,
-                num_levels, lower_level, upper_level,
-                num_row_samples, num_rows, row_stride_bytes,
-                stream, debug_synchronous
-            )
-        );
+        (void)debug_synchronous;
+        return hipCUDAErrorTohipError(::cub::DeviceHistogram::HistogramEven(d_temp_storage,
+                                                                            temp_storage_bytes,
+                                                                            d_samples,
+                                                                            d_histogram,
+                                                                            num_levels,
+                                                                            lower_level,
+                                                                            upper_level,
+                                                                            num_row_samples,
+                                                                            num_rows,
+                                                                            row_stride_bytes,
+                                                                            stream));
     }
 
     template<
@@ -120,16 +122,18 @@ struct DeviceHistogram
                                   hipStream_t stream = 0,
                                   bool debug_synchronous = false)
     {
+        (void)debug_synchronous;
         return hipCUDAErrorTohipError(
             ::cub::DeviceHistogram::MultiHistogramEven<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
-                d_temp_storage, temp_storage_bytes,
+                d_temp_storage,
+                temp_storage_bytes,
                 d_samples,
                 d_histogram,
-                num_levels, lower_level, upper_level,
+                num_levels,
+                lower_level,
+                upper_level,
                 num_pixels,
-                stream, debug_synchronous
-            )
-        );
+                stream));
     }
 
     template<
@@ -154,16 +158,20 @@ struct DeviceHistogram
                                   hipStream_t stream = 0,
                                   bool debug_synchronous = false)
     {
+        (void)debug_synchronous;
         return hipCUDAErrorTohipError(
             ::cub::DeviceHistogram::MultiHistogramEven<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
-                d_temp_storage, temp_storage_bytes,
+                d_temp_storage,
+                temp_storage_bytes,
                 d_samples,
                 d_histogram,
-                num_levels, lower_level, upper_level,
-                num_row_pixels, num_rows, row_stride_bytes,
-                stream, debug_synchronous
-            )
-        );
+                num_levels,
+                lower_level,
+                upper_level,
+                num_row_pixels,
+                num_rows,
+                row_stride_bytes,
+                stream));
     }
 
     template<
@@ -183,16 +191,15 @@ struct DeviceHistogram
                               hipStream_t stream = 0,
                               bool debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceHistogram::HistogramRange(
-                d_temp_storage, temp_storage_bytes,
-                d_samples,
-                d_histogram,
-                num_levels, d_levels,
-                num_samples,
-                stream, debug_synchronous
-            )
-        );
+        (void)debug_synchronous;
+        return hipCUDAErrorTohipError(::cub::DeviceHistogram::HistogramRange(d_temp_storage,
+                                                                             temp_storage_bytes,
+                                                                             d_samples,
+                                                                             d_histogram,
+                                                                             num_levels,
+                                                                             d_levels,
+                                                                             num_samples,
+                                                                             stream));
     }
 
     template<
@@ -214,16 +221,17 @@ struct DeviceHistogram
                               hipStream_t stream = 0,
                               bool debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceHistogram::HistogramRange(
-                d_temp_storage, temp_storage_bytes,
-                d_samples,
-                d_histogram,
-                num_levels, d_levels,
-                num_row_samples, num_rows, row_stride_bytes,
-                stream, debug_synchronous
-            )
-        );
+        (void)debug_synchronous;
+        return hipCUDAErrorTohipError(::cub::DeviceHistogram::HistogramRange(d_temp_storage,
+                                                                             temp_storage_bytes,
+                                                                             d_samples,
+                                                                             d_histogram,
+                                                                             num_levels,
+                                                                             d_levels,
+                                                                             num_row_samples,
+                                                                             num_rows,
+                                                                             row_stride_bytes,
+                                                                             stream));
     }
 
     template<
@@ -245,16 +253,17 @@ struct DeviceHistogram
                                    hipStream_t stream = 0,
                                    bool debug_synchronous = false)
     {
+        (void)debug_synchronous;
         return hipCUDAErrorTohipError(
             ::cub::DeviceHistogram::MultiHistogramRange<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
-                d_temp_storage, temp_storage_bytes,
+                d_temp_storage,
+                temp_storage_bytes,
                 d_samples,
                 d_histogram,
-                num_levels, d_levels,
+                num_levels,
+                d_levels,
                 num_pixels,
-                stream, debug_synchronous
-            )
-        );
+                stream));
     }
 
     template<
@@ -278,16 +287,19 @@ struct DeviceHistogram
                                    hipStream_t stream = 0,
                                    bool debug_synchronous = false)
     {
+        (void)debug_synchronous;
         return hipCUDAErrorTohipError(
             ::cub::DeviceHistogram::MultiHistogramRange<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
-                d_temp_storage, temp_storage_bytes,
+                d_temp_storage,
+                temp_storage_bytes,
                 d_samples,
                 d_histogram,
-                num_levels, d_levels,
-                num_row_pixels, num_rows, row_stride_bytes,
-                stream, debug_synchronous
-            )
-        );
+                num_levels,
+                d_levels,
+                num_row_pixels,
+                num_rows,
+                row_stride_bytes,
+                stream));
     }
 };
 

--- a/hipcub/include/hipcub/backend/cub/device/device_merge_sort.hpp
+++ b/hipcub/include/hipcub/backend/cub/device/device_merge_sort.hpp
@@ -1,7 +1,7 @@
 /******************************************************************************
  * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
  * Copyright (c) 2011-2018, NVIDIA CORPORATION.  All rights reserved.
- * Modifications Copyright (c) 2017-2021, Advanced Micro Devices, Inc.  All rights reserved.
+ * Modifications Copyright (c) 2017-2023, Advanced Micro Devices, Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -48,14 +48,14 @@ struct DeviceMergeSort
                                                       hipStream_t    stream            = 0,
                                                       bool           debug_synchronous = false)
     {
+        (void)debug_synchronous;
         return hipCUDAErrorTohipError(::cub::DeviceMergeSort::SortPairs(d_temp_storage,
                                                                         temp_storage_bytes,
                                                                         d_keys,
                                                                         d_items,
                                                                         num_items,
                                                                         compare_op,
-                                                                        stream,
-                                                                        debug_synchronous));
+                                                                        stream));
     }
 
     template<typename KeyInputIteratorT,
@@ -75,6 +75,7 @@ struct DeviceMergeSort
                                                           hipStream_t         stream = 0,
                                                           bool debug_synchronous     = false)
     {
+        (void)debug_synchronous;
         return hipCUDAErrorTohipError(::cub::DeviceMergeSort::SortPairsCopy(d_temp_storage,
                                                                             temp_storage_bytes,
                                                                             d_input_keys,
@@ -83,8 +84,7 @@ struct DeviceMergeSort
                                                                             d_output_items,
                                                                             num_items,
                                                                             compare_op,
-                                                                            stream,
-                                                                            debug_synchronous));
+                                                                            stream));
     }
 
     template<typename KeyIteratorT, typename OffsetT, typename CompareOpT>
@@ -96,13 +96,13 @@ struct DeviceMergeSort
                                                      hipStream_t   stream            = 0,
                                                      bool          debug_synchronous = false)
     {
+        (void)debug_synchronous;
         return hipCUDAErrorTohipError(::cub::DeviceMergeSort::SortKeys(d_temp_storage,
-                                                                            temp_storage_bytes,
-                                                                            d_keys,
-                                                                            num_items,
-                                                                            compare_op,
-                                                                            stream,
-                                                                            debug_synchronous));
+                                                                       temp_storage_bytes,
+                                                                       d_keys,
+                                                                       num_items,
+                                                                       compare_op,
+                                                                       stream));
     }
 
     template<typename KeyInputIteratorT,
@@ -119,40 +119,34 @@ struct DeviceMergeSort
                                                          bool debug_synchronous = false)
 
     {
+        (void)debug_synchronous;
         return hipCUDAErrorTohipError(::cub::DeviceMergeSort::SortKeysCopy(d_temp_storage,
-                                                                        temp_storage_bytes,
-                                                                        d_input_keys,
-                                                                        d_output_keys,
-                                                                        num_items,
-                                                                        compare_op,
-                                                                        stream,
-                                                                        debug_synchronous));
+                                                                           temp_storage_bytes,
+                                                                           d_input_keys,
+                                                                           d_output_keys,
+                                                                           num_items,
+                                                                           compare_op,
+                                                                           stream));
     }
-    
-    template <typename KeyIteratorT,
-             typename ValueIteratorT,
-             typename OffsetT,
-             typename CompareOpT>
-    HIPCUB_RUNTIME_FUNCTION static hipError_t
-    StableSortPairs(void *d_temp_storage,            
-                    std::size_t &temp_storage_bytes, 
-                    KeyIteratorT d_keys,             
-                    ValueIteratorT d_items,          
-                    OffsetT num_items,               
-                    CompareOpT compare_op,           
-                    hipStream_t stream = 0,         
-                    bool debug_synchronous = false)  
+
+    template<typename KeyIteratorT, typename ValueIteratorT, typename OffsetT, typename CompareOpT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t StableSortPairs(void*          d_temp_storage,
+                                                              std::size_t&   temp_storage_bytes,
+                                                              KeyIteratorT   d_keys,
+                                                              ValueIteratorT d_items,
+                                                              OffsetT        num_items,
+                                                              CompareOpT     compare_op,
+                                                              hipStream_t    stream  = 0,
+                                                              bool debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceMergeSort::StableSortPairs(d_temp_storage,            
-                                                    temp_storage_bytes, 
-                                                    d_keys,             
-                                                    d_items,          
-                                                    num_items,               
-                                                    compare_op,           
-                                                    stream,         
-                                                    debug_synchronous)
-        );
+        (void)debug_synchronous;
+        return hipCUDAErrorTohipError(::cub::DeviceMergeSort::StableSortPairs(d_temp_storage,
+                                                                              temp_storage_bytes,
+                                                                              d_keys,
+                                                                              d_items,
+                                                                              num_items,
+                                                                              compare_op,
+                                                                              stream));
     }
 
     template<typename KeyIteratorT, typename OffsetT, typename CompareOpT>
@@ -164,13 +158,13 @@ struct DeviceMergeSort
                                                              hipStream_t   stream   = 0,
                                                              bool debug_synchronous = false)
     {
+        (void)debug_synchronous;
         return hipCUDAErrorTohipError(::cub::DeviceMergeSort::StableSortKeys(d_temp_storage,
-                                                                              temp_storage_bytes,
-                                                                              d_keys,
-                                                                              num_items,
-                                                                              compare_op,
-                                                                              stream,
-                                                                              debug_synchronous));
+                                                                             temp_storage_bytes,
+                                                                             d_keys,
+                                                                             num_items,
+                                                                             compare_op,
+                                                                             stream));
     }
 };
 

--- a/hipcub/include/hipcub/backend/cub/device/device_partition.hpp
+++ b/hipcub/include/hipcub/backend/cub/device/device_partition.hpp
@@ -1,7 +1,7 @@
 /******************************************************************************
  * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
  * Copyright (c) 2011-2018, NVIDIA CORPORATION.  All rights reserved.
- * Modifications Copyright (c) 2017-2021, Advanced Micro Devices, Inc.  All rights reserved.
+ * Modifications Copyright (c) 2017-2023, Advanced Micro Devices, Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -55,19 +55,15 @@ struct DevicePartition
         hipStream_t                 stream             = 0,         ///< [in] <b>[optional]</b> hip stream to launch kernels within.  Default is stream<sub>0</sub>.
         bool                        debug_synchronous  = false)     ///< [in] <b>[optional]</b> Whether or not to synchronize the stream after every kernel launch to check for errors.  May cause significant slowdown.  Default is \p false.
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DevicePartition::Flagged(
-                d_temp_storage,
-                temp_storage_bytes,
-                d_in,
-                d_flags,
-                d_out,
-                d_num_selected_out,
-                num_items,
-                stream,
-                debug_synchronous
-            )
-        );
+        (void)debug_synchronous;
+        return hipCUDAErrorTohipError(::cub::DevicePartition::Flagged(d_temp_storage,
+                                                                      temp_storage_bytes,
+                                                                      d_in,
+                                                                      d_flags,
+                                                                      d_out,
+                                                                      d_num_selected_out,
+                                                                      num_items,
+                                                                      stream));
     }
 
     template <
@@ -87,19 +83,15 @@ struct DevicePartition
         hipStream_t                 stream             = 0,         ///< [in] <b>[optional]</b> hip stream to launch kernels within.  Default is stream<sub>0</sub>.
         bool                        debug_synchronous  = false)     ///< [in] <b>[optional]</b> Whether or not to synchronize the stream after every kernel launch to check for errors.  May cause significant slowdown.  Default is \p false.
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DevicePartition::If(
-                d_temp_storage,
-                temp_storage_bytes,
-                d_in,
-                d_out,
-                d_num_selected_out,
-                num_items,
-                select_op,
-                stream,
-                debug_synchronous
-            )
-        );
+        (void)debug_synchronous;
+        return hipCUDAErrorTohipError(::cub::DevicePartition::If(d_temp_storage,
+                                                                 temp_storage_bytes,
+                                                                 d_in,
+                                                                 d_out,
+                                                                 d_num_selected_out,
+                                                                 num_items,
+                                                                 select_op,
+                                                                 stream));
     }
 
     template <typename InputIteratorT,
@@ -123,22 +115,18 @@ struct DevicePartition
        hipStream_t stream     = 0,
        bool debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DevicePartition::If(
-                d_temp_storage,
-                temp_storage_bytes,
-                d_in,
-                d_first_part_out,
-                d_second_part_out,
-                d_unselected_out,
-                d_num_selected_out,
-                num_items,
-                select_first_part_op,
-                select_second_part_op,
-                stream,
-                debug_synchronous
-            )
-        );
+        (void)debug_synchronous;
+        return hipCUDAErrorTohipError(::cub::DevicePartition::If(d_temp_storage,
+                                                                 temp_storage_bytes,
+                                                                 d_in,
+                                                                 d_first_part_out,
+                                                                 d_second_part_out,
+                                                                 d_unselected_out,
+                                                                 d_num_selected_out,
+                                                                 num_items,
+                                                                 select_first_part_op,
+                                                                 select_second_part_op,
+                                                                 stream));
     }
 };
 

--- a/hipcub/include/hipcub/backend/cub/device/device_radix_sort.hpp
+++ b/hipcub/include/hipcub/backend/cub/device/device_radix_sort.hpp
@@ -1,7 +1,7 @@
 /******************************************************************************
  * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
  * Copyright (c) 2011-2018, NVIDIA CORPORATION.  All rights reserved.
- * Modifications Copyright (c) 2017-2020, Advanced Micro Devices, Inc.  All rights reserved.
+ * Modifications Copyright (c) 2017-2023, Advanced Micro Devices, Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -52,15 +52,17 @@ struct DeviceRadixSort
                          hipStream_t stream = 0,
                          bool debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceRadixSort::SortPairs(
-                d_temp_storage, temp_storage_bytes,
-                d_keys_in, d_keys_out,
-                d_values_in, d_values_out, num_items,
-                begin_bit, end_bit,
-                stream, debug_synchronous
-            )
-        );
+        (void)debug_synchronous;
+        return hipCUDAErrorTohipError(::cub::DeviceRadixSort::SortPairs(d_temp_storage,
+                                                                        temp_storage_bytes,
+                                                                        d_keys_in,
+                                                                        d_keys_out,
+                                                                        d_values_in,
+                                                                        d_values_out,
+                                                                        num_items,
+                                                                        begin_bit,
+                                                                        end_bit,
+                                                                        stream));
     }
 
     template<typename KeyT, typename ValueT, typename NumItemsT>
@@ -75,14 +77,15 @@ struct DeviceRadixSort
                          hipStream_t stream = 0,
                          bool debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceRadixSort::SortPairs(
-                d_temp_storage, temp_storage_bytes,
-                d_keys, d_values, num_items,
-                begin_bit, end_bit,
-                stream, debug_synchronous
-            )
-        );
+        (void)debug_synchronous;
+        return hipCUDAErrorTohipError(::cub::DeviceRadixSort::SortPairs(d_temp_storage,
+                                                                        temp_storage_bytes,
+                                                                        d_keys,
+                                                                        d_values,
+                                                                        num_items,
+                                                                        begin_bit,
+                                                                        end_bit,
+                                                                        stream));
     }
 
     template<typename KeyT, typename ValueT, typename NumItemsT>
@@ -99,16 +102,18 @@ struct DeviceRadixSort
                                    hipStream_t stream = 0,
                                    bool debug_synchronous = false)
     {
+        (void)debug_synchronous;
         return hipCUDAErrorTohipError(
-            ::cub::DeviceRadixSort::SortPairsDescending(
-                d_temp_storage, temp_storage_bytes,
-                d_keys_in, d_keys_out,
-                d_values_in, d_values_out, num_items,
-                begin_bit, end_bit,
-                stream, debug_synchronous
-            )
-        );
-
+            ::cub::DeviceRadixSort::SortPairsDescending(d_temp_storage,
+                                                        temp_storage_bytes,
+                                                        d_keys_in,
+                                                        d_keys_out,
+                                                        d_values_in,
+                                                        d_values_out,
+                                                        num_items,
+                                                        begin_bit,
+                                                        end_bit,
+                                                        stream));
     }
 
     template<typename KeyT, typename ValueT, typename NumItemsT>
@@ -123,14 +128,16 @@ struct DeviceRadixSort
                                    hipStream_t stream = 0,
                                    bool debug_synchronous = false)
     {
+        (void)debug_synchronous;
         return hipCUDAErrorTohipError(
-            ::cub::DeviceRadixSort::SortPairsDescending(
-                d_temp_storage, temp_storage_bytes,
-                d_keys, d_values, num_items,
-                begin_bit, end_bit,
-                stream, debug_synchronous
-            )
-        );
+            ::cub::DeviceRadixSort::SortPairsDescending(d_temp_storage,
+                                                        temp_storage_bytes,
+                                                        d_keys,
+                                                        d_values,
+                                                        num_items,
+                                                        begin_bit,
+                                                        end_bit,
+                                                        stream));
     }
 
     template<typename KeyT, typename NumItemsT>
@@ -145,14 +152,15 @@ struct DeviceRadixSort
                         hipStream_t stream = 0,
                         bool debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceRadixSort::SortKeys(
-                d_temp_storage, temp_storage_bytes,
-                d_keys_in, d_keys_out, num_items,
-                begin_bit, end_bit,
-                stream, debug_synchronous
-            )
-        );
+        (void)debug_synchronous;
+        return hipCUDAErrorTohipError(::cub::DeviceRadixSort::SortKeys(d_temp_storage,
+                                                                       temp_storage_bytes,
+                                                                       d_keys_in,
+                                                                       d_keys_out,
+                                                                       num_items,
+                                                                       begin_bit,
+                                                                       end_bit,
+                                                                       stream));
     }
 
     template<typename KeyT, typename NumItemsT>
@@ -166,14 +174,14 @@ struct DeviceRadixSort
                         hipStream_t stream = 0,
                         bool debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceRadixSort::SortKeys(
-                d_temp_storage, temp_storage_bytes,
-                d_keys, num_items,
-                begin_bit, end_bit,
-                stream, debug_synchronous
-            )
-        );
+        (void)debug_synchronous;
+        return hipCUDAErrorTohipError(::cub::DeviceRadixSort::SortKeys(d_temp_storage,
+                                                                       temp_storage_bytes,
+                                                                       d_keys,
+                                                                       num_items,
+                                                                       begin_bit,
+                                                                       end_bit,
+                                                                       stream));
     }
 
     template<typename KeyT, typename NumItemsT>
@@ -188,14 +196,15 @@ struct DeviceRadixSort
                                   hipStream_t stream = 0,
                                   bool debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceRadixSort::SortKeysDescending(
-                d_temp_storage, temp_storage_bytes,
-                d_keys_in, d_keys_out, num_items,
-                begin_bit, end_bit,
-                stream, debug_synchronous
-            )
-        );
+        (void)debug_synchronous;
+        return hipCUDAErrorTohipError(::cub::DeviceRadixSort::SortKeysDescending(d_temp_storage,
+                                                                                 temp_storage_bytes,
+                                                                                 d_keys_in,
+                                                                                 d_keys_out,
+                                                                                 num_items,
+                                                                                 begin_bit,
+                                                                                 end_bit,
+                                                                                 stream));
     }
 
     template<typename KeyT, typename NumItemsT>
@@ -209,14 +218,14 @@ struct DeviceRadixSort
                                   hipStream_t stream = 0,
                                   bool debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceRadixSort::SortKeysDescending(
-                d_temp_storage, temp_storage_bytes,
-                d_keys, num_items,
-                begin_bit, end_bit,
-                stream, debug_synchronous
-            )
-        );
+        (void)debug_synchronous;
+        return hipCUDAErrorTohipError(::cub::DeviceRadixSort::SortKeysDescending(d_temp_storage,
+                                                                                 temp_storage_bytes,
+                                                                                 d_keys,
+                                                                                 num_items,
+                                                                                 begin_bit,
+                                                                                 end_bit,
+                                                                                 stream));
     }
 };
 

--- a/hipcub/include/hipcub/backend/cub/device/device_reduce.hpp
+++ b/hipcub/include/hipcub/backend/cub/device/device_reduce.hpp
@@ -1,7 +1,7 @@
 /******************************************************************************
  * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
  * Copyright (c) 2011-2018, NVIDIA CORPORATION.  All rights reserved.
- * Modifications Copyright (c) 2017-2020, Advanced Micro Devices, Inc.  All rights reserved.
+ * Modifications Copyright (c) 2017-2023, Advanced Micro Devices, Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -56,14 +56,15 @@ public:
                       hipStream_t stream = 0,
                       bool debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceReduce::Reduce(
-                d_temp_storage, temp_storage_bytes,
-                d_in, d_out, num_items,
-                reduction_op, init,
-                stream, debug_synchronous
-            )
-        );
+        (void)debug_synchronous;
+        return hipCUDAErrorTohipError(::cub::DeviceReduce::Reduce(d_temp_storage,
+                                                                  temp_storage_bytes,
+                                                                  d_in,
+                                                                  d_out,
+                                                                  num_items,
+                                                                  reduction_op,
+                                                                  init,
+                                                                  stream));
     }
 
     template <
@@ -79,13 +80,13 @@ public:
                    hipStream_t stream = 0,
                    bool debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceReduce::Sum(
-                d_temp_storage, temp_storage_bytes,
-                d_in, d_out, num_items,
-                stream, debug_synchronous
-            )
-        );
+        (void)debug_synchronous;
+        return hipCUDAErrorTohipError(::cub::DeviceReduce::Sum(d_temp_storage,
+                                                               temp_storage_bytes,
+                                                               d_in,
+                                                               d_out,
+                                                               num_items,
+                                                               stream));
     }
 
     template <
@@ -101,13 +102,13 @@ public:
                    hipStream_t stream = 0,
                    bool debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceReduce::Min(
-                d_temp_storage, temp_storage_bytes,
-                d_in, d_out, num_items,
-                stream, debug_synchronous
-            )
-        );
+        (void)debug_synchronous;
+        return hipCUDAErrorTohipError(::cub::DeviceReduce::Min(d_temp_storage,
+                                                               temp_storage_bytes,
+                                                               d_in,
+                                                               d_out,
+                                                               num_items,
+                                                               stream));
     }
 
     template <
@@ -123,13 +124,13 @@ public:
                       hipStream_t stream = 0,
                       bool debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceReduce::ArgMin(
-                d_temp_storage, temp_storage_bytes,
-                d_in, d_out, num_items,
-                stream, debug_synchronous
-            )
-        );
+        (void)debug_synchronous;
+        return hipCUDAErrorTohipError(::cub::DeviceReduce::ArgMin(d_temp_storage,
+                                                                  temp_storage_bytes,
+                                                                  d_in,
+                                                                  d_out,
+                                                                  num_items,
+                                                                  stream));
     }
 
     template <
@@ -145,13 +146,13 @@ public:
                    hipStream_t stream = 0,
                    bool debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceReduce::Max(
-                d_temp_storage, temp_storage_bytes,
-                d_in, d_out, num_items,
-                stream, debug_synchronous
-            )
-        );
+        (void)debug_synchronous;
+        return hipCUDAErrorTohipError(::cub::DeviceReduce::Max(d_temp_storage,
+                                                               temp_storage_bytes,
+                                                               d_in,
+                                                               d_out,
+                                                               num_items,
+                                                               stream));
     }
 
     template <
@@ -167,13 +168,13 @@ public:
                       hipStream_t stream = 0,
                       bool debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceReduce::ArgMax(
-                d_temp_storage, temp_storage_bytes,
-                d_in, d_out, num_items,
-                stream, debug_synchronous
-            )
-        );
+        (void)debug_synchronous;
+        return hipCUDAErrorTohipError(::cub::DeviceReduce::ArgMax(d_temp_storage,
+                                                                  temp_storage_bytes,
+                                                                  d_in,
+                                                                  d_out,
+                                                                  num_items,
+                                                                  stream));
     }
 
     template<
@@ -197,15 +198,17 @@ public:
                            hipStream_t stream = 0,
                            bool debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceReduce::ReduceByKey(
-                d_temp_storage, temp_storage_bytes,
-                d_keys_in, d_unique_out,
-                d_values_in, d_aggregates_out,
-                d_num_runs_out, reduction_op, num_items,
-                stream, debug_synchronous
-            )
-        );
+        (void)debug_synchronous;
+        return hipCUDAErrorTohipError(::cub::DeviceReduce::ReduceByKey(d_temp_storage,
+                                                                       temp_storage_bytes,
+                                                                       d_keys_in,
+                                                                       d_unique_out,
+                                                                       d_values_in,
+                                                                       d_aggregates_out,
+                                                                       d_num_runs_out,
+                                                                       reduction_op,
+                                                                       num_items,
+                                                                       stream));
     }
 };
 

--- a/hipcub/include/hipcub/backend/cub/device/device_run_length_encode.hpp
+++ b/hipcub/include/hipcub/backend/cub/device/device_run_length_encode.hpp
@@ -1,7 +1,7 @@
 /******************************************************************************
  * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
  * Copyright (c) 2011-2018, NVIDIA CORPORATION.  All rights reserved.
- * Modifications Copyright (c) 2017-2020, Advanced Micro Devices, Inc.  All rights reserved.
+ * Modifications Copyright (c) 2017-2023, Advanced Micro Devices, Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -56,15 +56,15 @@ public:
                       hipStream_t stream = 0,
                       bool debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceRunLengthEncode::Encode(
-                d_temp_storage, temp_storage_bytes,
-                d_in,
-                d_unique_out, d_counts_out, d_num_runs_out,
-                num_items,
-                stream, debug_synchronous
-            )
-        );
+        (void)debug_synchronous;
+        return hipCUDAErrorTohipError(::cub::DeviceRunLengthEncode::Encode(d_temp_storage,
+                                                                           temp_storage_bytes,
+                                                                           d_in,
+                                                                           d_unique_out,
+                                                                           d_counts_out,
+                                                                           d_num_runs_out,
+                                                                           num_items,
+                                                                           stream));
     }
 
     template<
@@ -84,15 +84,16 @@ public:
                               hipStream_t stream = 0,
                               bool debug_synchronous = false)
     {
+        (void)debug_synchronous;
         return hipCUDAErrorTohipError(
-            ::cub::DeviceRunLengthEncode::NonTrivialRuns(
-                d_temp_storage, temp_storage_bytes,
-                d_in,
-                d_offsets_out, d_lengths_out, d_num_runs_out,
-                num_items,
-                stream, debug_synchronous
-            )
-        );
+            ::cub::DeviceRunLengthEncode::NonTrivialRuns(d_temp_storage,
+                                                         temp_storage_bytes,
+                                                         d_in,
+                                                         d_offsets_out,
+                                                         d_lengths_out,
+                                                         d_num_runs_out,
+                                                         num_items,
+                                                         stream));
     }
 };
 

--- a/hipcub/include/hipcub/backend/cub/device/device_scan.hpp
+++ b/hipcub/include/hipcub/backend/cub/device/device_scan.hpp
@@ -1,7 +1,7 @@
 /******************************************************************************
  * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
  * Copyright (c) 2011-2018, NVIDIA CORPORATION.  All rights reserved.
- * Modifications Copyright (c) 2017-2020, Advanced Micro Devices, Inc.  All rights reserved.
+ * Modifications Copyright (c) 2017-2023, Advanced Micro Devices, Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -52,13 +52,13 @@ public:
                             hipStream_t stream = 0,
                             bool debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceScan::InclusiveSum(
-                d_temp_storage, temp_storage_bytes,
-                d_in, d_out, num_items,
-                stream, debug_synchronous
-            )
-        );
+        (void)debug_synchronous;
+        return hipCUDAErrorTohipError(::cub::DeviceScan::InclusiveSum(d_temp_storage,
+                                                                      temp_storage_bytes,
+                                                                      d_in,
+                                                                      d_out,
+                                                                      num_items,
+                                                                      stream));
     }
 
     template <
@@ -76,13 +76,14 @@ public:
                              hipStream_t stream = 0,
                              bool debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceScan::InclusiveScan(
-                d_temp_storage, temp_storage_bytes,
-                d_in, d_out, scan_op, num_items,
-                stream, debug_synchronous
-            )
-        );
+        (void)debug_synchronous;
+        return hipCUDAErrorTohipError(::cub::DeviceScan::InclusiveScan(d_temp_storage,
+                                                                       temp_storage_bytes,
+                                                                       d_in,
+                                                                       d_out,
+                                                                       scan_op,
+                                                                       num_items,
+                                                                       stream));
     }
 
     template <
@@ -98,13 +99,13 @@ public:
                             hipStream_t stream = 0,
                             bool debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceScan::ExclusiveSum(
-                d_temp_storage, temp_storage_bytes,
-                d_in, d_out, num_items,
-                stream, debug_synchronous
-            )
-        );
+        (void)debug_synchronous;
+        return hipCUDAErrorTohipError(::cub::DeviceScan::ExclusiveSum(d_temp_storage,
+                                                                      temp_storage_bytes,
+                                                                      d_in,
+                                                                      d_out,
+                                                                      num_items,
+                                                                      stream));
     }
 
     template <
@@ -124,13 +125,15 @@ public:
                              hipStream_t stream = 0,
                              bool debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceScan::ExclusiveScan(
-                d_temp_storage, temp_storage_bytes,
-                d_in, d_out, scan_op, init_value, num_items,
-                stream, debug_synchronous
-            )
-        );
+        (void)debug_synchronous;
+        return hipCUDAErrorTohipError(::cub::DeviceScan::ExclusiveScan(d_temp_storage,
+                                                                       temp_storage_bytes,
+                                                                       d_in,
+                                                                       d_out,
+                                                                       scan_op,
+                                                                       init_value,
+                                                                       num_items,
+                                                                       stream));
     }
 
     template <
@@ -151,13 +154,15 @@ public:
                              hipStream_t stream = 0,
                              bool debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceScan::ExclusiveScan(
-                d_temp_storage, temp_storage_bytes,
-                d_in, d_out, scan_op, init_value, num_items,
-                stream, debug_synchronous
-            )
-        );
+        (void)debug_synchronous;
+        return hipCUDAErrorTohipError(::cub::DeviceScan::ExclusiveScan(d_temp_storage,
+                                                                       temp_storage_bytes,
+                                                                       d_in,
+                                                                       d_out,
+                                                                       scan_op,
+                                                                       init_value,
+                                                                       num_items,
+                                                                       stream));
     }
 
     template <
@@ -177,13 +182,15 @@ public:
                                  hipStream_t stream = 0,
                                  bool debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceScan::ExclusiveSumByKey(
-                d_temp_storage, temp_storage_bytes,
-                d_keys_in, d_values_in, d_values_out, num_items,
-                equality_op, stream, debug_synchronous
-            )
-        );
+        (void)debug_synchronous;
+        return hipCUDAErrorTohipError(::cub::DeviceScan::ExclusiveSumByKey(d_temp_storage,
+                                                                           temp_storage_bytes,
+                                                                           d_keys_in,
+                                                                           d_values_in,
+                                                                           d_values_out,
+                                                                           num_items,
+                                                                           equality_op,
+                                                                           stream));
     }
 
     template <
@@ -207,13 +214,17 @@ public:
                                   hipStream_t stream = 0,
                                   bool debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceScan::ExclusiveScanByKey(
-                d_temp_storage, temp_storage_bytes,
-                d_keys_in, d_values_in, d_values_out, scan_op, init_value,
-                num_items, equality_op, stream, debug_synchronous
-            )
-        );
+        (void)debug_synchronous;
+        return hipCUDAErrorTohipError(::cub::DeviceScan::ExclusiveScanByKey(d_temp_storage,
+                                                                            temp_storage_bytes,
+                                                                            d_keys_in,
+                                                                            d_values_in,
+                                                                            d_values_out,
+                                                                            scan_op,
+                                                                            init_value,
+                                                                            num_items,
+                                                                            equality_op,
+                                                                            stream));
     }
 
     template <
@@ -233,13 +244,15 @@ public:
                                  hipStream_t stream = 0,
                                  bool debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceScan::InclusiveSumByKey(
-                d_temp_storage, temp_storage_bytes,
-                d_keys_in, d_values_in, d_values_out, num_items,
-                equality_op, stream, debug_synchronous
-            )
-        );
+        (void)debug_synchronous;
+        return hipCUDAErrorTohipError(::cub::DeviceScan::InclusiveSumByKey(d_temp_storage,
+                                                                           temp_storage_bytes,
+                                                                           d_keys_in,
+                                                                           d_values_in,
+                                                                           d_values_out,
+                                                                           num_items,
+                                                                           equality_op,
+                                                                           stream));
     }
 
     template <
@@ -261,13 +274,16 @@ public:
                                   hipStream_t stream = 0,
                                   bool debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceScan::InclusiveScanByKey(
-                d_temp_storage, temp_storage_bytes,
-                d_keys_in, d_values_in, d_values_out, scan_op,
-                num_items, equality_op, stream, debug_synchronous
-            )
-        );
+        (void)debug_synchronous;
+        return hipCUDAErrorTohipError(::cub::DeviceScan::InclusiveScanByKey(d_temp_storage,
+                                                                            temp_storage_bytes,
+                                                                            d_keys_in,
+                                                                            d_values_in,
+                                                                            d_values_out,
+                                                                            scan_op,
+                                                                            num_items,
+                                                                            equality_op,
+                                                                            stream));
     }
 };
 

--- a/hipcub/include/hipcub/backend/cub/device/device_segmented_radix_sort.hpp
+++ b/hipcub/include/hipcub/backend/cub/device/device_segmented_radix_sort.hpp
@@ -1,7 +1,7 @@
 /******************************************************************************
  * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
  * Copyright (c) 2011-2018, NVIDIA CORPORATION.  All rights reserved.
- * Modifications Copyright (c) 2017-2020, Advanced Micro Devices, Inc.  All rights reserved.
+ * Modifications Copyright (c) 2017-2023, Advanced Micro Devices, Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -55,17 +55,20 @@ struct DeviceSegmentedRadixSort
                          hipStream_t stream = 0,
                          bool debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceSegmentedRadixSort::SortPairs(
-                d_temp_storage, temp_storage_bytes,
-                d_keys_in, d_keys_out,
-                d_values_in, d_values_out,
-                num_items, num_segments,
-                d_begin_offsets, d_end_offsets,
-                begin_bit, end_bit,
-                stream, debug_synchronous
-            )
-        );
+        (void)debug_synchronous;
+        return hipCUDAErrorTohipError(::cub::DeviceSegmentedRadixSort::SortPairs(d_temp_storage,
+                                                                                 temp_storage_bytes,
+                                                                                 d_keys_in,
+                                                                                 d_keys_out,
+                                                                                 d_values_in,
+                                                                                 d_values_out,
+                                                                                 num_items,
+                                                                                 num_segments,
+                                                                                 d_begin_offsets,
+                                                                                 d_end_offsets,
+                                                                                 begin_bit,
+                                                                                 end_bit,
+                                                                                 stream));
     }
 
     template<typename KeyT, typename ValueT, typename OffsetIteratorT>
@@ -83,16 +86,18 @@ struct DeviceSegmentedRadixSort
                          hipStream_t stream = 0,
                          bool debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceSegmentedRadixSort::SortPairs(
-                d_temp_storage, temp_storage_bytes,
-                d_keys, d_values,
-                num_items, num_segments,
-                d_begin_offsets, d_end_offsets,
-                begin_bit, end_bit,
-                stream, debug_synchronous
-            )
-        );
+        (void)debug_synchronous;
+        return hipCUDAErrorTohipError(::cub::DeviceSegmentedRadixSort::SortPairs(d_temp_storage,
+                                                                                 temp_storage_bytes,
+                                                                                 d_keys,
+                                                                                 d_values,
+                                                                                 num_items,
+                                                                                 num_segments,
+                                                                                 d_begin_offsets,
+                                                                                 d_end_offsets,
+                                                                                 begin_bit,
+                                                                                 end_bit,
+                                                                                 stream));
     }
 
     template<typename KeyT, typename ValueT, typename OffsetIteratorT>
@@ -112,17 +117,21 @@ struct DeviceSegmentedRadixSort
                                    hipStream_t stream = 0,
                                    bool debug_synchronous = false)
     {
+        (void)debug_synchronous;
         return hipCUDAErrorTohipError(
-            ::cub::DeviceSegmentedRadixSort::SortPairsDescending(
-                d_temp_storage, temp_storage_bytes,
-                d_keys_in, d_keys_out,
-                d_values_in, d_values_out,
-                num_items, num_segments,
-                d_begin_offsets, d_end_offsets,
-                begin_bit, end_bit,
-                stream, debug_synchronous
-            )
-        );
+            ::cub::DeviceSegmentedRadixSort::SortPairsDescending(d_temp_storage,
+                                                                 temp_storage_bytes,
+                                                                 d_keys_in,
+                                                                 d_keys_out,
+                                                                 d_values_in,
+                                                                 d_values_out,
+                                                                 num_items,
+                                                                 num_segments,
+                                                                 d_begin_offsets,
+                                                                 d_end_offsets,
+                                                                 begin_bit,
+                                                                 end_bit,
+                                                                 stream));
     }
 
     template<typename KeyT, typename ValueT, typename OffsetIteratorT>
@@ -140,16 +149,19 @@ struct DeviceSegmentedRadixSort
                                    hipStream_t stream = 0,
                                    bool debug_synchronous = false)
     {
+        (void)debug_synchronous;
         return hipCUDAErrorTohipError(
-            ::cub::DeviceSegmentedRadixSort::SortPairsDescending(
-                d_temp_storage, temp_storage_bytes,
-                d_keys, d_values,
-                num_items, num_segments,
-                d_begin_offsets, d_end_offsets,
-                begin_bit, end_bit,
-                stream, debug_synchronous
-            )
-        );
+            ::cub::DeviceSegmentedRadixSort::SortPairsDescending(d_temp_storage,
+                                                                 temp_storage_bytes,
+                                                                 d_keys,
+                                                                 d_values,
+                                                                 num_items,
+                                                                 num_segments,
+                                                                 d_begin_offsets,
+                                                                 d_end_offsets,
+                                                                 begin_bit,
+                                                                 end_bit,
+                                                                 stream));
     }
 
     template<typename KeyT, typename OffsetIteratorT>
@@ -167,16 +179,18 @@ struct DeviceSegmentedRadixSort
                         hipStream_t stream = 0,
                         bool debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceSegmentedRadixSort::SortKeys(
-                d_temp_storage, temp_storage_bytes,
-                d_keys_in, d_keys_out,
-                num_items, num_segments,
-                d_begin_offsets, d_end_offsets,
-                begin_bit, end_bit,
-                stream, debug_synchronous
-            )
-        );
+        (void)debug_synchronous;
+        return hipCUDAErrorTohipError(::cub::DeviceSegmentedRadixSort::SortKeys(d_temp_storage,
+                                                                                temp_storage_bytes,
+                                                                                d_keys_in,
+                                                                                d_keys_out,
+                                                                                num_items,
+                                                                                num_segments,
+                                                                                d_begin_offsets,
+                                                                                d_end_offsets,
+                                                                                begin_bit,
+                                                                                end_bit,
+                                                                                stream));
     }
 
     template<typename KeyT, typename OffsetIteratorT>
@@ -193,16 +207,17 @@ struct DeviceSegmentedRadixSort
                         hipStream_t stream = 0,
                         bool debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceSegmentedRadixSort::SortKeys(
-                d_temp_storage, temp_storage_bytes,
-                d_keys,
-                num_items, num_segments,
-                d_begin_offsets, d_end_offsets,
-                begin_bit, end_bit,
-                stream, debug_synchronous
-            )
-        );
+        (void)debug_synchronous;
+        return hipCUDAErrorTohipError(::cub::DeviceSegmentedRadixSort::SortKeys(d_temp_storage,
+                                                                                temp_storage_bytes,
+                                                                                d_keys,
+                                                                                num_items,
+                                                                                num_segments,
+                                                                                d_begin_offsets,
+                                                                                d_end_offsets,
+                                                                                begin_bit,
+                                                                                end_bit,
+                                                                                stream));
     }
 
     template<typename KeyT, typename OffsetIteratorT>
@@ -220,16 +235,19 @@ struct DeviceSegmentedRadixSort
                                   hipStream_t stream = 0,
                                   bool debug_synchronous = false)
     {
+        (void)debug_synchronous;
         return hipCUDAErrorTohipError(
-            ::cub::DeviceSegmentedRadixSort::SortKeysDescending(
-                d_temp_storage, temp_storage_bytes,
-                d_keys_in, d_keys_out,
-                num_items, num_segments,
-                d_begin_offsets, d_end_offsets,
-                begin_bit, end_bit,
-                stream, debug_synchronous
-            )
-        );
+            ::cub::DeviceSegmentedRadixSort::SortKeysDescending(d_temp_storage,
+                                                                temp_storage_bytes,
+                                                                d_keys_in,
+                                                                d_keys_out,
+                                                                num_items,
+                                                                num_segments,
+                                                                d_begin_offsets,
+                                                                d_end_offsets,
+                                                                begin_bit,
+                                                                end_bit,
+                                                                stream));
     }
 
     template<typename KeyT, typename OffsetIteratorT>
@@ -246,16 +264,18 @@ struct DeviceSegmentedRadixSort
                                   hipStream_t stream = 0,
                                   bool debug_synchronous = false)
     {
+        (void)debug_synchronous;
         return hipCUDAErrorTohipError(
-            ::cub::DeviceSegmentedRadixSort::SortKeysDescending(
-                d_temp_storage, temp_storage_bytes,
-                d_keys,
-                num_items, num_segments,
-                d_begin_offsets, d_end_offsets,
-                begin_bit, end_bit,
-                stream, debug_synchronous
-            )
-        );
+            ::cub::DeviceSegmentedRadixSort::SortKeysDescending(d_temp_storage,
+                                                                temp_storage_bytes,
+                                                                d_keys,
+                                                                num_items,
+                                                                num_segments,
+                                                                d_begin_offsets,
+                                                                d_end_offsets,
+                                                                begin_bit,
+                                                                end_bit,
+                                                                stream));
     }
 };
 

--- a/hipcub/include/hipcub/backend/cub/device/device_segmented_reduce.hpp
+++ b/hipcub/include/hipcub/backend/cub/device/device_segmented_reduce.hpp
@@ -1,7 +1,7 @@
 /******************************************************************************
  * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
  * Copyright (c) 2011-2018, NVIDIA CORPORATION.  All rights reserved.
- * Modifications Copyright (c) 2017-2020, Advanced Micro Devices, Inc.  All rights reserved.
+ * Modifications Copyright (c) 2017-2023, Advanced Micro Devices, Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -58,15 +58,17 @@ struct DeviceSegmentedReduce
                       hipStream_t stream = 0,
                       bool debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceSegmentedReduce::Reduce(
-                d_temp_storage, temp_storage_bytes,
-                d_in, d_out, num_segments,
-                d_begin_offsets, d_end_offsets,
-                reduction_op, initial_value,
-                stream, debug_synchronous
-            )
-        );
+        (void)debug_synchronous;
+        return hipCUDAErrorTohipError(::cub::DeviceSegmentedReduce::Reduce(d_temp_storage,
+                                                                           temp_storage_bytes,
+                                                                           d_in,
+                                                                           d_out,
+                                                                           num_segments,
+                                                                           d_begin_offsets,
+                                                                           d_end_offsets,
+                                                                           reduction_op,
+                                                                           initial_value,
+                                                                           stream));
     }
 
     template<
@@ -85,14 +87,15 @@ struct DeviceSegmentedReduce
                    hipStream_t stream = 0,
                    bool debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceSegmentedReduce::Sum(
-                d_temp_storage, temp_storage_bytes,
-                d_in, d_out, num_segments,
-                d_begin_offsets, d_end_offsets,
-                stream, debug_synchronous
-            )
-        );
+        (void)debug_synchronous;
+        return hipCUDAErrorTohipError(::cub::DeviceSegmentedReduce::Sum(d_temp_storage,
+                                                                        temp_storage_bytes,
+                                                                        d_in,
+                                                                        d_out,
+                                                                        num_segments,
+                                                                        d_begin_offsets,
+                                                                        d_end_offsets,
+                                                                        stream));
     }
 
     template<
@@ -111,14 +114,15 @@ struct DeviceSegmentedReduce
                    hipStream_t stream = 0,
                    bool debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceSegmentedReduce::Min(
-                d_temp_storage, temp_storage_bytes,
-                d_in, d_out, num_segments,
-                d_begin_offsets, d_end_offsets,
-                stream, debug_synchronous
-            )
-        );
+        (void)debug_synchronous;
+        return hipCUDAErrorTohipError(::cub::DeviceSegmentedReduce::Min(d_temp_storage,
+                                                                        temp_storage_bytes,
+                                                                        d_in,
+                                                                        d_out,
+                                                                        num_segments,
+                                                                        d_begin_offsets,
+                                                                        d_end_offsets,
+                                                                        stream));
     }
 
     template<
@@ -137,14 +141,15 @@ struct DeviceSegmentedReduce
                       hipStream_t stream = 0,
                       bool debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceSegmentedReduce::ArgMin(
-                d_temp_storage, temp_storage_bytes,
-                d_in, d_out, num_segments,
-                d_begin_offsets, d_end_offsets,
-                stream, debug_synchronous
-            )
-        );
+        (void)debug_synchronous;
+        return hipCUDAErrorTohipError(::cub::DeviceSegmentedReduce::ArgMin(d_temp_storage,
+                                                                           temp_storage_bytes,
+                                                                           d_in,
+                                                                           d_out,
+                                                                           num_segments,
+                                                                           d_begin_offsets,
+                                                                           d_end_offsets,
+                                                                           stream));
     }
 
     template<
@@ -163,14 +168,15 @@ struct DeviceSegmentedReduce
                    hipStream_t stream = 0,
                    bool debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceSegmentedReduce::Max(
-                d_temp_storage, temp_storage_bytes,
-                d_in, d_out, num_segments,
-                d_begin_offsets, d_end_offsets,
-                stream, debug_synchronous
-            )
-        );
+        (void)debug_synchronous;
+        return hipCUDAErrorTohipError(::cub::DeviceSegmentedReduce::Max(d_temp_storage,
+                                                                        temp_storage_bytes,
+                                                                        d_in,
+                                                                        d_out,
+                                                                        num_segments,
+                                                                        d_begin_offsets,
+                                                                        d_end_offsets,
+                                                                        stream));
     }
 
     template<
@@ -189,14 +195,15 @@ struct DeviceSegmentedReduce
                       hipStream_t stream = 0,
                       bool debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceSegmentedReduce::ArgMax(
-                d_temp_storage, temp_storage_bytes,
-                d_in, d_out, num_segments,
-                d_begin_offsets, d_end_offsets,
-                stream, debug_synchronous
-            )
-        );
+        (void)debug_synchronous;
+        return hipCUDAErrorTohipError(::cub::DeviceSegmentedReduce::ArgMax(d_temp_storage,
+                                                                           temp_storage_bytes,
+                                                                           d_in,
+                                                                           d_out,
+                                                                           num_segments,
+                                                                           d_begin_offsets,
+                                                                           d_end_offsets,
+                                                                           stream));
     }
 };
 

--- a/hipcub/include/hipcub/backend/cub/device/device_segmented_sort.hpp
+++ b/hipcub/include/hipcub/backend/cub/device/device_segmented_sort.hpp
@@ -1,7 +1,7 @@
 /******************************************************************************
  * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
  * Copyright (c) 2011-2018, NVIDIA CORPORATION.  All rights reserved.
- * Modifications Copyright (c) 2017-2020, Advanced Micro Devices, Inc.  All rights reserved.
+ * Modifications Copyright (c) 2017-2023, Advanced Micro Devices, Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -53,15 +53,16 @@ struct DeviceSegmentedSort
                         hipStream_t stream = 0,
                         bool debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceSegmentedSort::SortKeys(
-                d_temp_storage, temp_storage_bytes,
-                d_keys_in, d_keys_out,
-                num_items, num_segments,
-                d_begin_offsets, d_end_offsets,
-                stream, debug_synchronous
-            )
-        );
+        (void)debug_synchronous;
+        return hipCUDAErrorTohipError(::cub::DeviceSegmentedSort::SortKeys(d_temp_storage,
+                                                                           temp_storage_bytes,
+                                                                           d_keys_in,
+                                                                           d_keys_out,
+                                                                           num_items,
+                                                                           num_segments,
+                                                                           d_begin_offsets,
+                                                                           d_end_offsets,
+                                                                           stream));
     }
 
     template <typename KeyT,
@@ -79,15 +80,17 @@ struct DeviceSegmentedSort
                                   hipStream_t stream = 0,
                                   bool debug_synchronous = false)
     {
+        (void)debug_synchronous;
         return hipCUDAErrorTohipError(
-            ::cub::DeviceSegmentedSort::SortKeysDescending(
-                d_temp_storage, temp_storage_bytes,
-                d_keys_in, d_keys_out,
-                num_items, num_segments,
-                d_begin_offsets, d_end_offsets,
-                stream, debug_synchronous
-            )
-        );
+            ::cub::DeviceSegmentedSort::SortKeysDescending(d_temp_storage,
+                                                           temp_storage_bytes,
+                                                           d_keys_in,
+                                                           d_keys_out,
+                                                           num_items,
+                                                           num_segments,
+                                                           d_begin_offsets,
+                                                           d_end_offsets,
+                                                           stream));
     }
 
     template <typename KeyT,
@@ -104,15 +107,15 @@ struct DeviceSegmentedSort
                         hipStream_t stream = 0,
                         bool debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceSegmentedSort::SortKeys(
-                d_temp_storage, temp_storage_bytes,
-                d_keys,
-                num_items, num_segments,
-                d_begin_offsets, d_end_offsets,
-                stream, debug_synchronous
-            )
-        );
+        (void)debug_synchronous;
+        return hipCUDAErrorTohipError(::cub::DeviceSegmentedSort::SortKeys(d_temp_storage,
+                                                                           temp_storage_bytes,
+                                                                           d_keys,
+                                                                           num_items,
+                                                                           num_segments,
+                                                                           d_begin_offsets,
+                                                                           d_end_offsets,
+                                                                           stream));
     }
     
     template <typename KeyT,
@@ -129,15 +132,16 @@ struct DeviceSegmentedSort
                                   hipStream_t stream = 0,
                                   bool debug_synchronous = false)
     {
+        (void)debug_synchronous;
         return hipCUDAErrorTohipError(
-            ::cub::DeviceSegmentedSort::SortKeysDescending(
-                d_temp_storage, temp_storage_bytes,
-                d_keys,
-                num_items, num_segments,
-                d_begin_offsets, d_end_offsets,
-                stream, debug_synchronous
-            )
-        );
+            ::cub::DeviceSegmentedSort::SortKeysDescending(d_temp_storage,
+                                                           temp_storage_bytes,
+                                                           d_keys,
+                                                           num_items,
+                                                           num_segments,
+                                                           d_begin_offsets,
+                                                           d_end_offsets,
+                                                           stream));
     }
 
     template <typename KeyT,
@@ -155,15 +159,16 @@ struct DeviceSegmentedSort
                               hipStream_t stream = 0,
                               bool debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceSegmentedSort::StableSortKeys(
-                d_temp_storage, temp_storage_bytes,
-                d_keys_in, d_keys_out,
-                num_items, num_segments,
-                d_begin_offsets, d_end_offsets,
-                stream, debug_synchronous
-            )
-        );
+        (void)debug_synchronous;
+        return hipCUDAErrorTohipError(::cub::DeviceSegmentedSort::StableSortKeys(d_temp_storage,
+                                                                                 temp_storage_bytes,
+                                                                                 d_keys_in,
+                                                                                 d_keys_out,
+                                                                                 num_items,
+                                                                                 num_segments,
+                                                                                 d_begin_offsets,
+                                                                                 d_end_offsets,
+                                                                                 stream));
     }
 
     template <typename KeyT,
@@ -181,15 +186,17 @@ struct DeviceSegmentedSort
                                         hipStream_t stream = 0,
                                         bool debug_synchronous = false)
     {
+        (void)debug_synchronous;
         return hipCUDAErrorTohipError(
-            ::cub::DeviceSegmentedSort::StableSortKeysDescending(
-                d_temp_storage, temp_storage_bytes,
-                d_keys_in, d_keys_out,
-                num_items, num_segments,
-                d_begin_offsets, d_end_offsets,
-                stream, debug_synchronous
-            )
-        );
+            ::cub::DeviceSegmentedSort::StableSortKeysDescending(d_temp_storage,
+                                                                 temp_storage_bytes,
+                                                                 d_keys_in,
+                                                                 d_keys_out,
+                                                                 num_items,
+                                                                 num_segments,
+                                                                 d_begin_offsets,
+                                                                 d_end_offsets,
+                                                                 stream));
     }
 
     template <typename KeyT,
@@ -206,15 +213,15 @@ struct DeviceSegmentedSort
                               hipStream_t stream = 0,
                               bool debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceSegmentedSort::StableSortKeys(
-                d_temp_storage, temp_storage_bytes,
-                d_keys,
-                num_items, num_segments,
-                d_begin_offsets, d_end_offsets,
-                stream, debug_synchronous
-            )
-        );
+        (void)debug_synchronous;
+        return hipCUDAErrorTohipError(::cub::DeviceSegmentedSort::StableSortKeys(d_temp_storage,
+                                                                                 temp_storage_bytes,
+                                                                                 d_keys,
+                                                                                 num_items,
+                                                                                 num_segments,
+                                                                                 d_begin_offsets,
+                                                                                 d_end_offsets,
+                                                                                 stream));
     }
     
     template <typename KeyT,
@@ -231,15 +238,16 @@ struct DeviceSegmentedSort
                                         hipStream_t stream = 0,
                                         bool debug_synchronous = false)
     {
+        (void)debug_synchronous;
         return hipCUDAErrorTohipError(
-            ::cub::DeviceSegmentedSort::StableSortKeysDescending(
-                d_temp_storage, temp_storage_bytes,
-                d_keys,
-                num_items, num_segments,
-                d_begin_offsets, d_end_offsets,
-                stream, debug_synchronous
-            )
-        );
+            ::cub::DeviceSegmentedSort::StableSortKeysDescending(d_temp_storage,
+                                                                 temp_storage_bytes,
+                                                                 d_keys,
+                                                                 num_items,
+                                                                 num_segments,
+                                                                 d_begin_offsets,
+                                                                 d_end_offsets,
+                                                                 stream));
     }
 
     template <typename KeyT,
@@ -260,16 +268,18 @@ struct DeviceSegmentedSort
                          hipStream_t stream = 0,
                          bool debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceSegmentedSort::SortPairs(
-                d_temp_storage, temp_storage_bytes,
-                d_keys_in, d_keys_out,
-                d_values_in, d_values_out,
-                num_items, num_segments,
-                d_begin_offsets, d_end_offsets,
-                stream, debug_synchronous
-            )
-        );
+        (void)debug_synchronous;
+        return hipCUDAErrorTohipError(::cub::DeviceSegmentedSort::SortPairs(d_temp_storage,
+                                                                            temp_storage_bytes,
+                                                                            d_keys_in,
+                                                                            d_keys_out,
+                                                                            d_values_in,
+                                                                            d_values_out,
+                                                                            num_items,
+                                                                            num_segments,
+                                                                            d_begin_offsets,
+                                                                            d_end_offsets,
+                                                                            stream));
     }
 
     template <typename KeyT,
@@ -290,16 +300,19 @@ struct DeviceSegmentedSort
                                    hipStream_t stream = 0,
                                    bool debug_synchronous = false)
     {
+        (void)debug_synchronous;
         return hipCUDAErrorTohipError(
-            ::cub::DeviceSegmentedSort::SortPairsDescending(
-                d_temp_storage, temp_storage_bytes,
-                d_keys_in, d_keys_out,
-                d_values_in, d_values_out,
-                num_items, num_segments,
-                d_begin_offsets, d_end_offsets,
-                stream, debug_synchronous
-            )
-        );
+            ::cub::DeviceSegmentedSort::SortPairsDescending(d_temp_storage,
+                                                            temp_storage_bytes,
+                                                            d_keys_in,
+                                                            d_keys_out,
+                                                            d_values_in,
+                                                            d_values_out,
+                                                            num_items,
+                                                            num_segments,
+                                                            d_begin_offsets,
+                                                            d_end_offsets,
+                                                            stream));
     }
 
     template <typename KeyT,
@@ -318,15 +331,16 @@ struct DeviceSegmentedSort
                          hipStream_t stream = 0,
                          bool debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceSegmentedSort::SortPairs(
-                d_temp_storage, temp_storage_bytes,
-                d_keys, d_values,
-                num_items, num_segments,
-                d_begin_offsets, d_end_offsets,
-                stream, debug_synchronous
-            )
-        );
+        (void)debug_synchronous;
+        return hipCUDAErrorTohipError(::cub::DeviceSegmentedSort::SortPairs(d_temp_storage,
+                                                                            temp_storage_bytes,
+                                                                            d_keys,
+                                                                            d_values,
+                                                                            num_items,
+                                                                            num_segments,
+                                                                            d_begin_offsets,
+                                                                            d_end_offsets,
+                                                                            stream));
     }
     
     template <typename KeyT,
@@ -345,15 +359,17 @@ struct DeviceSegmentedSort
                                    hipStream_t stream = 0,
                                    bool debug_synchronous = false)
     {
+        (void)debug_synchronous;
         return hipCUDAErrorTohipError(
-            ::cub::DeviceSegmentedSort::SortPairsDescending(
-                d_temp_storage, temp_storage_bytes,
-                d_keys, d_values,
-                num_items, num_segments,
-                d_begin_offsets, d_end_offsets,
-                stream, debug_synchronous
-            )
-        );
+            ::cub::DeviceSegmentedSort::SortPairsDescending(d_temp_storage,
+                                                            temp_storage_bytes,
+                                                            d_keys,
+                                                            d_values,
+                                                            num_items,
+                                                            num_segments,
+                                                            d_begin_offsets,
+                                                            d_end_offsets,
+                                                            stream));
     }
 
     template <typename KeyT,
@@ -374,16 +390,19 @@ struct DeviceSegmentedSort
                                hipStream_t stream = 0,
                                bool debug_synchronous = false)
     {
+        (void)debug_synchronous;
         return hipCUDAErrorTohipError(
-            ::cub::DeviceSegmentedSort::StableSortPairs(
-                d_temp_storage, temp_storage_bytes,
-                d_keys_in, d_keys_out,
-                d_values_in, d_values_out,
-                num_items, num_segments,
-                d_begin_offsets, d_end_offsets,
-                stream, debug_synchronous
-            )
-        );
+            ::cub::DeviceSegmentedSort::StableSortPairs(d_temp_storage,
+                                                        temp_storage_bytes,
+                                                        d_keys_in,
+                                                        d_keys_out,
+                                                        d_values_in,
+                                                        d_values_out,
+                                                        num_items,
+                                                        num_segments,
+                                                        d_begin_offsets,
+                                                        d_end_offsets,
+                                                        stream));
     }
 
     template <typename KeyT,
@@ -404,16 +423,19 @@ struct DeviceSegmentedSort
                                          hipStream_t stream = 0,
                                          bool debug_synchronous = false)
     {
+        (void)debug_synchronous;
         return hipCUDAErrorTohipError(
-            ::cub::DeviceSegmentedSort::StableSortPairsDescending(
-                d_temp_storage, temp_storage_bytes,
-                d_keys_in, d_keys_out,
-                d_values_in, d_values_out,
-                num_items, num_segments,
-                d_begin_offsets, d_end_offsets,
-                stream, debug_synchronous
-            )
-        );
+            ::cub::DeviceSegmentedSort::StableSortPairsDescending(d_temp_storage,
+                                                                  temp_storage_bytes,
+                                                                  d_keys_in,
+                                                                  d_keys_out,
+                                                                  d_values_in,
+                                                                  d_values_out,
+                                                                  num_items,
+                                                                  num_segments,
+                                                                  d_begin_offsets,
+                                                                  d_end_offsets,
+                                                                  stream));
     }
 
     template <typename KeyT,
@@ -432,15 +454,17 @@ struct DeviceSegmentedSort
                                hipStream_t stream = 0,
                                bool debug_synchronous = false)
     {
+        (void)debug_synchronous;
         return hipCUDAErrorTohipError(
-            ::cub::DeviceSegmentedSort::StableSortPairs(
-                d_temp_storage, temp_storage_bytes,
-                d_keys, d_values,
-                num_items, num_segments,
-                d_begin_offsets, d_end_offsets,
-                stream, debug_synchronous
-            )
-        );
+            ::cub::DeviceSegmentedSort::StableSortPairs(d_temp_storage,
+                                                        temp_storage_bytes,
+                                                        d_keys,
+                                                        d_values,
+                                                        num_items,
+                                                        num_segments,
+                                                        d_begin_offsets,
+                                                        d_end_offsets,
+                                                        stream));
     }
     
     template <typename KeyT,
@@ -459,15 +483,17 @@ struct DeviceSegmentedSort
                                          hipStream_t stream = 0,
                                          bool debug_synchronous = false)
     {
+        (void)debug_synchronous;
         return hipCUDAErrorTohipError(
-            ::cub::DeviceSegmentedSort::StableSortPairsDescending(
-                d_temp_storage, temp_storage_bytes,
-                d_keys, d_values,
-                num_items, num_segments,
-                d_begin_offsets, d_end_offsets,
-                stream, debug_synchronous
-            )
-        );
+            ::cub::DeviceSegmentedSort::StableSortPairsDescending(d_temp_storage,
+                                                                  temp_storage_bytes,
+                                                                  d_keys,
+                                                                  d_values,
+                                                                  num_items,
+                                                                  num_segments,
+                                                                  d_begin_offsets,
+                                                                  d_end_offsets,
+                                                                  stream));
     }
 };
 

--- a/hipcub/include/hipcub/backend/cub/device/device_select.hpp
+++ b/hipcub/include/hipcub/backend/cub/device/device_select.hpp
@@ -1,7 +1,7 @@
 /******************************************************************************
  * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
  * Copyright (c) 2011-2018, NVIDIA CORPORATION.  All rights reserved.
- * Modifications Copyright (c) 2017-2020, Advanced Micro Devices, Inc.  All rights reserved.
+ * Modifications Copyright (c) 2017-2023, Advanced Micro Devices, Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -56,14 +56,15 @@ public:
                        hipStream_t stream = 0,
                        bool debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceSelect::Flagged(
-                d_temp_storage, temp_storage_bytes,
-                d_in, d_flags,
-                d_out, d_num_selected_out, num_items,
-                stream, debug_synchronous
-            )
-        );
+        (void)debug_synchronous;
+        return hipCUDAErrorTohipError(::cub::DeviceSelect::Flagged(d_temp_storage,
+                                                                   temp_storage_bytes,
+                                                                   d_in,
+                                                                   d_flags,
+                                                                   d_out,
+                                                                   d_num_selected_out,
+                                                                   num_items,
+                                                                   stream));
     }
 
     template <
@@ -83,14 +84,15 @@ public:
                   hipStream_t stream = 0,
                   bool debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceSelect::If(
-                d_temp_storage, temp_storage_bytes,
-                d_in, d_out, d_num_selected_out,
-                num_items, select_op,
-                stream, debug_synchronous
-            )
-        );
+        (void)debug_synchronous;
+        return hipCUDAErrorTohipError(::cub::DeviceSelect::If(d_temp_storage,
+                                                              temp_storage_bytes,
+                                                              d_in,
+                                                              d_out,
+                                                              d_num_selected_out,
+                                                              num_items,
+                                                              select_op,
+                                                              stream));
     }
 
     template <
@@ -108,13 +110,14 @@ public:
                       hipStream_t stream = 0,
                       bool debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceSelect::Unique(
-                d_temp_storage, temp_storage_bytes,
-                d_in, d_out, d_num_selected_out, num_items,
-                stream, debug_synchronous
-            )
-        );
+        (void)debug_synchronous;
+        return hipCUDAErrorTohipError(::cub::DeviceSelect::Unique(d_temp_storage,
+                                                                  temp_storage_bytes,
+                                                                  d_in,
+                                                                  d_out,
+                                                                  d_num_selected_out,
+                                                                  num_items,
+                                                                  stream));
     }
 
     template <
@@ -136,15 +139,16 @@ public:
                            hipStream_t stream = 0,
                            bool debug_synchronous = false)
     {
-        return hipCUDAErrorTohipError(
-            ::cub::DeviceSelect::UniqueByKey(
-                d_temp_storage, temp_storage_bytes,
-                d_keys_input, d_values_input, 
-                d_keys_output, d_values_output,
-                d_num_selected_out, num_items,
-                stream, debug_synchronous
-            )
-        );
+        (void)debug_synchronous;
+        return hipCUDAErrorTohipError(::cub::DeviceSelect::UniqueByKey(d_temp_storage,
+                                                                       temp_storage_bytes,
+                                                                       d_keys_input,
+                                                                       d_values_input,
+                                                                       d_keys_output,
+                                                                       d_values_output,
+                                                                       d_num_selected_out,
+                                                                       num_items,
+                                                                       stream));
     }
 };
 

--- a/hipcub/include/hipcub/backend/cub/device/device_spmv.hpp
+++ b/hipcub/include/hipcub/backend/cub/device/device_spmv.hpp
@@ -1,7 +1,7 @@
 /******************************************************************************
  * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
  * Copyright (c) 2011-2018, NVIDIA CORPORATION.  All rights reserved.
- * Modifications Copyright (c) 2017-2020, Advanced Micro Devices, Inc.  All rights reserved.
+ * Modifications Copyright (c) 2017-2023, Advanced Micro Devices, Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -89,12 +89,13 @@ template <typename ValueT>
         spmv_params.alpha                = 1.0;
         spmv_params.beta                 = 0.0;
 
-        return static_cast<hipError_t>(::cub::DispatchSpmv<ValueT, int>::Dispatch(
-            d_temp_storage,
-            temp_storage_bytes,
-            spmv_params,
-            stream,
-            debug_synchronous));
+        (void)debug_synchronous;
+
+        return static_cast<hipError_t>(
+            ::cub::DispatchSpmv<ValueT, int>::Dispatch(d_temp_storage,
+                                                       temp_storage_bytes,
+                                                       spmv_params,
+                                                       stream));
     }
 };
 

--- a/hipcub/include/hipcub/backend/rocprim/block/block_radix_rank.hpp
+++ b/hipcub/include/hipcub/backend/rocprim/block/block_radix_rank.hpp
@@ -46,6 +46,8 @@
 #include "../thread/thread_reduce.hpp"
 #include "../thread/thread_scan.hpp"
 
+#include <rocprim/block/block_radix_rank.hpp>
+
 BEGIN_HIPCUB_NAMESPACE
 
 
@@ -84,237 +86,55 @@ BEGIN_HIPCUB_NAMESPACE
  *
  *      \endcode
  */
-template <
-    int                     BLOCK_DIM_X,
-    int                     RADIX_BITS,
-    bool                    IS_DESCENDING,
-    bool                    MEMOIZE_OUTER_SCAN   = false,
-    BlockScanAlgorithm      INNER_SCAN_ALGORITHM = BLOCK_SCAN_WARP_SCANS,
-    hipSharedMemConfig      SMEM_CONFIG          = hipSharedMemBankSizeFourByte,
-    int                     BLOCK_DIM_Y          = 1,
-    int                     BLOCK_DIM_Z          = 1,
-    int                     ARCH                 = HIPCUB_ARCH /* ignored */>
+template<int                BLOCK_DIM_X,
+         int                RADIX_BITS,
+         bool               IS_DESCENDING,
+         bool               MEMOIZE_OUTER_SCAN   = false,
+         BlockScanAlgorithm INNER_SCAN_ALGORITHM = BLOCK_SCAN_WARP_SCANS,
+         hipSharedMemConfig SMEM_CONFIG          = hipSharedMemBankSizeFourByte,
+         int                BLOCK_DIM_Y          = 1,
+         int                BLOCK_DIM_Z          = 1,
+         int                ARCH                 = HIPCUB_ARCH /* ignored */>
 class BlockRadixRank
+    : private ::rocprim::block_radix_rank<BLOCK_DIM_X,
+                                          RADIX_BITS,
+                                          MEMOIZE_OUTER_SCAN
+                                              ? ::rocprim::block_radix_rank_algorithm::basic_memoize
+                                              : ::rocprim::block_radix_rank_algorithm::basic,
+                                          BLOCK_DIM_Y,
+                                          BLOCK_DIM_Z>
 {
-private:
+    static_assert(BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z > 0,
+                  "BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z must be greater than 0");
 
-    /******************************************************************************
-     * Type definitions and constants
-     ******************************************************************************/
-
-    // Integer type for digit counters (to be packed into words of type PackedCounters)
-    typedef unsigned short DigitCounter;
-
-    // Integer type for packing DigitCounters into columns of shared memory banks
-    typedef typename std::conditional<(SMEM_CONFIG == hipSharedMemBankSizeEightByte),
-        unsigned long long,
-        unsigned int>::type PackedCounter;
-
-    enum
-    {
-        // The thread block size in threads
-        BLOCK_THREADS               = BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z,
-
-        RADIX_DIGITS                = 1 << RADIX_BITS,
-
-        LOG_WARP_THREADS            = Log2<ARCH>::VALUE,
-        WARP_THREADS                = 1 << LOG_WARP_THREADS,
-        WARPS                       = (BLOCK_THREADS + WARP_THREADS - 1) / WARP_THREADS,
-
-        BYTES_PER_COUNTER           = sizeof(DigitCounter),
-        LOG_BYTES_PER_COUNTER       = Log2<BYTES_PER_COUNTER>::VALUE,
-
-        PACKING_RATIO               = sizeof(PackedCounter) / sizeof(DigitCounter),
-        LOG_PACKING_RATIO           = Log2<PACKING_RATIO>::VALUE,
-
-        LOG_COUNTER_LANES           = rocprim::maximum<int>()((int(RADIX_BITS) - int(LOG_PACKING_RATIO)), 0),                // Always at least one lane
-        COUNTER_LANES               = 1 << LOG_COUNTER_LANES,
-
-        // The number of packed counters per thread (plus one for padding)
-        PADDED_COUNTER_LANES        = COUNTER_LANES + 1,
-        RAKING_SEGMENT              = PADDED_COUNTER_LANES,
-    };
+    using base_type
+        = ::rocprim::block_radix_rank<BLOCK_DIM_X,
+                                      RADIX_BITS,
+                                      MEMOIZE_OUTER_SCAN
+                                          ? ::rocprim::block_radix_rank_algorithm::basic_memoize
+                                          : ::rocprim::block_radix_rank_algorithm::basic,
+                                      BLOCK_DIM_Y,
+                                      BLOCK_DIM_Z>;
 
 public:
-
-    enum
-    {
-        /// Number of bin-starting offsets tracked per thread
-        BINS_TRACKED_PER_THREAD = rocprim::maximum<int>()(1, (RADIX_DIGITS + BLOCK_THREADS - 1) / BLOCK_THREADS),
-    };
+    using TempStorage = typename base_type::storage_type;
 
 private:
+    // Reference to temporary storage (usually shared memory)
+    TempStorage& temp_storage_;
 
-
-    /// BlockScan type
-    typedef BlockScan<
-            PackedCounter,
-            BLOCK_DIM_X,
-            INNER_SCAN_ALGORITHM,
-            BLOCK_DIM_Y,
-            BLOCK_DIM_Z,
-            ARCH>
-        BlockScan;
-
-#ifndef DOXYGEN_SHOULD_SKIP_THIS    // Do not document
-
-    /// Shared memory storage layout type for BlockRadixRank
-    struct __align__(16) _TempStorage
+    HIPCUB_DEVICE inline TempStorage& PrivateStorage()
     {
-        union Aliasable
-        {
-            DigitCounter            digit_counters[PADDED_COUNTER_LANES * BLOCK_THREADS * PACKING_RATIO];
-            PackedCounter           raking_grid[BLOCK_THREADS * RAKING_SEGMENT];
-
-        } aliasable;
-
-        // Storage for scanning local ranks
-        typename BlockScan::TempStorage block_scan;
-    };
-
-#endif
-
-    /******************************************************************************
-     * Thread fields
-     ******************************************************************************/
-
-    /// Shared storage reference
-    _TempStorage &temp_storage;
-
-    /// Linear thread-id
-    unsigned int linear_tid;
-
-    /// Copy of raking segment, promoted to registers
-    PackedCounter cached_segment[RAKING_SEGMENT];
-
-
-    /******************************************************************************
-     * Utility methods
-     ******************************************************************************/
-
-    /**
-     * Internal storage allocator
-     */
-    HIPCUB_DEVICE inline _TempStorage& PrivateStorage()
-    {
-        __shared__ _TempStorage private_storage;
+        HIPCUB_SHARED_MEMORY TempStorage private_storage;
         return private_storage;
     }
 
-
-    /**
-     * Performs upsweep raking reduction, returning the aggregate
-     */
-    HIPCUB_DEVICE inline PackedCounter Upsweep()
-    {
-        PackedCounter *smem_raking_ptr = &temp_storage.aliasable.raking_grid[linear_tid * RAKING_SEGMENT];
-        PackedCounter *raking_ptr;
-
-        if (MEMOIZE_OUTER_SCAN)
-        {
-            // Copy data into registers
-            #pragma unroll
-            for (int i = 0; i < RAKING_SEGMENT; i++)
-            {
-                cached_segment[i] = smem_raking_ptr[i];
-            }
-            raking_ptr = cached_segment;
-        }
-        else
-        {
-            raking_ptr = smem_raking_ptr;
-        }
-
-        return internal::ThreadReduce<RAKING_SEGMENT>(raking_ptr, Sum());
-    }
-
-
-    /// Performs exclusive downsweep raking scan
-    HIPCUB_DEVICE inline void ExclusiveDownsweep(
-        PackedCounter raking_partial)
-    {
-        PackedCounter *smem_raking_ptr = &temp_storage.aliasable.raking_grid[linear_tid * RAKING_SEGMENT];
-
-        PackedCounter *raking_ptr = (MEMOIZE_OUTER_SCAN) ?
-            cached_segment :
-            smem_raking_ptr;
-
-        // Exclusive raking downsweep scan
-        internal::ThreadScanExclusive<RAKING_SEGMENT>(raking_ptr, raking_ptr, Sum(), raking_partial);
-
-        if (MEMOIZE_OUTER_SCAN)
-        {
-            // Copy data back to smem
-            #pragma unroll
-            for (int i = 0; i < RAKING_SEGMENT; i++)
-            {
-                smem_raking_ptr[i] = cached_segment[i];
-            }
-        }
-    }
-
-
-    /**
-     * Reset shared memory digit counters
-     */
-    HIPCUB_DEVICE inline void ResetCounters()
-    {
-        // Reset shared memory digit counters
-        #pragma unroll
-        for (int LANE = 0; LANE < PADDED_COUNTER_LANES; LANE++)
-        {
-            #pragma unroll
-            for (int SUB_COUNTER = 0; SUB_COUNTER < PACKING_RATIO; SUB_COUNTER++)
-            {
-                temp_storage.aliasable.digit_counters[(LANE * BLOCK_THREADS + linear_tid) * PACKING_RATIO + SUB_COUNTER] = 0;
-            }
-        }
-    }
-
-
-    /**
-     * Block-scan prefix callback
-     */
-    struct PrefixCallBack
-    {
-        HIPCUB_DEVICE inline PackedCounter operator()(PackedCounter block_aggregate)
-        {
-            PackedCounter block_prefix = 0;
-
-            // Propagate totals in packed fields
-            #pragma unroll
-            for (int PACKED = 1; PACKED < PACKING_RATIO; PACKED++)
-            {
-                block_prefix += block_aggregate << (sizeof(DigitCounter) * 8 * PACKED);
-            }
-
-            return block_prefix;
-        }
-    };
-
-
-    /**
-     * Scan shared memory digit counters.
-     */
-    HIPCUB_DEVICE inline void ScanCounters()
-    {
-        // Upsweep scan
-        PackedCounter raking_partial = Upsweep();
-
-        // Compute exclusive sum
-        PackedCounter exclusive_partial;
-        PrefixCallBack prefix_call_back;
-        BlockScan(temp_storage.block_scan).ExclusiveSum(raking_partial, exclusive_partial, prefix_call_back);
-
-        // Downsweep scan with exclusive partial
-        ExclusiveDownsweep(exclusive_partial);
-    }
-
 public:
-
-    /// \smemstorage{BlockScan}
-    struct TempStorage : Uninitialized<_TempStorage> {};
-
+    enum
+    {
+        /// Number of bin-starting offsets tracked per thread
+        BINS_TRACKED_PER_THREAD = base_type::digits_per_thread,
+    };
 
     /******************************************************************//**
      * \name Collective constructors
@@ -324,134 +144,82 @@ public:
     /**
      * \brief Collective constructor using a private static allocation of shared memory as temporary storage.
      */
-    HIPCUB_DEVICE inline BlockRadixRank()
-    :
-        temp_storage(PrivateStorage()),
-        linear_tid(RowMajorTid(BLOCK_DIM_X, BLOCK_DIM_Y, BLOCK_DIM_Z))
-    {}
-
+    HIPCUB_DEVICE inline BlockRadixRank() : temp_storage_(PrivateStorage()) {}
 
     /**
      * \brief Collective constructor using the specified memory allocation as temporary storage.
      */
     HIPCUB_DEVICE inline BlockRadixRank(
-        TempStorage &temp_storage)             ///< [in] Reference to memory allocation having layout type TempStorage
-    :
-        temp_storage(temp_storage.Alias()),
-        linear_tid(RowMajorTid(BLOCK_DIM_X, BLOCK_DIM_Y, BLOCK_DIM_Z))
+        TempStorage&
+            temp_storage) ///< [in] Reference to memory allocation having layout type TempStorage
+        : temp_storage_(temp_storage)
     {}
 
-
     //@}  end member group
-    /******************************************************************//**
-     * \name Raking
+    /******************************************************************/ /**
+     * \name Ranking
      *********************************************************************/
     //@{
 
     /**
      * \brief Rank keys.
      */
-    template <
-        typename        UnsignedBits,
-        int             KEYS_PER_THREAD,
-        typename        DigitExtractorT>
+    template<typename UnsignedBits,
+             int KEYS_PER_THREAD,
+             typename DigitExtractorT>
     HIPCUB_DEVICE inline void RankKeys(
-        UnsignedBits    (&keys)[KEYS_PER_THREAD],           ///< [in] Keys for this tile
-        int             (&ranks)[KEYS_PER_THREAD],          ///< [out] For each key, the local rank within the tile
-        DigitExtractorT digit_extractor)                    ///< [in] The digit extractor
+        UnsignedBits (&keys)[KEYS_PER_THREAD], ///< [in] Keys for this tile
+        int (&ranks)[KEYS_PER_THREAD], ///< [out] For each key, the local rank within the tile
+        DigitExtractorT digit_extractor) ///< [in] The digit extractor
     {
-        DigitCounter    thread_prefixes[KEYS_PER_THREAD];   // For each key, the count of previous keys in this tile having the same digit
-        DigitCounter*   digit_counters[KEYS_PER_THREAD];    // For each key, the byte-offset of its corresponding digit counter in smem
-
-        // Reset shared memory digit counters
-        ResetCounters();
-
-        #pragma unroll
-        for (int ITEM = 0; ITEM < KEYS_PER_THREAD; ++ITEM)
-        {
-            // Get digit
-            unsigned int digit = digit_extractor.Digit(keys[ITEM]);
-
-            // Get sub-counter
-            unsigned int sub_counter = digit >> LOG_COUNTER_LANES;
-
-            // Get counter lane
-            unsigned int counter_lane = digit & (COUNTER_LANES - 1);
-
-            if (IS_DESCENDING)
-            {
-                sub_counter = PACKING_RATIO - 1 - sub_counter;
-                counter_lane = COUNTER_LANES - 1 - counter_lane;
-            }
-
-            // Pointer to smem digit counter
-            digit_counters[ITEM] = &temp_storage.aliasable.digit_counters[counter_lane * BLOCK_THREADS * PACKING_RATIO + linear_tid * PACKING_RATIO + sub_counter];
-
-            // Load thread-exclusive prefix
-            thread_prefixes[ITEM] = *digit_counters[ITEM];
-
-            // Store inclusive prefix
-            *digit_counters[ITEM] = thread_prefixes[ITEM] + 1;
-        }
-
-        ::rocprim::syncthreads();
-
-        // Scan shared memory counters
-        ScanCounters();
-
-        ::rocprim::syncthreads();
-
-        // Extract the local ranks of each key
-        #pragma unroll
-        for (int ITEM = 0; ITEM < KEYS_PER_THREAD; ++ITEM)
-        {
-            // Add in thread block exclusive prefix
-            ranks[ITEM] = thread_prefixes[ITEM] + *digit_counters[ITEM];
-        }
+        base_type::rank_keys(keys,
+                             reinterpret_cast<unsigned int(&)[KEYS_PER_THREAD]>(ranks),
+                             temp_storage_,
+                             [&](const UnsignedBits key)
+                             {
+                                 UnsignedBits digit = digit_extractor.Digit(key);
+                                 if(IS_DESCENDING)
+                                 {
+                                     // Flip digit bits
+                                     digit ^= (1 << RADIX_BITS) - 1;
+                                 }
+                                 return digit;
+                             });
     }
-
 
     /**
      * \brief Rank keys.  For the lower \p RADIX_DIGITS threads, digit counts for each digit are provided for the corresponding thread.
      */
-    template <
-        typename        UnsignedBits,
-        int             KEYS_PER_THREAD,
-        typename        DigitExtractorT>
+    template<typename UnsignedBits,
+             int KEYS_PER_THREAD,
+             typename DigitExtractorT>
     HIPCUB_DEVICE inline void RankKeys(
-        UnsignedBits    (&keys)[KEYS_PER_THREAD],           ///< [in] Keys for this tile
-        int             (&ranks)[KEYS_PER_THREAD],          ///< [out] For each key, the local rank within the tile (out parameter)
-        DigitExtractorT digit_extractor,                    ///< [in] The digit extractor
-        int             (&exclusive_digit_prefix)[BINS_TRACKED_PER_THREAD])            ///< [out] The exclusive prefix sum for the digits [(threadIdx.x * BINS_TRACKED_PER_THREAD) ... (threadIdx.x * BINS_TRACKED_PER_THREAD) + BINS_TRACKED_PER_THREAD - 1]
+        UnsignedBits (&keys)[KEYS_PER_THREAD], ///< [in] Keys for this tile
+        int (&ranks)
+            [KEYS_PER_THREAD], ///< [out] For each key, the local rank within the tile (out parameter)
+        DigitExtractorT digit_extractor, ///< [in] The digit extractor
+        int (&exclusive_digit_prefix)
+            [BINS_TRACKED_PER_THREAD]) ///< [out] The exclusive prefix sum for the digits [(threadIdx.x * BINS_TRACKED_PER_THREAD) ... (threadIdx.x * BINS_TRACKED_PER_THREAD) + BINS_TRACKED_PER_THREAD - 1]
     {
-        // Rank keys
-        RankKeys(keys, ranks, digit_extractor);
-
-        // Get the inclusive and exclusive digit totals corresponding to the calling thread.
-        #pragma unroll
-        for (int track = 0; track < BINS_TRACKED_PER_THREAD; ++track)
-        {
-            int bin_idx = (linear_tid * BINS_TRACKED_PER_THREAD) + track;
-
-            if ((BLOCK_THREADS == RADIX_DIGITS) || (bin_idx < RADIX_DIGITS))
+        unsigned int counts[BINS_TRACKED_PER_THREAD];
+        base_type::rank_keys(
+            keys,
+            reinterpret_cast<unsigned int(&)[KEYS_PER_THREAD]>(ranks),
+            temp_storage_,
+            [&](const UnsignedBits key)
             {
-                if (IS_DESCENDING)
-                    bin_idx = RADIX_DIGITS - bin_idx - 1;
-
-                // Obtain ex/inclusive digit counts.  (Unfortunately these all reside in the
-                // first counter column, resulting in unavoidable bank conflicts.)
-                unsigned int counter_lane   = (bin_idx & (COUNTER_LANES - 1));
-                unsigned int sub_counter    = bin_idx >> (LOG_COUNTER_LANES);
-
-                exclusive_digit_prefix[track] = temp_storage.aliasable.digit_counter[counter_lane * BLOCK_THREADS * PACKING_RATIO + sub_counter];
-            }
-        }
+                UnsignedBits digit = digit_extractor.Digit(key);
+                if(IS_DESCENDING)
+                {
+                    // Flip digit bits
+                    digit ^= (1 << RADIX_BITS) - 1;
+                }
+                return digit;
+            },
+            reinterpret_cast<unsigned int(&)[BINS_TRACKED_PER_THREAD]>(exclusive_digit_prefix),
+            counts);
     }
 };
-
-
-
-
 
 /**
  * Radix-rank using match.any

--- a/hipcub/include/hipcub/backend/rocprim/device/device_merge_sort.hpp
+++ b/hipcub/include/hipcub/backend/rocprim/device/device_merge_sort.hpp
@@ -1,7 +1,7 @@
 /******************************************************************************
  * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
  * Copyright (c) 2011-2018, NVIDIA CORPORATION.  All rights reserved.
- * Modifications Copyright (c) 2017-2021, Advanced Micro Devices, Inc.  All rights reserved.
+ * Modifications Copyright (c) 2017-2023, Advanced Micro Devices, Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -170,6 +170,28 @@ struct DeviceMergeSort
         );
     }
 
+    template<typename KeyInputIteratorT,
+             typename KeyIteratorT,
+             typename OffsetT,
+             typename CompareOpT>
+    HIPCUB_RUNTIME_FUNCTION static hipError_t StableSortKeysCopy(void*        d_temp_storage,
+                                                                 std::size_t& temp_storage_bytes,
+                                                                 KeyInputIteratorT d_input_keys,
+                                                                 KeyIteratorT      d_output_keys,
+                                                                 OffsetT           num_items,
+                                                                 CompareOpT        compare_op,
+                                                                 hipStream_t       stream = 0,
+                                                                 bool debug_synchronous   = false)
+    {
+        return ::rocprim::merge_sort(d_temp_storage,
+                                     temp_storage_bytes,
+                                     d_input_keys,
+                                     d_output_keys,
+                                     num_items,
+                                     compare_op,
+                                     stream,
+                                     debug_synchronous);
+    }
 };
 END_HIPCUB_NAMESPACE
 

--- a/hipcub/include/hipcub/backend/rocprim/device/device_segmented_reduce.hpp
+++ b/hipcub/include/hipcub/backend/rocprim/device/device_segmented_reduce.hpp
@@ -69,7 +69,7 @@ __global__ __launch_bounds__(
                                                 end_offsets,
                                                 reduce_op,
                                                 initial_value);
-    __syncthreads();
+    // no synchronization is needed since thread 0 writes to output
 
     const unsigned int flat_id    = ::rocprim::detail::block_thread_id<0>();
     const unsigned int segment_id = ::rocprim::detail::block_id<0>();

--- a/hipcub/include/hipcub/backend/rocprim/device/device_segmented_reduce.hpp
+++ b/hipcub/include/hipcub/backend/rocprim/device/device_segmented_reduce.hpp
@@ -1,7 +1,7 @@
 /******************************************************************************
  * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
  * Copyright (c) 2011-2018, NVIDIA CORPORATION.  All rights reserved.
- * Modifications Copyright (c) 2017-2020, Advanced Micro Devices, Inc.  All rights reserved.
+ * Modifications Copyright (c) 2017-2023, Advanced Micro Devices, Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -35,12 +35,52 @@
 
 #include "../../../config.hpp"
 
-#include "../thread/thread_operators.hpp"
 #include "../iterator/arg_index_input_iterator.hpp"
+#include "../thread/thread_operators.hpp"
+#include "device_reduce.hpp"
 
 #include <rocprim/device/device_segmented_reduce.hpp>
 
 BEGIN_HIPCUB_NAMESPACE
+
+namespace detail
+{
+
+/// For \p DeviceSegmentedReduce::ArgMin's output values and the segment sizes: if the segment is
+/// empty, set the special value as output. If the segment is nonempty, convert the key from
+/// absolute to relative to the segment beginning.
+struct segmented_min_transform
+{
+    template<typename Key, typename Value, typename OffsetIteratorT>
+    HIPCUB_DEVICE KeyValuePair<Key, Value>
+        operator()(rocprim::tuple<KeyValuePair<Key, Value>, OffsetIteratorT, OffsetIteratorT> iter)
+    {
+        auto offset_begin = rocprim::get<1>(iter);
+        return offset_begin == rocprim::get<2>(iter)
+                   ? KeyValuePair<Key, Value>(1, hipcub::detail::get_max_value<Value>())
+                   : KeyValuePair<Key, Value>(rocprim::get<0>(iter).key - offset_begin,
+                                              rocprim::get<0>(iter).value);
+    }
+};
+
+/// For \p DeviceSegmentedReduce::ArgMax's output values and the segment sizes: if the segment is
+/// empty, set the special value as output. If the segment is nonempty, convert the key from
+/// absolute to relative to the segment beginning.
+struct segmented_max_transform
+{
+    template<typename Key, typename Value, typename OffsetIteratorT>
+    HIPCUB_DEVICE KeyValuePair<Key, Value>
+        operator()(rocprim::tuple<KeyValuePair<Key, Value>, OffsetIteratorT, OffsetIteratorT> iter)
+    {
+        auto offset_begin = rocprim::get<1>(iter);
+        return offset_begin == rocprim::get<2>(iter)
+                   ? KeyValuePair<Key, Value>(1, hipcub::detail::get_lowest_value<Value>())
+                   : KeyValuePair<Key, Value>(rocprim::get<0>(iter).key - offset_begin,
+                                              rocprim::get<0>(iter).value);
+    }
+};
+
+} // namespace detail
 
 struct DeviceSegmentedReduce
 {
@@ -157,15 +197,35 @@ struct DeviceSegmentedReduce
         using IteratorT = ArgIndexInputIterator<InputIteratorT, OffsetT, OutputValueT>;
 
         IteratorT d_indexed_in(d_in);
-        const OutputTupleT init(1, std::numeric_limits<T>::max());
+        // key is ::max because ArgMin finds the lowest value that has the lowest key
+        const OutputTupleT init(std::numeric_limits<OffsetT>::max(),
+                                detail::get_max_special_value<T>());
 
-        return Reduce(
-            d_temp_storage, temp_storage_bytes,
-            d_indexed_in, d_out,
-            num_segments, d_begin_offsets, d_end_offsets,
-            ::hipcub::ArgMin(), init,
-            stream, debug_synchronous
-        );
+        hipError_t result = Reduce(d_temp_storage,
+                                   temp_storage_bytes,
+                                   d_indexed_in,
+                                   d_out,
+                                   num_segments,
+                                   d_begin_offsets,
+                                   d_end_offsets,
+                                   ::hipcub::ArgMin(),
+                                   init,
+                                   stream,
+                                   debug_synchronous);
+        if(result != hipSuccess || !d_temp_storage)
+        {
+            return result;
+        }
+
+        // apply transform on output that sets relative keys and get_max_value for empty segments
+        auto iterator_tuple = rocprim::make_tuple(d_out, d_begin_offsets, d_end_offsets);
+        auto iter           = rocprim::make_zip_iterator(iterator_tuple);
+        return rocprim::transform(iter,
+                                  d_out,
+                                  num_segments,
+                                  detail::segmented_min_transform{},
+                                  stream,
+                                  debug_synchronous);
     }
 
     template<
@@ -224,15 +284,36 @@ struct DeviceSegmentedReduce
         using IteratorT = ArgIndexInputIterator<InputIteratorT, OffsetT, OutputValueT>;
 
         IteratorT d_indexed_in(d_in);
-        const OutputTupleT init(1, std::numeric_limits<T>::lowest());
+        // key is ::max because ArgMax finds the highest value that has the lowest key
+        const OutputTupleT init(std::numeric_limits<OffsetT>::max(),
+                                detail::get_lowest_special_value<T>());
 
-        return Reduce(
-            d_temp_storage, temp_storage_bytes,
-            d_indexed_in, d_out,
-            num_segments, d_begin_offsets, d_end_offsets,
-            ::hipcub::ArgMax(), init,
-            stream, debug_synchronous
-        );
+        hipError_t result = Reduce(d_temp_storage,
+                                   temp_storage_bytes,
+                                   d_indexed_in,
+                                   d_out,
+                                   num_segments,
+                                   d_begin_offsets,
+                                   d_end_offsets,
+                                   ::hipcub::ArgMax(),
+                                   init,
+                                   stream,
+                                   debug_synchronous);
+
+        if(result != hipSuccess || !d_temp_storage)
+        {
+            return result;
+        }
+
+        // apply transform on output that sets relative keys and get_lowest_value for empty segments
+        auto iterator_tuple = rocprim::make_tuple(d_out, d_begin_offsets, d_end_offsets);
+        auto iter           = rocprim::make_zip_iterator(iterator_tuple);
+        return rocprim::transform(iter,
+                                  d_out,
+                                  num_segments,
+                                  detail::segmented_max_transform{},
+                                  stream,
+                                  debug_synchronous);
     }
 };
 

--- a/hipcub/include/hipcub/backend/rocprim/grid/grid_queue.hpp
+++ b/hipcub/include/hipcub/backend/rocprim/grid/grid_queue.hpp
@@ -1,7 +1,7 @@
 /******************************************************************************
  * Copyright (c) 2011, Duane Merrill.  All rights reserved.
  * Copyright (c) 2011-2018, NVIDIA CORPORATION.  All rights reserved.
- * Modifications Copyright (c) 2021, Advanced Micro Devices, Inc.  All rights reserved.
+ * Modifications Copyright (c) 2021-2023, Advanced Micro Devices, Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -132,7 +132,11 @@ public:
         OffsetT counters[2];
         counters[FILL] = fill_size;
         counters[DRAIN] = 0;
-        result = CubDebug(hipMemcpyAsync(d_counters, counters, sizeof(OffsetT) * 2, hipMemcpyHostToDevice, stream));
+        result          = HipcubDebug(hipMemcpyAsync(d_counters,
+                                            counters,
+                                            sizeof(OffsetT) * 2,
+                                            hipMemcpyHostToDevice,
+                                            stream));
         return result;
     }
 
@@ -149,7 +153,7 @@ public:
     HIPCUB_HOST hipError_t ResetDrain(hipStream_t stream = 0)
     {
         hipError_t result = hipErrorUnknown;
-        result = CubDebug(hipMemsetAsync(d_counters + DRAIN, 0, sizeof(OffsetT), stream));
+        result = HipcubDebug(hipMemsetAsync(d_counters + DRAIN, 0, sizeof(OffsetT), stream));
         return result;
     }
 
@@ -167,7 +171,7 @@ public:
     HIPCUB_HOST hipError_t ResetFill(hipStream_t stream = 0)
     {
         hipError_t result = hipErrorUnknown;
-        result = CubDebug(hipMemsetAsync(d_counters + FILL, 0, sizeof(OffsetT), stream));
+        result = HipcubDebug(hipMemsetAsync(d_counters + FILL, 0, sizeof(OffsetT), stream));
         return result;
     }
 
@@ -189,7 +193,11 @@ public:
         hipStream_t stream = 0)
     {
         hipError_t result = hipErrorUnknown;
-        result = CubDebug(hipMemcpyAsync(&fill_size, d_counters + FILL, sizeof(OffsetT), hipMemcpyDeviceToHost, stream));
+        result            = HipcubDebug(hipMemcpyAsync(&fill_size,
+                                            d_counters + FILL,
+                                            sizeof(OffsetT),
+                                            hipMemcpyDeviceToHost,
+                                            stream));
         return result;
     }
 

--- a/hipcub/include/hipcub/backend/rocprim/util_ptx.hpp
+++ b/hipcub/include/hipcub/backend/rocprim/util_ptx.hpp
@@ -1,7 +1,7 @@
 /******************************************************************************
  * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
  * Copyright (c) 2011-2018, NVIDIA CORPORATION.  All rights reserved.
- * Modifications Copyright (c) 2017-2022, Advanced Micro Devices, Inc.  All rights reserved.
+ * Modifications Copyright (c) 2017-2023, Advanced Micro Devices, Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -50,7 +50,7 @@ BEGIN_HIPCUB_NAMESPACE
 // Differences:
 // * Warp thread masks (when used) are 64-bit unsigned integers
 // * member_mask argument is ignored in WARP_[ALL|ANY|BALLOT] funcs
-// * Arguments first_lane, last_lane, and member_mask are ignored
+// * Arguments first_thread, last_thread, and member_mask are ignored
 // in Shuffle* funcs
 // * count in BAR is ignored, BAR works like CTA_SYNC
 

--- a/install
+++ b/install
@@ -134,12 +134,8 @@ fi
 
 # Configure hipCUB, setup options for your system.
 # Build options:
-#   BUILD_TEST - on by default,
+#   BUILD_TEST - off by default,
 #   BUILD_BENCHMARK - off by default.
-#
-# ! IMPORTANT !
-# On ROCm platform set C++ compiler to HCC. You can do it by adding 'CXX=<path-to-hcc>'
-# before 'cmake' or setting cmake option 'CMAKE_CXX_COMPILER' to path to the HCC compiler.
 #
 compiler="hipcc"
 
@@ -168,7 +164,6 @@ fi
 if [[ "${build_relocatable}" == true ]]; then
     CXX=$rocm_path/bin/${compiler} ${cmake_executable} \
         -DCMAKE_INSTALL_PREFIX=${rocm_path} \
-        -DCMAKE_PREFIX_PATH="${rocm_path} ${rocm_path}/hcc ${rocm_path}/hip" \
         -DCMAKE_MODULE_PATH="${rocm_path}/lib/cmake/hip ${rocm_path}/hip/cmake" \
         -Drocprim_DIR=${rocm_path}/rocprim \
         ${cmake_common_options} \

--- a/test/extra/CMakeLists.txt
+++ b/test/extra/CMakeLists.txt
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2017-2020 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2017-2023 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -40,53 +40,53 @@ include(VerifyCompiler)
 include(DownloadProject)
 if(HIP_COMPILER STREQUAL "nvcc")
   file(
-    DOWNLOAD https://github.com/NVIDIA/cub/archive/1.17.2.zip
-    ${CMAKE_CURRENT_BINARY_DIR}/cub-1.17.2.zip
+    DOWNLOAD https://github.com/NVIDIA/cub/archive/2.0.1.zip
+    ${CMAKE_CURRENT_BINARY_DIR}/cub-2.0.1.zip
     STATUS cub_download_status LOG cub_download_log
   )
   list(GET cub_download_status 0 cub_download_error_code)
   if(cub_download_error_code)
     message(FATAL_ERROR "Error: downloading "
-      "https://github.com/NVIDIA/cub/archive/1.17.2.zip failed "
+      "https://github.com/NVIDIA/cub/archive/2.0.1.zip failed "
       "error_code: ${cub_download_error_code} "
       "log: ${cub_download_log} "
     )
   endif()
 
   execute_process(
-    COMMAND ${CMAKE_COMMAND} -E tar xzf ${CMAKE_CURRENT_BINARY_DIR}/cub-1.17.2.zip
+    COMMAND ${CMAKE_COMMAND} -E tar xzf ${CMAKE_CURRENT_BINARY_DIR}/cub-2.0.1.zip
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     RESULT_VARIABLE cub_unpack_error_code
   )
   if(cub_unpack_error_code)
-    message(FATAL_ERROR "Error: unpacking ${CMAKE_CURRENT_BINARY_DIR}/cub-1.17.2.zip failed")
+    message(FATAL_ERROR "Error: unpacking ${CMAKE_CURRENT_BINARY_DIR}/cub-2.0.1.zip failed")
   endif()
-  set(CUB_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/cub-1.17.2/ CACHE PATH "" FORCE)
+  set(CUB_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/cub-2.0.1/ CACHE PATH "" FORCE)
   message(STATUS "CUB_INCLUDE_DIR: ${CUB_INCLUDE_DIR}")
 
   file(
-    DOWNLOAD https://github.com/NVIDIA/thrust/archive/1.17.2.zip
-    ${CMAKE_CURRENT_BINARY_DIR}/thrust-1.17.2.zip
+    DOWNLOAD https://github.com/NVIDIA/thrust/archive/2.0.1.zip
+    ${CMAKE_CURRENT_BINARY_DIR}/thrust-2.0.1.zip
     STATUS thrust_download_status LOG thrust_download_log
   )
   list(GET thrust_download_status 0 thrust_download_error_code)
   if(thrust_download_error_code)
     message(FATAL_ERROR "Error: downloading "
-      "https://github.com/NVIDIA/thrust/archive/1.17.2.zip failed "
+      "https://github.com/NVIDIA/thrust/archive/2.0.1.zip failed "
       "error_code: ${thrust_download_error_code} "
       "log: ${thrust_download_log} "
     )
   endif()
 
   execute_process(
-    COMMAND ${CMAKE_COMMAND} -E tar xzf ${CMAKE_CURRENT_BINARY_DIR}/thrust-1.17.2.zip
+    COMMAND ${CMAKE_COMMAND} -E tar xzf ${CMAKE_CURRENT_BINARY_DIR}/thrust-2.0.1.zip
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     RESULT_VARIABLE thrust_unpack_error_code
   )
   if(thrust_unpack_error_code)
-    message(FATAL_ERROR "Error: unpacking ${CMAKE_CURRENT_BINARY_DIR}/thrust-1.17.2.zip failed")
+    message(FATAL_ERROR "Error: unpacking ${CMAKE_CURRENT_BINARY_DIR}/thrust-2.0.1.zip failed")
   endif()
-  set(THRUST_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/thrust-1.17.2/ CACHE PATH "" FORCE)
+  set(THRUST_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/thrust-2.0.1/ CACHE PATH "" FORCE)
   message(STATUS "THRUST_INCLUDE_DIR: ${THRUST_INCLUDE_DIR}")
 endif()
 

--- a/test/hipcub/common_test_header.hpp
+++ b/test/hipcub/common_test_header.hpp
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/test/hipcub/common_test_header.hpp
+++ b/test/hipcub/common_test_header.hpp
@@ -27,13 +27,13 @@
 #include <functional>
 #include <iostream>
 #include <limits>
+#include <numeric>
 #include <random>
 #include <string>
 #include <tuple>
 #include <type_traits>
 #include <utility>
 #include <vector>
-#include <numeric>
 
 // Google Test
 #include <gtest/gtest.h>

--- a/test/hipcub/common_test_header.hpp
+++ b/test/hipcub/common_test_header.hpp
@@ -33,10 +33,7 @@
 #include <type_traits>
 #include <utility>
 #include <vector>
-
-#ifdef WIN32
 #include <numeric>
-#endif
 
 // Google Test
 #include <gtest/gtest.h>

--- a/test/hipcub/half.hpp
+++ b/test/hipcub/half.hpp
@@ -1,6 +1,6 @@
 /******************************************************************************
  * Copyright (c) 2011, Duane Merrill.  All rights reserved.
- * Copyright (c) 2011-2019, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2011-2023, NVIDIA CORPORATION.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -219,6 +219,12 @@ struct half_t
     half_t operator*(const half_t &other)
     {
         return half_t(float(*this) * float(other));
+    }
+
+    /// Divide
+    __host__ __device__ __forceinline__ half_t operator/(const half_t& other) const
+    {
+        return half_t(float(*this) / float(other));
     }
 
     /// Add

--- a/test/hipcub/test_hipcub_block_adjacent_difference.cpp
+++ b/test/hipcub/test_hipcub_block_adjacent_difference.cpp
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2017-2022 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2023 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -86,35 +86,48 @@ apply(FlagOp flag_op, const T& a, const T& b, unsigned int)
     return flag_op(b, a);
 }
 
-
-
 typedef ::testing::Types<
     // Power of 2 BlockSize
     params<unsigned int, int, 64U, 1, hipcub::Equality>,
     params<int, bool, 128U, 1, hipcub::Inequality>,
     params<float, int, 256U, 1, test_utils::less>,
+#ifndef __HIP_PLATFORM_NVIDIA__
+    // Nvidia does not handle half and bfloat16 properly
+    params<test_utils::half, int, 256U, 1, test_utils::less>,
+    params<test_utils::bfloat16, int, 256U, 1, test_utils::less>,
+#endif
     params<char, char, 1024U, 1, test_utils::less_equal>,
-    params<int, bool, 256U, 1, custom_flag_op1<int> >,
+    params<int, bool, 256U, 1, custom_flag_op1<int>>,
 
     // Non-power of 2 BlockSize
     params<double, unsigned int, 65U, 1, test_utils::greater>,
-    params<float, int, 37U, 1, custom_flag_op1<float> >,
+    params<float, int, 37U, 1, custom_flag_op1<float>>,
+
+#ifndef __HIP_PLATFORM_NVIDIA__
+    params<test_utils::half, int, 37U, 1, test_utils::greater>,
+    params<test_utils::bfloat16, int, 37U, 1, test_utils::greater>,
+#endif
+
     params<long long, char, 510U, 1, test_utils::greater_equal>,
     params<unsigned int, long long, 162U, 1, hipcub::Inequality>,
     params<unsigned char, bool, 255U, 1, hipcub::Equality>,
 
     // Power of 2 BlockSize and ItemsPerThread > 1
-    params<int, char, 64U, 2, custom_flag_op2<int> >,
+    params<int, char, 64U, 2, custom_flag_op2<int>>,
     params<int, short, 128U, 4, test_utils::less>,
-    params<unsigned short, unsigned char, 256U, 7, custom_flag_op2<unsigned short> >,
+    params<unsigned short, unsigned char, 256U, 7, custom_flag_op2<unsigned short>>,
     params<short, short, 512U, 8, hipcub::Equality>,
 
     // Non-power of 2 BlockSize and ItemsPerThread > 1
-    params<double, int, 33U, 5, custom_flag_op2<double> >,
+    params<double, int, 33U, 5, custom_flag_op2<double>>,
     params<double, unsigned int, 464U, 2, hipcub::Equality>,
+#ifndef __HIP_PLATFORM_NVIDIA__
+    params<test_utils::half, int, 37U, 5, test_utils::greater>,
+    params<test_utils::bfloat16, int, 37U, 3, test_utils::greater>,
+#endif
     params<unsigned short, int, 100U, 3, test_utils::greater>,
-    params<short, bool, 234U, 9, custom_flag_op1<short> >
-> Params;
+    params<short, bool, 234U, 9, custom_flag_op1<short>>>
+    Params;
 
 TYPED_TEST_SUITE(HipcubBlockAdjacentDifference, Params);
 
@@ -284,27 +297,30 @@ struct custom_op2
     }
 };
 
-typedef ::testing::Types<
-    params_subtract<unsigned int, int, hipcub::Sum, 64U, 1>,
-    params_subtract<int, bool, custom_op1, 128U, 1>,
-    params_subtract<float, int, custom_op2, 256U, 1>,
-    params_subtract<int, bool, custom_op1, 256U, 1>,
+typedef ::testing::Types<params_subtract<unsigned int, int, hipcub::Sum, 64U, 1>,
+                         params_subtract<int, bool, custom_op1, 128U, 1>,
+                         params_subtract<float, int, custom_op2, 256U, 1>,
+#ifndef __HIP_PLATFORM_NVIDIA__
+                         params_subtract<test_utils::half, int, custom_op1, 256U, 1>,
+                         params_subtract<test_utils::bfloat16, int, custom_op2, 256U, 1>,
+#endif
+                         params_subtract<int, bool, custom_op1, 256U, 1>,
 
-    params_subtract<float, int, hipcub::Sum, 37U, 1>,
-    params_subtract<long long, char, custom_op1, 510U, 1>,
-    params_subtract<unsigned int, long long, custom_op2, 162U, 1>,  
-    params_subtract<unsigned char, bool, hipcub::Sum, 255U, 1>,
+                         params_subtract<float, int, hipcub::Sum, 37U, 1>,
+                         params_subtract<long long, char, custom_op1, 510U, 1>,
+                         params_subtract<unsigned int, long long, custom_op2, 162U, 1>,
+                         params_subtract<unsigned char, bool, hipcub::Sum, 255U, 1>,
 
-    params_subtract<int, char, custom_op1, 64U, 2>,
-    params_subtract<int, short, custom_op2, 128U, 4>,
-    params_subtract<unsigned short, unsigned char, hipcub::Sum, 256U, 7>,
-    params_subtract<short, short, custom_op1, 512U, 8>,
+                         params_subtract<int, char, custom_op1, 64U, 2>,
+                         params_subtract<int, short, custom_op2, 128U, 4>,
+                         params_subtract<unsigned short, unsigned char, hipcub::Sum, 256U, 7>,
+                         params_subtract<short, short, custom_op1, 512U, 8>,
 
-    params_subtract<double, int, custom_op2, 33U, 5>,
-    params_subtract<double, unsigned int, hipcub::Sum, 464U, 2>,
-    params_subtract<unsigned short, int, custom_op1, 100U, 3>,
-    params_subtract<short, bool, custom_op2, 234U, 9>
-> ParamsSubtract;
+                         params_subtract<double, int, custom_op2, 33U, 5>,
+                         params_subtract<double, unsigned int, hipcub::Sum, 464U, 2>,
+                         params_subtract<unsigned short, int, custom_op1, 100U, 3>,
+                         params_subtract<short, bool, custom_op2, 234U, 9>>
+    ParamsSubtract;
 
 TYPED_TEST_SUITE(HipcubBlockAdjacentDifferenceSubtract, ParamsSubtract);
 

--- a/test/hipcub/test_hipcub_block_discontinuity.cpp
+++ b/test/hipcub/test_hipcub_block_discontinuity.cpp
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2017-2020 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2023 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -81,28 +81,34 @@ typedef ::testing::Types<
     params<unsigned int, int, 64U, 1, hipcub::Equality>,
     params<int, bool, 128U, 1, hipcub::Inequality>,
     params<float, int, 256U, 1, test_utils::less>,
+    params<test_utils::half, int, 256U, 1, test_utils::less>,
+    params<test_utils::bfloat16, int, 256U, 1, test_utils::less>,
     params<char, char, 1024U, 1, test_utils::less_equal>,
-    params<int, bool, 256U, 1, custom_flag_op1<int> >,
+    params<int, bool, 256U, 1, custom_flag_op1<int>>,
 
     // Non-power of 2 BlockSize
     params<double, unsigned int, 65U, 1, test_utils::greater>,
-    params<float, int, 37U, 1, custom_flag_op1<float> >,
+    params<float, int, 37U, 1, custom_flag_op1<float>>,
+    params<test_utils::half, int, 37U, 1, test_utils::greater>,
+    params<test_utils::bfloat16, int, 37U, 1, test_utils::greater>,
     params<long long, char, 510U, 1, test_utils::greater_equal>,
     params<unsigned int, long long, 162U, 1, hipcub::Inequality>,
     params<unsigned char, bool, 255U, 1, hipcub::Equality>,
 
     // Power of 2 BlockSize and ItemsPerThread > 1
-    params<int, char, 64U, 2, custom_flag_op2<int> >,
+    params<int, char, 64U, 2, custom_flag_op2<int>>,
     params<int, short, 128U, 4, test_utils::less>,
-    params<unsigned short, unsigned char, 256U, 7, custom_flag_op2<unsigned short> >,
+    params<unsigned short, unsigned char, 256U, 7, custom_flag_op2<unsigned short>>,
     params<short, short, 512U, 8, hipcub::Equality>,
 
     // Non-power of 2 BlockSize and ItemsPerThread > 1
-    params<double, int, 33U, 5, custom_flag_op2<double> >,
+    params<double, int, 33U, 5, custom_flag_op2<double>>,
     params<double, unsigned int, 464U, 2, hipcub::Equality>,
+    params<test_utils::half, unsigned int, 464U, 2, test_utils::greater>,
+    params<test_utils::bfloat16, unsigned int, 464U, 2, test_utils::greater>,
     params<unsigned short, int, 100U, 3, test_utils::greater>,
-    params<short, bool, 234U, 9, custom_flag_op1<short> >
-> Params;
+    params<short, bool, 234U, 9, custom_flag_op1<short>>>
+    Params;
 
 TYPED_TEST_SUITE(HipcubBlockDiscontinuity, Params);
 
@@ -174,7 +180,11 @@ TYPED_TEST(HipcubBlockDiscontinuity, FlagHeads)
         SCOPED_TRACE(testing::Message() << "with seed= " << seed_value);
 
         // Generate data
-        std::vector<type> input = test_utils::get_random_data<type>(size, type(0), type(10), seed_value);
+        std::vector<type> input
+            = test_utils::get_random_data<type>(size,
+                                                test_utils::convert_to_device<type>(0),
+                                                test_utils::convert_to_device<type>(10),
+                                                seed_value);
         std::vector<long long> heads(size);
 
         // Calculate expected results on host
@@ -313,7 +323,11 @@ TYPED_TEST(HipcubBlockDiscontinuity, FlagTails)
         SCOPED_TRACE(testing::Message() << "with seed= " << seed_value);
 
         // Generate data
-        std::vector<type> input = test_utils::get_random_data<type>(size, type(0), type(10), seed_value);
+        std::vector<type> input
+            = test_utils::get_random_data<type>(size,
+                                                test_utils::convert_to_device<type>(0),
+                                                test_utils::convert_to_device<type>(10),
+                                                seed_value);
         std::vector<long long> tails(size);
 
         // Calculate expected results on host
@@ -466,7 +480,11 @@ TYPED_TEST(HipcubBlockDiscontinuity, FlagHeadsAndTails)
         SCOPED_TRACE(testing::Message() << "with seed= " << seed_value);
 
         // Generate data
-        std::vector<type> input = test_utils::get_random_data<type>(size, type(0), type(10), seed_value);
+        std::vector<type> input
+            = test_utils::get_random_data<type>(size,
+                                                test_utils::convert_to_device<type>(0),
+                                                test_utils::convert_to_device<type>(10),
+                                                seed_value);
         std::vector<long long> heads(size);
         std::vector<long long> tails(size);
 

--- a/test/hipcub/test_hipcub_block_load_store.hpp
+++ b/test/hipcub/test_hipcub_block_load_store.hpp
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2017-2020 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2023 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -52,10 +52,10 @@ typed_test_def(HipcubBlockLoadStoreTests, name_suffix, LoadStoreClass)
 
         // Generate data
         std::vector<Type> input = test_utils::get_random_data<Type>(size, -100, 100, seed_value);
-        std::vector<Type> output(input.size(), 0);
+        std::vector<Type> output(input.size(), test_utils::convert_to_device<Type>(0));
 
         // Calculate expected results on host
-        std::vector<Type> expected(input.size(), 0);
+        std::vector<Type> expected(input.size(), test_utils::convert_to_device<Type>(0));
         for(size_t i = 0; i < 113; i++)
         {
             size_t block_offset = i * items_per_block;
@@ -100,7 +100,8 @@ typed_test_def(HipcubBlockLoadStoreTests, name_suffix, LoadStoreClass)
         // Validating results
         for(size_t i = 0; i < output.size(); i++)
         {
-            ASSERT_EQ(output[i], expected[i]);
+            ASSERT_EQ(test_utils::convert_to_native(output[i]),
+                      test_utils::convert_to_native(expected[i]));
         }
 
         HIP_CHECK(hipFree(device_input));
@@ -137,10 +138,10 @@ typed_test_def(HipcubBlockLoadStoreTests, name_suffix, LoadStoreClassValid)
         const size_t valid = items_per_block - 32;
         // Generate data
         std::vector<Type> input = test_utils::get_random_data<Type>(size, -100, 100, seed_value);
-        std::vector<Type> output(input.size(), 0);
+        std::vector<Type> output(input.size(), test_utils::convert_to_device<Type>(0));
 
         // Calculate expected results on host
-        std::vector<Type> expected(input.size(), 0);
+        std::vector<Type> expected(input.size(), test_utils::convert_to_device<Type>(0));
         for(size_t i = 0; i < 113; i++)
         {
             size_t block_offset = i * items_per_block;
@@ -197,7 +198,8 @@ typed_test_def(HipcubBlockLoadStoreTests, name_suffix, LoadStoreClassValid)
         // Validating results
         for(size_t i = 0; i < output.size(); i++)
         {
-            ASSERT_EQ(output[i], expected[i]);
+            ASSERT_EQ(test_utils::convert_to_native(output[i]),
+                      test_utils::convert_to_native(expected[i]));
         }
 
         HIP_CHECK(hipFree(device_input));
@@ -232,10 +234,10 @@ typed_test_def(HipcubBlockLoadStoreTests, name_suffix, LoadStoreClassDefault)
         SCOPED_TRACE(testing::Message() << "with seed= " << seed_value);
 
         const size_t valid    = items_per_thread + 1;
-        int          _default = -1;
+        Type         _default = test_utils::convert_to_device<Type>(-1);
         // Generate data
         std::vector<Type> input = test_utils::get_random_data<Type>(size, -100, 100, seed_value);
-        std::vector<Type> output(input.size(), 0);
+        std::vector<Type> output(input.size(), test_utils::convert_to_device<Type>(0));
 
         // Calculate expected results on host
         std::vector<Type> expected(input.size(), _default);
@@ -290,7 +292,8 @@ typed_test_def(HipcubBlockLoadStoreTests, name_suffix, LoadStoreClassDefault)
         // Validating results
         for(size_t i = 0; i < output.size(); i++)
         {
-            ASSERT_EQ(output[i], expected[i]);
+            ASSERT_EQ(test_utils::convert_to_native(output[i]),
+                      test_utils::convert_to_native(expected[i]));
         }
 
         HIP_CHECK(hipFree(device_input));
@@ -333,8 +336,8 @@ typed_test_def(HipcubBlockLoadStoreTests, name_suffix, LoadStoreDiscardIterator)
         // Generate data
         std::vector<Type> input =
             test_utils::get_random_data<Type>(unguarded_elements, -100, 100, seed_value);
-        std::vector<Type> unguarded(unguarded_elements, 0);
-        std::vector<Type> guarded(guarded_elements, 0);
+        std::vector<Type> unguarded(unguarded_elements, test_utils::convert_to_device<Type>(0));
+        std::vector<Type> guarded(guarded_elements, test_utils::convert_to_device<Type>(0));
 
         // Calculate expected results on host
         std::vector<Type> unguarded_expected(unguarded_elements);
@@ -410,11 +413,15 @@ typed_test_def(HipcubBlockLoadStoreTests, name_suffix, LoadStoreDiscardIterator)
         // Validating results
         for(size_t i = 0; i < guarded_expected.size(); i++)
         {
-            ASSERT_EQ(guarded[i], guarded_expected[i]) << "where index = " << i;
+            ASSERT_EQ(test_utils::convert_to_native(guarded[i]),
+                      test_utils::convert_to_native(guarded_expected[i]))
+                << "where index = " << i;
         }
         for(size_t i = 0; i < unguarded_expected.size(); i++)
         {
-            ASSERT_EQ(unguarded[i], unguarded_expected[i]) << "where index = " << i;
+            ASSERT_EQ(test_utils::convert_to_native(unguarded[i]),
+                      test_utils::convert_to_native(unguarded_expected[i]))
+                << "where index = " << i;
         }
 
         HIP_CHECK(hipFree(device_input));

--- a/test/hipcub/test_hipcub_block_load_store.kernels.hpp
+++ b/test/hipcub/test_hipcub_block_load_store.kernels.hpp
@@ -1,4 +1,6 @@
-// Copyright (c) 2019-2020 Advanced Micro Devices, Inc. All rights reserved.
+// MIT License
+//
+// Copyright (c) 2019-2023 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -56,6 +58,8 @@ struct class_params
 #define class_param_type(load_algo, store_algo)                                           \
     class_param_block_size_512(load_algo, store_algo, int),                               \
         class_param_block_size_512(load_algo, store_algo, double),                        \
+        class_param_block_size_512(load_algo, store_algo, test_utils::half),              \
+        class_param_block_size_512(load_algo, store_algo, test_utils::bfloat16),          \
         class_param_block_size(load_algo, store_algo, test_utils::custom_test_type<int>), \
         class_param_block_size(load_algo, store_algo, test_utils::custom_test_type<double>)
 
@@ -113,10 +117,10 @@ template<class Type,
          hipcub::BlockStoreAlgorithm StoreMethod,
          unsigned int                BlockSize,
          unsigned int                ItemsPerThread>
-__global__ __launch_bounds__(BlockSize) void load_store_valid_default_kernel(Type * device_input,
-                                                                             Type * device_output,
+__global__ __launch_bounds__(BlockSize) void load_store_valid_default_kernel(Type*  device_input,
+                                                                             Type*  device_output,
                                                                              size_t valid,
-                                                                             int    _default)
+                                                                             Type   _default)
 {
     Type         items[ItemsPerThread];
     unsigned int offset = hipBlockIdx_x * BlockSize * ItemsPerThread;

--- a/test/hipcub/test_hipcub_block_merge_sort.cpp
+++ b/test/hipcub/test_hipcub_block_merge_sort.cpp
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2021 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2021-2023 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -62,6 +62,8 @@ typedef ::testing::Types<
 
     // Power of 2 BlockSize and ItemsPerThread > 1
     params<float, char, 64U, 2, test_utils::greater>,
+    params<test_utils::half, test_utils::half, 64U, 2, test_utils::greater>,
+    params<test_utils::bfloat16, test_utils::bfloat16, 64U, 2, test_utils::greater>,
     params<int, short, 128U, 4>,
     params<unsigned short, char, 256U, 7>,
 
@@ -69,8 +71,8 @@ typedef ::testing::Types<
 
     // Stability (a number of key values is lower than BlockSize * ItemsPerThread: some keys appear
     // multiple times with different values
-    params<unsigned char, int, 512U, 2, test_utils::less, true>
-> Params;
+    params<unsigned char, int, 512U, 2, test_utils::less, true>>
+    Params;
 
 TYPED_TEST_SUITE(HipcubBlockMergeSort, Params);
 
@@ -173,7 +175,8 @@ TYPED_TEST(HipcubBlockMergeSort, SortKeys)
         // Verifying results
         for(size_t i = 0; i < size; i++)
         {
-            ASSERT_EQ(keys_output[i], expected[i]);
+            ASSERT_EQ(test_utils::convert_to_native(keys_output[i]),
+                      test_utils::convert_to_native(expected[i]));
         }
 
         HIP_CHECK(hipFree(device_keys_output));
@@ -316,8 +319,10 @@ TYPED_TEST(HipcubBlockMergeSort, SortKeysValues)
 
         for(size_t i = 0; i < size; i++)
         {
-            ASSERT_EQ(keys_output[i], expected[i].first);
-            ASSERT_EQ(values_output[i], expected[i].second);
+            ASSERT_EQ(test_utils::convert_to_native(keys_output[i]),
+                      test_utils::convert_to_native(expected[i].first));
+            ASSERT_EQ(test_utils::convert_to_native(values_output[i]),
+                      test_utils::convert_to_native(expected[i].second));
         }
 
         HIP_CHECK(hipFree(device_keys_output));

--- a/test/hipcub/test_hipcub_block_radix_rank.cpp
+++ b/test/hipcub/test_hipcub_block_radix_rank.cpp
@@ -159,9 +159,9 @@ __global__ __launch_bounds__(BlockSize) void rank_kernel(const KeyType* keys_inp
         = reinterpret_cast<UnsignedBits(&)[ItemsPerThread]>(keys);
 
 #pragma unroll
-    for(unsigned int KEY = 0; KEY < ItemsPerThread; KEY++)
+    for(unsigned int key = 0; key < ItemsPerThread; key++)
     {
-        unsigned_keys[KEY] = KeyTraits::TwiddleIn(unsigned_keys[KEY]);
+        unsigned_keys[key] = KeyTraits::TwiddleIn(unsigned_keys[key]);
     }
 
     RankType             rank(storage.rank);

--- a/test/hipcub/test_hipcub_block_radix_rank.cpp
+++ b/test/hipcub/test_hipcub_block_radix_rank.cpp
@@ -144,7 +144,7 @@ __global__ __launch_bounds__(BlockSize) void rank_kernel(const KeyType* keys_inp
         = reinterpret_cast<UnsignedBits(&)[ItemsPerThread]>(keys);
 
 #pragma unroll
-    for(int KEY = 0; KEY < ItemsPerThread; KEY++)
+    for(unsigned int KEY = 0; KEY < ItemsPerThread; KEY++)
     {
         unsigned_keys[KEY] = KeyTraits::TwiddleIn(unsigned_keys[KEY]);
     }

--- a/test/hipcub/test_hipcub_block_radix_rank.cpp
+++ b/test/hipcub/test_hipcub_block_radix_rank.cpp
@@ -317,12 +317,7 @@ TYPED_TEST(HipcubBlockRadixRank, BlockRadixRankMemoize)
 
 TYPED_TEST(HipcubBlockRadixRank, BlockRadixRankMatch)
 {
-// The hipCUB implementation of BlockRadixRankMatch is currently broken for the
-// rocPRIM backend, and does not pass the tests yet.
-#ifdef __HIP_PLATFORM_AMD__
-    GTEST_SKIP();
-#endif
-
+#ifdef __HIP_PLATFORM_NVIDIA__
     constexpr unsigned int block_size = TestFixture::params::block_size;
     if(block_size % HIPCUB_DEVICE_WARP_THREADS != 0)
     {
@@ -331,6 +326,7 @@ TYPED_TEST(HipcubBlockRadixRank, BlockRadixRankMatch)
         // https://github.com/NVIDIA/cub/issues/552.
         GTEST_SKIP();
     }
+#endif
 
     test_radix_rank<TestFixture, RadixRankAlgorithm::RADIX_RANK_MATCH>();
 }

--- a/test/hipcub/test_hipcub_block_run_length_decode.cpp
+++ b/test/hipcub/test_hipcub_block_run_length_decode.cpp
@@ -48,27 +48,34 @@ public:
     using params = Params;
 };
 
-using HipcubBlockRunLengthDecodeTestParams = ::testing::Types<
-    Params<int, int, 256, 4, 4>,
-    Params<double, char, 256, 4, 4>,
-    Params<char, long long, 256, 4, 4>,
-    Params<float, int, 256, 4, 4>,
+using HipcubBlockRunLengthDecodeTestParams
+    = ::testing::Types<Params<int, int, 256, 4, 4>,
+                       Params<double, char, 256, 4, 4>,
+                       Params<char, long long, 256, 4, 4>,
+                       Params<float, int, 256, 4, 4>,
+                       Params<test_utils::half, int, 256, 4, 4>,
+                       Params<test_utils::bfloat16, int, 256, 4, 4>,
 
-    Params<int, int, 256, 8, 8>,
-    Params<double, char, 256, 8, 8>,
-    Params<char, long long, 256, 8, 8>,
-    Params<float, int, 256, 8, 8>,
+                       Params<int, int, 256, 8, 8>,
+                       Params<double, char, 256, 8, 8>,
+                       Params<char, long long, 256, 8, 8>,
+                       Params<float, int, 256, 8, 8>,
+                       Params<test_utils::half, int, 256, 8, 8>,
+                       Params<test_utils::bfloat16, int, 256, 8, 8>,
 
-    Params<int, int, 256, 1, 14>,
-    Params<double, char, 256, 1, 14>,
-    Params<char, long long, 256, 1, 14>,
-    Params<float, int, 256, 1, 14>,
+                       Params<int, int, 256, 1, 14>,
+                       Params<double, char, 256, 1, 14>,
+                       Params<char, long long, 256, 1, 14>,
+                       Params<float, int, 256, 1, 14>,
+                       Params<test_utils::half, int, 256, 1, 14>,
+                       Params<test_utils::bfloat16, int, 256, 1, 14>,
 
-    Params<int, int, 256, 9, 7>,
-    Params<double, char, 256, 9, 7>,
-    Params<char, long long, 256, 9, 7>,
-    Params<float, int, 256, 9, 7>
->;
+                       Params<int, int, 256, 9, 7>,
+                       Params<double, char, 256, 9, 7>,
+                       Params<char, long long, 256, 9, 7>,
+                       Params<float, int, 256, 9, 7>,
+                       Params<test_utils::half, int, 256, 9, 7>,
+                       Params<test_utils::bfloat16, int, 256, 9, 7>>;
 
 TYPED_TEST_SUITE(HipcubBlockRunLengthDecodeTest, HipcubBlockRunLengthDecodeTestParams);
 
@@ -239,6 +246,10 @@ TYPED_TEST(HipcubBlockRunLengthDecodeTest, TestDecode)
         HIP_CHECK(hipFree(d_run_lengths));
         HIP_CHECK(hipFree(d_decoded_runs));
 
-        ASSERT_EQ(output, expected);
+        for(size_t i = 0; i < output.size(); ++i)
+        {
+            ASSERT_EQ(test_utils::convert_to_native(output[i]),
+                      test_utils::convert_to_native(expected[i]));
+        }
     }
 }

--- a/test/hipcub/test_hipcub_device_histogram.cpp
+++ b/test/hipcub/test_hipcub_device_histogram.cpp
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2017-2020 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2023 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -533,19 +533,18 @@ public:
     using params = Params;
 };
 
-typedef ::testing::Types<
-    params3<int, 4, 3, 2000, 0, 2000>,
-    params3<int, 2, 1, 10, 0, 10>,
-    params3<int, 3, 3, 128, 0, 256>,
-    params3<unsigned int, 1, 1, 12345, 10, 12355, short>,
-    params3<unsigned short, 4, 4, 65536, 0, 65536, int>,
-    params3<unsigned char, 3, 1, 10, 20, 240, unsigned char, unsigned int>,
-    params3<unsigned char, 2, 2, 256, 0, 256, short>,
+typedef ::testing::Types<params3<int, 4, 3, 2000, 0, 2000>,
+                         params3<int, 2, 1, 10, 0, 10>,
+                         params3<int, 3, 3, 128, 0, 256>,
+                         params3<unsigned int, 1, 1, 12345, 10, 12355, short>,
+                         params3<unsigned int, 4, 4, 65536, 0, 65536, int>,
+                         params3<unsigned char, 3, 1, 10, 20, 240, unsigned char, unsigned int>,
+                         params3<unsigned char, 2, 2, 256, 0, 256, short>,
 
-    params3<double, 4, 2, 10, 0, 1000, double, int>,
-    params3<int, 3, 2, 123, 100, 5635, int>,
-    params3<double, 4, 3, 55, -123, +123, double>
-> Params3;
+                         params3<double, 4, 2, 10, 0, 1000, double, int>,
+                         params3<int, 3, 2, 123, 100, 5635, int>,
+                         params3<double, 4, 3, 55, -123, +123, double>>
+    Params3;
 
 TYPED_TEST_SUITE(HipcubDeviceHistogramMultiEven, Params3);
 

--- a/test/hipcub/test_hipcub_device_merge_sort.cpp
+++ b/test/hipcub/test_hipcub_device_merge_sort.cpp
@@ -317,6 +317,8 @@ TYPED_TEST(HipcubDeviceMergeSort, StableSortKeys)
     }
 }
 
+// hipCUB currently provides the CUB 1.x interface, StableSortKeysCopy is part of CUB 2.x
+#ifdef __HIP_PLATFORM_AMD__
 TYPED_TEST(HipcubDeviceMergeSort, StableSortKeysCopy)
 {
     int device_id = test_common_utils::obtain_device_from_ctest();
@@ -400,6 +402,7 @@ TYPED_TEST(HipcubDeviceMergeSort, StableSortKeysCopy)
         }
     }
 }
+#endif
 
 TYPED_TEST(HipcubDeviceMergeSort, SortPairs)
 {

--- a/test/hipcub/test_hipcub_device_merge_sort.cpp
+++ b/test/hipcub/test_hipcub_device_merge_sort.cpp
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2017-2021 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2023 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -24,6 +24,9 @@
 
 // hipcub API
 #include "hipcub/device/device_merge_sort.hpp"
+
+// Only test sizes this big if CheckHugeSizes is set in params.
+constexpr size_t huge_size = 1ull << 20;
 
 template<class Key,
          class Value,
@@ -90,7 +93,7 @@ TYPED_TEST(HipcubDeviceMergeSort, SortKeys)
     const std::vector<size_t> sizes = get_sizes();
     for(size_t size: sizes)
     {
-        if(size > (1 << 20) && !check_huge_sizes)
+        if(size > huge_size && !check_huge_sizes)
             continue;
 
         for(size_t seed_index = 0; seed_index < random_seeds_count + seed_size; seed_index++)
@@ -168,7 +171,7 @@ TYPED_TEST(HipcubDeviceMergeSort, SortKeysCopy)
     const std::vector<size_t> sizes = get_sizes();
     for(size_t size: sizes)
     {
-        if(size > (1 << 20) && !check_huge_sizes)
+        if(size > huge_size && !check_huge_sizes)
             continue;
 
         for(size_t seed_index = 0; seed_index < random_seeds_count + seed_size; seed_index++)
@@ -251,7 +254,7 @@ TYPED_TEST(HipcubDeviceMergeSort, StableSortKeys)
     const std::vector<size_t> sizes = get_sizes();
     for(size_t size: sizes)
     {
-        if(size > (1 << 20) && !check_huge_sizes)
+        if(size > huge_size && !check_huge_sizes)
             continue;
 
         for(size_t seed_index = 0; seed_index < random_seeds_count + seed_size; seed_index++)
@@ -314,6 +317,90 @@ TYPED_TEST(HipcubDeviceMergeSort, StableSortKeys)
     }
 }
 
+TYPED_TEST(HipcubDeviceMergeSort, StableSortKeysCopy)
+{
+    int device_id = test_common_utils::obtain_device_from_ctest();
+    SCOPED_TRACE(testing::Message() << "with device_id= " << device_id);
+    HIP_CHECK(hipSetDevice(device_id));
+
+    using key_type                   = typename TestFixture::params::key_type;
+    using compare_function           = typename TestFixture::params::compare_function;
+    constexpr bool check_huge_sizes  = TestFixture::params::check_huge_sizes;
+    constexpr bool debug_synchronous = false;
+
+    hipStream_t stream = hipStreamDefault;
+
+    const std::vector<size_t> sizes = get_sizes();
+    for(size_t size : sizes)
+    {
+        if(size > huge_size && !check_huge_sizes)
+        {
+            continue;
+        }
+
+        for(size_t seed_index = 0; seed_index < random_seeds_count + seed_size; seed_index++)
+        {
+            unsigned int seed_value
+                = seed_index < random_seeds_count ? rand() : seeds[seed_index - random_seeds_count];
+            SCOPED_TRACE(testing::Message() << "with seed= " << seed_value);
+            SCOPED_TRACE(testing::Message() << "with size = " << size);
+
+            // Generate data
+            std::vector<key_type> keys_input;
+            keys_input
+                = test_utils::get_random_data<key_type>(size,
+                                                        test_utils::numeric_limits<key_type>::min(),
+                                                        test_utils::numeric_limits<key_type>::max(),
+                                                        seed_value + seed_value_addition);
+            key_type* d_keys_input;
+            key_type* d_keys_output;
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_keys_input, size * sizeof(key_type)));
+            HIP_CHECK(test_common_utils::hipMallocHelper(&d_keys_output, size * sizeof(key_type)));
+            HIP_CHECK(hipMemcpy(d_keys_input,
+                                keys_input.data(),
+                                size * sizeof(key_type),
+                                hipMemcpyHostToDevice));
+
+            void*  d_temporary_storage     = nullptr;
+            size_t temporary_storage_bytes = 0;
+            HIP_CHECK(hipcub::DeviceMergeSort::StableSortKeysCopy(d_temporary_storage,
+                                                                  temporary_storage_bytes,
+                                                                  d_keys_input,
+                                                                  d_keys_output,
+                                                                  size,
+                                                                  compare_function()));
+            ASSERT_GT(temporary_storage_bytes, 0U);
+            HIP_CHECK(
+                test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
+
+            HIP_CHECK(hipcub::DeviceMergeSort::StableSortKeysCopy(d_temporary_storage,
+                                                                  temporary_storage_bytes,
+                                                                  d_keys_input,
+                                                                  d_keys_output,
+                                                                  size,
+                                                                  compare_function(),
+                                                                  stream,
+                                                                  debug_synchronous));
+            HIP_CHECK(hipFree(d_temporary_storage));
+            HIP_CHECK(hipFree(d_keys_input));
+
+            // Calculate expected results on host
+            std::vector<key_type> expected(keys_input);
+            std::stable_sort(expected.begin(), expected.end(), compare_function());
+
+            std::vector<key_type> keys_output(size);
+            HIP_CHECK(hipMemcpy(keys_output.data(),
+                                d_keys_output,
+                                size * sizeof(key_type),
+                                hipMemcpyDeviceToHost));
+
+            HIP_CHECK(hipFree(d_keys_output));
+
+            ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(keys_output, expected));
+        }
+    }
+}
+
 TYPED_TEST(HipcubDeviceMergeSort, SortPairs)
 {
     int device_id = test_common_utils::obtain_device_from_ctest();
@@ -332,7 +419,7 @@ TYPED_TEST(HipcubDeviceMergeSort, SortPairs)
     const std::vector<size_t> sizes = get_sizes();
     for(size_t size: sizes)
     {
-        if(size > (1 << 20) && !check_huge_sizes)
+        if(size > huge_size && !check_huge_sizes)
             continue;
 
         for(size_t seed_index = 0; seed_index < random_seeds_count + seed_size; seed_index++)
@@ -460,7 +547,7 @@ TYPED_TEST(HipcubDeviceMergeSort, SortPairsCopy)
     const std::vector<size_t> sizes = get_sizes();
     for(size_t size: sizes)
     {
-        if(size > (1 << 20) && !check_huge_sizes)
+        if(size > huge_size && !check_huge_sizes)
             continue;
 
         for(size_t seed_index = 0; seed_index < random_seeds_count + seed_size; seed_index++)
@@ -599,7 +686,7 @@ TYPED_TEST(HipcubDeviceMergeSort, StableSortPairs)
     const std::vector<size_t> sizes = get_sizes();
     for(size_t size: sizes)
     {
-        if(size > (1 << 20) && !check_huge_sizes)
+        if(size > huge_size && !check_huge_sizes)
             continue;
 
         for(size_t seed_index = 0; seed_index < random_seeds_count + seed_size; seed_index++)

--- a/test/hipcub/test_hipcub_device_reduce.cpp
+++ b/test/hipcub/test_hipcub_device_reduce.cpp
@@ -530,6 +530,8 @@ void test_argminmax_allinf(TypeParam value, TypeParam empty_value)
     }
 }
 
+// TODO: enable for NVIDIA platform once CUB backend incorporates fix
+#ifdef __HIP_PLATFORM_AMD__
 /// ArgMin with all +Inf should result in +Inf.
 TYPED_TEST(HipcubDeviceReduceArgMinMaxSpecialTests, ReduceArgMinInf)
 {
@@ -545,3 +547,4 @@ TYPED_TEST(HipcubDeviceReduceArgMinMaxSpecialTests, ReduceArgMaxInf)
         test_utils::numeric_limits<TypeParam>::infinity_neg(),
         test_utils::numeric_limits<TypeParam>::lowest());
 }
+#endif // __HIP_PLATFORM_AMD__

--- a/test/hipcub/test_hipcub_device_reduce.cpp
+++ b/test/hipcub/test_hipcub_device_reduce.cpp
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2017-2020 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2023 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -55,20 +55,24 @@ typedef ::testing::Types<
     DeviceReduceParams<unsigned long>,
     DeviceReduceParams<short>,
     DeviceReduceParams<short, float>,
-    DeviceReduceParams<int, double>,
-    DeviceReduceParams<test_utils::half, float>,
-    DeviceReduceParams<test_utils::bfloat16, float>
-    #ifdef __HIP_PLATFORM_AMD__
+    DeviceReduceParams<int, double>
+#ifdef __HIP_PLATFORM_AMD__
     ,
-    DeviceReduceParams<test_utils::bfloat16, test_utils::bfloat16> // Kernel crash on NVIDIA / CUB, failing Reduce::Sum test on AMD due to rounding.
-    #endif
-    #ifdef HIPCUB_ROCPRIM_API
+    DeviceReduceParams<test_utils::half, float>, // Doesn't compile in CUB 2.0.1
+    DeviceReduceParams<test_utils::bfloat16, float>, // Doesn't compile in CUB 2.0.1
+    DeviceReduceParams<
+        test_utils::bfloat16,
+        test_utils::
+            bfloat16> // Kernel crash on NVIDIA / CUB, failing Reduce::Sum test on AMD due to rounding.
+#endif
+#ifdef HIPCUB_ROCPRIM_API
     ,
     DeviceReduceParams<test_utils::custom_test_type<float>, test_utils::custom_test_type<float>>,
     DeviceReduceParams<test_utils::custom_test_type<int>, test_utils::custom_test_type<float>>
-    #endif
+#endif
 
-> HipcubDeviceReduceTestsParams;
+    >
+    HipcubDeviceReduceTestsParams;
 
 std::vector<size_t> get_sizes()
 {

--- a/test/hipcub/test_hipcub_device_reduce.cpp
+++ b/test/hipcub/test_hipcub_device_reduce.cpp
@@ -21,6 +21,7 @@
 // SOFTWARE.
 
 #include "common_test_header.hpp"
+#include "test_utils_argminmax.hpp"
 
 // hipcub API
 #include "hipcub/device/device_reduce.hpp"
@@ -45,15 +46,16 @@ template<class Params>
 class HipcubDeviceReduceTests : public ::testing::Test
 {
 public:
-    using input_type = typename Params::input_type;
-    using output_type = typename Params::output_type;
-    const bool debug_synchronous = false;
+    using input_type                        = typename Params::input_type;
+    using output_type                       = typename Params::output_type;
+    static constexpr bool debug_synchronous = false;
 };
 
 typedef ::testing::Types<
     DeviceReduceParams<int, long>,
     DeviceReduceParams<unsigned long>,
     DeviceReduceParams<short>,
+    DeviceReduceParams<float>,
     DeviceReduceParams<short, float>,
     DeviceReduceParams<int, double>
 #ifdef __HIP_PLATFORM_AMD__
@@ -70,7 +72,6 @@ typedef ::testing::Types<
     DeviceReduceParams<test_utils::custom_test_type<float>, test_utils::custom_test_type<float>>,
     DeviceReduceParams<test_utils::custom_test_type<int>, test_utils::custom_test_type<float>>
 #endif
-
     >
     HipcubDeviceReduceTestsParams;
 
@@ -86,77 +87,6 @@ std::vector<size_t> get_sizes()
     std::sort(sizes.begin(), sizes.end());
     return sizes;
 }
-
-// BEGIN - Code has been added because NVIDIA's hipcub::ArgMax doesn't work with bfloat16 (HOST-SIDE)
-/**
- * \brief Arg max functor - Because NVIDIA's hipcub::ArgMax doesn't work with bfloat16 (HOST-SIDE)
- */
-struct ArgMax {
-    template<typename OffsetT, class T, std::enable_if_t<std::is_same<T, test_utils::half>::value ||
-                                                         std::is_same<T, test_utils::bfloat16>::value, bool> = true>
-    HIPCUB_HOST_DEVICE __forceinline__ hipcub::KeyValuePair <OffsetT, T> operator()(
-        const hipcub::KeyValuePair <OffsetT, T> &a,
-        const hipcub::KeyValuePair <OffsetT, T> &b) const {
-        const hipcub::KeyValuePair <OffsetT, float> native_a(a.key,a.value);
-        const hipcub::KeyValuePair <OffsetT, float> native_b(b.key,b.value);
-
-        if ((native_b.value > native_a.value) || ((native_a.value == native_b.value) && (native_b.key < native_a.key)))
-            return b;
-        return a;
-    }
-};
-/**
- * \brief Arg min functor - Because NVIDIA's hipcub::ArgMax doesn't work with bfloat16 (HOST-SIDE)
- */
-struct ArgMin {
-    template<typename OffsetT, class T, std::enable_if_t<std::is_same<T, test_utils::half>::value ||
-                                                         std::is_same<T, test_utils::bfloat16>::value, bool> = true>
-    HIPCUB_HOST_DEVICE __forceinline__ hipcub::KeyValuePair <OffsetT, T> operator()(
-        const hipcub::KeyValuePair <OffsetT, T> &a,
-        const hipcub::KeyValuePair <OffsetT, T> &b) const {
-        const hipcub::KeyValuePair <OffsetT, float> native_a(a.key,a.value);
-        const hipcub::KeyValuePair <OffsetT, float> native_b(b.key,b.value);
-
-        if ((native_b.value < native_a.value) || ((native_a.value == native_b.value) && (native_b.key < native_a.key)))
-            return b;
-        return a;
-    }
-};
-
-// Maximum to operator selector
-template<typename T>
-struct ArgMaxSelector {
-    typedef hipcub::ArgMax type;
-};
-
-template<>
-struct ArgMaxSelector<test_utils::half> {
-    typedef ArgMax type;
-};
-
-template<>
-struct ArgMaxSelector<test_utils::bfloat16> {
-    typedef ArgMax type;
-};
-
-// Minimum to operator selector
-template<typename T>
-struct ArgMinSelector {
-    typedef hipcub::ArgMin type;
-};
-
-#ifdef __HIP_PLATFORM_NVIDIA__
-template<>
-struct ArgMinSelector<test_utils::half> {
-    typedef ArgMin type;
-};
-
-template<>
-struct ArgMinSelector<test_utils::bfloat16> {
-    typedef ArgMin type;
-};
-#endif
-// END - Code has been added because NVIDIA's hipcub::ArgMax doesn't work with bfloat16 (HOST-SIDE)
 
 TYPED_TEST_SUITE(HipcubDeviceReduceTests, HipcubDeviceReduceTestsParams);
 
@@ -359,194 +289,259 @@ TYPED_TEST(HipcubDeviceReduceTests, ReduceMinimum)
     }
 }
 
-TYPED_TEST(HipcubDeviceReduceTests, ReduceArgMinimum)
+struct ArgMinDispatch
+{
+    template<typename InputIteratorT, typename OutputIteratorT>
+    auto operator()(void*           d_temp_storage,
+                    size_t&         temp_storage_bytes,
+                    InputIteratorT  d_in,
+                    OutputIteratorT d_out,
+                    int             num_items,
+                    hipStream_t     stream,
+                    bool            debug_synchronous)
+    {
+        return hipcub::DeviceReduce::ArgMin(d_temp_storage,
+                                            temp_storage_bytes,
+                                            d_in,
+                                            d_out,
+                                            num_items,
+                                            stream,
+                                            debug_synchronous);
+    }
+};
+
+struct ArgMaxDispatch
+{
+    template<typename InputIteratorT, typename OutputIteratorT>
+    auto operator()(void*           d_temp_storage,
+                    size_t&         temp_storage_bytes,
+                    InputIteratorT  d_in,
+                    OutputIteratorT d_out,
+                    int             num_items,
+                    hipStream_t     stream,
+                    bool            debug_synchronous)
+    {
+        return hipcub::DeviceReduce::ArgMax(d_temp_storage,
+                                            temp_storage_bytes,
+                                            d_in,
+                                            d_out,
+                                            num_items,
+                                            stream,
+                                            debug_synchronous);
+    }
+};
+
+template<typename TestFixture, typename DispatchFunction, typename HostOp>
+void test_argminmax(typename TestFixture::input_type empty_value)
 {
     int device_id = test_common_utils::obtain_device_from_ctest();
     SCOPED_TRACE(testing::Message() << "with device_id= " << device_id);
     HIP_CHECK(hipSetDevice(device_id));
 
-    using T = typename TestFixture::input_type;
-    using Iterator = typename hipcub::ArgIndexInputIterator<T*, int>;
+    using T         = typename TestFixture::input_type;
+    using Iterator  = typename hipcub::ArgIndexInputIterator<T*, int>;
     using key_value = typename Iterator::value_type;
-    const bool debug_synchronous = TestFixture::debug_synchronous;
 
-    const std::vector<size_t> sizes = get_sizes();
+    const bool          debug_synchronous = TestFixture::debug_synchronous;
+    DispatchFunction    function;
+    std::vector<size_t> sizes = get_sizes();
+    sizes.push_back(0);
+
     for(auto size : sizes)
     {
-        for (size_t seed_index = 0; seed_index < random_seeds_count + seed_size; seed_index++)
+        for(size_t seed_index = 0; seed_index < random_seeds_count + seed_size; seed_index++)
         {
-            unsigned int seed_value = seed_index < random_seeds_count  ? rand() : seeds[seed_index - random_seeds_count];
+            unsigned int seed_value
+                = seed_index < random_seeds_count ? rand() : seeds[seed_index - random_seeds_count];
             SCOPED_TRACE(testing::Message() << "with seed= " << seed_value);
             SCOPED_TRACE(testing::Message() << "with size = " << size);
 
             hipStream_t stream = 0; // default
 
             // Generate data
-            std::vector<T> input = test_utils::get_random_data<T>(size, 1, 200, seed_value);
+            std::vector<T>         input = test_utils::get_random_data<T>(size, 0, 200, seed_value);
             std::vector<key_value> output(1);
 
-            T * d_input;
-            key_value * d_output;
+            T*         d_input;
+            key_value* d_output;
             HIP_CHECK(test_common_utils::hipMallocHelper(&d_input, input.size() * sizeof(T)));
-            HIP_CHECK(test_common_utils::hipMallocHelper(&d_output, output.size() * sizeof(key_value)));
             HIP_CHECK(
-                hipMemcpy(
-                    d_input, input.data(),
-                    input.size() * sizeof(T),
-                    hipMemcpyHostToDevice
-                )
-            );
+                test_common_utils::hipMallocHelper(&d_output, output.size() * sizeof(key_value)));
+            HIP_CHECK(
+                hipMemcpy(d_input, input.data(), input.size() * sizeof(T), hipMemcpyHostToDevice));
             HIP_CHECK(hipDeviceSynchronize());
 
-            // Calculate expected results on host
-            Iterator x(input.data());
-            const key_value max(1, test_utils::numeric_limits<T>::max());
-            using ArgMin = typename ArgMinSelector<T>::type; // Because NVIDIA's hipcub::ArgMin doesn't work with bfloat16 (HOST-SIDE)
-            key_value expected = std::accumulate(x, x + size, max, ArgMin());
+            key_value expected;
+            if(size > 0)
+            {
+                // Calculate expected results on host
+                Iterator        x(input.data());
+                const key_value max = x[0];
+                expected            = std::accumulate(x, x + size, max, HostOp());
+            }
+            else
+            {
+                // Empty inputs result in a special value
+                expected = key_value(1, empty_value);
+            }
 
-            // temp storage
-            size_t temp_storage_size_bytes;
-            void * d_temp_storage = nullptr;
-            // Get size of d_temp_storage
-            HIP_CHECK(
-                hipcub::DeviceReduce::ArgMin(
-                    d_temp_storage, temp_storage_size_bytes,
-                    d_input, d_output, input.size(),
-                    stream, debug_synchronous
-                )
-            );
+            size_t temp_storage_size_bytes{};
+            void*  d_temp_storage{};
+            HIP_CHECK(function(d_temp_storage,
+                               temp_storage_size_bytes,
+                               d_input,
+                               d_output,
+                               input.size(),
+                               stream,
+                               debug_synchronous));
 
-            // temp_storage_size_bytes must be >0
+            // temp_storage_size_bytes must be > 0
             ASSERT_GT(temp_storage_size_bytes, 0U);
 
-            // allocate temporary storage
             HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
             HIP_CHECK(hipDeviceSynchronize());
 
             // Run
-            HIP_CHECK(
-                hipcub::DeviceReduce::ArgMin(
-                    d_temp_storage, temp_storage_size_bytes,
-                    d_input, d_output, input.size(),
-                    stream, debug_synchronous
-                )
-            );
+            HIP_CHECK(function(d_temp_storage,
+                               temp_storage_size_bytes,
+                               d_input,
+                               d_output,
+                               input.size(),
+                               stream,
+                               debug_synchronous));
             HIP_CHECK(hipPeekAtLastError());
             HIP_CHECK(hipDeviceSynchronize());
 
-            // Copy output to host
-            HIP_CHECK(
-                hipMemcpy(
-                    output.data(), d_output,
-                    output.size() * sizeof(key_value),
-                    hipMemcpyDeviceToHost
-                )
-            );
-            HIP_CHECK(hipDeviceSynchronize());
+            HIP_CHECK(hipMemcpy(output.data(),
+                                d_output,
+                                output.size() * sizeof(key_value),
+                                hipMemcpyDeviceToHost));
 
-            // Check if output values are as expected
-            ASSERT_NO_FATAL_FAILURE(test_utils::assert_near(output[0].key, expected.key, 0.01f));
-            ASSERT_NO_FATAL_FAILURE(test_utils::assert_near(output[0].value, expected.value, 0.01f));
+            HIP_CHECK(hipFree(d_input));
+            HIP_CHECK(hipFree(d_output));
+            HIP_CHECK(hipFree(d_temp_storage));
 
-            hipFree(d_input);
-            hipFree(d_output);
-            hipFree(d_temp_storage);
+            ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(output[0].key, expected.key));
+            ASSERT_NO_FATAL_FAILURE(
+                test_utils::assert_near(output[0].value, expected.value, 0.01f));
         }
     }
 }
 
+TYPED_TEST(HipcubDeviceReduceTests, ReduceArgMinimum)
+{
+    using T = typename TestFixture::input_type;
+    // Because NVIDIA's hipcub::ArgMin doesn't work with bfloat16 (HOST-SIDE)
+    using HostOp = typename ArgMinSelector<T>::type;
+    test_argminmax<TestFixture, ArgMinDispatch, HostOp>(test_utils::numeric_limits<T>::max());
+}
+
 TYPED_TEST(HipcubDeviceReduceTests, ReduceArgMaximum)
+{
+    using T = typename TestFixture::input_type;
+    // Because NVIDIA's hipcub::ArgMax doesn't work with bfloat16 (HOST-SIDE)
+    using HostOp = typename ArgMaxSelector<T>::type;
+    test_argminmax<TestFixture, ArgMaxDispatch, HostOp>(test_utils::numeric_limits<T>::lowest());
+}
+
+template<class T>
+class HipcubDeviceReduceArgMinMaxSpecialTests : public testing::Test
+{};
+
+using HipcubDeviceReduceArgMinMaxSpecialTestsParams
+    = ::testing::Types<float, test_utils::half, test_utils::bfloat16>;
+TYPED_TEST_SUITE(HipcubDeviceReduceArgMinMaxSpecialTests,
+                 HipcubDeviceReduceArgMinMaxSpecialTestsParams);
+
+template<typename TypeParam, typename DispatchFunction>
+void test_argminmax_allinf(TypeParam value, TypeParam empty_value)
 {
     int device_id = test_common_utils::obtain_device_from_ctest();
     SCOPED_TRACE(testing::Message() << "with device_id= " << device_id);
     HIP_CHECK(hipSetDevice(device_id));
 
-    using T = typename TestFixture::input_type;
-    using Iterator = typename hipcub::ArgIndexInputIterator<T*, int>;
+    using T         = TypeParam;
+    using Iterator  = typename hipcub::ArgIndexInputIterator<T*, int>;
     using key_value = typename Iterator::value_type;
-    const bool debug_synchronous = TestFixture::debug_synchronous;
 
-    const std::vector<size_t> sizes = get_sizes();
-    for(auto size : sizes)
+    constexpr bool   debug_synchronous = false;
+    hipStream_t      stream            = 0; // default
+    DispatchFunction function;
+    constexpr size_t size = 100'000;
+
+    // Generate data
+    std::vector<T>         input(size, value);
+    std::vector<key_value> output(1);
+
+    T*         d_input;
+    key_value* d_output;
+    HIP_CHECK(test_common_utils::hipMallocHelper(&d_input, input.size() * sizeof(T)));
+    HIP_CHECK(test_common_utils::hipMallocHelper(&d_output, output.size() * sizeof(key_value)));
+    HIP_CHECK(hipMemcpy(d_input, input.data(), input.size() * sizeof(T), hipMemcpyHostToDevice));
+    HIP_CHECK(hipDeviceSynchronize());
+
+    size_t temp_storage_size_bytes{};
+    void*  d_temp_storage{};
+
+    HIP_CHECK(function(d_temp_storage,
+                       temp_storage_size_bytes,
+                       d_input,
+                       d_output,
+                       input.size(),
+                       stream,
+                       debug_synchronous));
+
+    // temp_storage_size_bytes must be > 0
+    ASSERT_GT(temp_storage_size_bytes, 0U);
+
+    HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
+    HIP_CHECK(hipDeviceSynchronize());
+
+    HIP_CHECK(function(d_temp_storage,
+                       temp_storage_size_bytes,
+                       d_input,
+                       d_output,
+                       input.size(),
+                       stream,
+                       debug_synchronous));
+    HIP_CHECK(hipPeekAtLastError());
+    HIP_CHECK(hipDeviceSynchronize());
+
+    HIP_CHECK(hipMemcpy(output.data(),
+                        d_output,
+                        output.size() * sizeof(key_value),
+                        hipMemcpyDeviceToHost));
+
+    HIP_CHECK(hipFree(d_input));
+    HIP_CHECK(hipFree(d_output));
+    HIP_CHECK(hipFree(d_temp_storage));
+
+    if(size > 0)
     {
-        for (size_t seed_index = 0; seed_index < random_seeds_count + seed_size; seed_index++)
-        {
-            unsigned int seed_value = seed_index < random_seeds_count  ? rand() : seeds[seed_index - random_seeds_count];
-            SCOPED_TRACE(testing::Message() << "with seed= " << seed_value);
-            SCOPED_TRACE(testing::Message() << "with size = " << size);
-
-            hipStream_t stream = 0; // default
-
-            // Generate data
-            std::vector<T> input = test_utils::get_random_data<T>(size, 0, 100, seed_value);
-            std::vector<key_value> output(1);
-
-            T * d_input;
-            key_value * d_output;
-            HIP_CHECK(test_common_utils::hipMallocHelper(&d_input, input.size() * sizeof(T)));
-            HIP_CHECK(test_common_utils::hipMallocHelper(&d_output, output.size() * sizeof(key_value)));
-            HIP_CHECK(
-                hipMemcpy(
-                    d_input, input.data(),
-                    input.size() * sizeof(T),
-                    hipMemcpyHostToDevice
-                )
-            );
-            HIP_CHECK(hipDeviceSynchronize());
-
-            // Calculate expected results on host
-            Iterator x(input.data());
-            const key_value min(1, test_utils::numeric_limits<T>::lowest());
-            using ArgMax = typename ArgMaxSelector<T>::type; // Because NVIDIA's hipcub::ArgMax doesn't work with bfloat16 (HOST-SIDE)
-            key_value expected = std::accumulate(x, x + size, min, ArgMax());
-
-            // temp storage
-            size_t temp_storage_size_bytes;
-            void * d_temp_storage = nullptr;
-            // Get size of d_temp_storage
-            HIP_CHECK(
-                hipcub::DeviceReduce::ArgMax(
-                    d_temp_storage, temp_storage_size_bytes,
-                    d_input, d_output, input.size(),
-                    stream, debug_synchronous
-                )
-            );
-
-            // temp_storage_size_bytes must be >0
-            ASSERT_GT(temp_storage_size_bytes, 0U);
-
-            // allocate temporary storage
-            HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
-            HIP_CHECK(hipDeviceSynchronize());
-
-            // Run
-            HIP_CHECK(
-                hipcub::DeviceReduce::ArgMax(
-                    d_temp_storage, temp_storage_size_bytes,
-                    d_input, d_output, input.size(),
-                    stream, debug_synchronous
-                )
-            );
-            HIP_CHECK(hipPeekAtLastError());
-            HIP_CHECK(hipDeviceSynchronize());
-
-            // Copy output to host
-            HIP_CHECK(
-                hipMemcpy(
-                    output.data(), d_output,
-                    output.size() * sizeof(key_value),
-                    hipMemcpyDeviceToHost
-                )
-            );
-            HIP_CHECK(hipDeviceSynchronize());
-
-            // Check if output values are as expected
-            ASSERT_EQ(output[0].key, expected.key);
-            ASSERT_NO_FATAL_FAILURE(test_utils::assert_near(output[0].value, expected.value, 0.01f));
-
-            hipFree(d_input);
-            hipFree(d_output);
-            hipFree(d_temp_storage);
-        }
+        // all +/- infinity should produce +/- infinity
+        ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(output[0].key, 0));
+        ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(output[0].value, value));
     }
+    else
+    {
+        // empty input should produce a special value
+        ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(output[0].key, 1));
+        ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(output[0].value, empty_value));
+    }
+}
+
+/// ArgMin with all +Inf should result in +Inf.
+TYPED_TEST(HipcubDeviceReduceArgMinMaxSpecialTests, ReduceArgMinInf)
+{
+    test_argminmax_allinf<TypeParam, ArgMinDispatch>(
+        test_utils::numeric_limits<TypeParam>::infinity(),
+        test_utils::numeric_limits<TypeParam>::max());
+}
+
+/// ArgMax with all -Inf should result in -Inf.
+TYPED_TEST(HipcubDeviceReduceArgMinMaxSpecialTests, ReduceArgMaxInf)
+{
+    test_argminmax_allinf<TypeParam, ArgMaxDispatch>(
+        test_utils::numeric_limits<TypeParam>::infinity_neg(),
+        test_utils::numeric_limits<TypeParam>::lowest());
 }

--- a/test/hipcub/test_hipcub_device_scan.cpp
+++ b/test/hipcub/test_hipcub_device_scan.cpp
@@ -244,7 +244,7 @@ TYPED_TEST(HipcubDeviceScanTests, InclusiveScan)
             for(size_t i = 0; i < output.size(); i++)
             {
                 auto diff
-                    = std::max<V>(std::abs(0.01f * test_utils::convert_to_fundemental(expected[i])),
+                    = std::max<V>(std::abs(0.01f * test_utils::convert_to_fundamental(expected[i])),
                                   V(0.01f));
                 if(std::is_integral<V>::value)
                     diff = 0;
@@ -398,7 +398,7 @@ TYPED_TEST(HipcubDeviceScanTests, InclusiveScanByKey)
             {
                 // to fundemental instead of native as native will be implicitely casted to fundemental anyway
                 auto diff
-                    = std::max<V>(std::abs(0.01f * test_utils::convert_to_fundemental(expected[i])),
+                    = std::max<V>(std::abs(0.01f * test_utils::convert_to_fundamental(expected[i])),
                                   V(0.01f));
                 if(std::is_integral<V>::value)
                 {
@@ -715,7 +715,7 @@ TYPED_TEST(HipcubDeviceScanTests, ExclusiveScanByKey)
             for (size_t i = 0; i < output.size(); i++)
             {
                 auto diff
-                    = std::max<V>(std::abs(0.01f * test_utils::convert_to_fundemental(expected[i])),
+                    = std::max<V>(std::abs(0.01f * test_utils::convert_to_fundamental(expected[i])),
                                   V(0.01f));
                 if(std::is_integral<V>::value)
                 {
@@ -1104,7 +1104,7 @@ TYPED_TEST(HipcubDeviceScanTests, ExclusiveScanFuture)
             for(size_t i = 0; i < output.size(); i++)
             {
                 auto diff
-                    = std::max<V>(std::abs(0.01f * test_utils::convert_to_fundemental(expected[i])),
+                    = std::max<V>(std::abs(0.01f * test_utils::convert_to_fundamental(expected[i])),
                                   V(0.01f));
                 if(std::is_integral<U>::value)
                     diff = 0;

--- a/test/hipcub/test_hipcub_device_segmented_reduce.cpp
+++ b/test/hipcub/test_hipcub_device_segmented_reduce.cpp
@@ -225,7 +225,7 @@ TYPED_TEST(HipcubDeviceSegmentedReduceOp, Reduce)
                 else
                 {
                     auto diff = std::max<test_utils::convert_to_fundamental_t<output_type>>(
-                        std::abs(0.01 * test_utils::convert_to_fundemental(aggregates_expected[i])),
+                        std::abs(0.01 * test_utils::convert_to_fundamental(aggregates_expected[i])),
                         output_type(0.01));
                     ASSERT_NEAR(test_utils::convert_to_native(aggregates_output[i]),
                                 test_utils::convert_to_native(aggregates_expected[i]),

--- a/test/hipcub/test_hipcub_warp_exchange.cpp
+++ b/test/hipcub/test_hipcub_warp_exchange.cpp
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2017-2021 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2023 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -23,6 +23,8 @@
 #include "common_test_header.hpp"
 
 #include "hipcub/warp/warp_exchange.hpp"
+#include "test_utils_data_generation.hpp"
+#include "test_utils_half.hpp"
 
 template<
     class T,
@@ -44,46 +46,57 @@ public:
     using params = Params;
 };
 
-using HipcubWarpExchangeTestParams = ::testing::Types<
-    Params<char, 1U, 8U>,
-    Params<char, 4U, 8U>,
-    Params<char, 5U, 8U>,
-    Params<char, 1U, 16U>,
-    Params<char, 4U, 16U>,
-    Params<char, 5U, 16U>,
-    Params<char, 1U, 32U>,
-    Params<char, 4U, 32U>,
-    Params<char, 5U, 32U>,
-    Params<char, 1U, 64U>,
-    Params<char, 4U, 64U>,
-    Params<char, 5U, 64U>,
+using HipcubWarpExchangeTestParams = ::testing::Types<Params<char, 1U, 8U>,
+                                                      Params<char, 4U, 8U>,
+                                                      Params<char, 5U, 8U>,
+                                                      Params<char, 1U, 16U>,
+                                                      Params<char, 4U, 16U>,
+                                                      Params<char, 5U, 16U>,
+                                                      Params<char, 1U, 32U>,
+                                                      Params<char, 4U, 32U>,
+                                                      Params<char, 5U, 32U>,
+                                                      Params<char, 1U, 64U>,
+                                                      Params<char, 4U, 64U>,
+                                                      Params<char, 5U, 64U>,
 
-    Params<int, 1U, 8U>,
-    Params<int, 4U, 8U>,
-    Params<int, 5U, 8U>,
-    Params<int, 1U, 16U>,
-    Params<int, 4U, 16U>,
-    Params<int, 5U, 16U>,
-    Params<int, 1U, 32U>,
-    Params<int, 4U, 32U>,
-    Params<int, 5U, 32U>,
-    Params<int, 1U, 64U>,
-    Params<int, 4U, 64U>,
-    Params<int, 5U, 64U>,
+                                                      Params<int, 1U, 8U>,
+                                                      Params<int, 4U, 8U>,
+                                                      Params<int, 5U, 8U>,
+                                                      Params<int, 1U, 16U>,
+                                                      Params<int, 4U, 16U>,
+                                                      Params<int, 5U, 16U>,
+                                                      Params<int, 1U, 32U>,
+                                                      Params<int, 4U, 32U>,
+                                                      Params<int, 5U, 32U>,
+                                                      Params<int, 1U, 64U>,
+                                                      Params<int, 4U, 64U>,
+                                                      Params<int, 5U, 64U>,
 
-    Params<double, 1U, 8U>,
-    Params<double, 4U, 8U>,
-    Params<double, 5U, 8U>,
-    Params<double, 1U, 16U>,
-    Params<double, 4U, 16U>,
-    Params<double, 5U, 16U>,
-    Params<double, 1U, 32U>,
-    Params<double, 4U, 32U>,
-    Params<double, 5U, 32U>,
-    Params<double, 1U, 64U>,
-    Params<double, 4U, 64U>,
-    Params<double, 5U, 64U>
->;
+                                                      Params<double, 1U, 8U>,
+                                                      Params<double, 4U, 8U>,
+                                                      Params<double, 5U, 8U>,
+                                                      Params<double, 1U, 16U>,
+                                                      Params<double, 4U, 16U>,
+                                                      Params<double, 5U, 16U>,
+                                                      Params<double, 1U, 32U>,
+                                                      Params<double, 4U, 32U>,
+                                                      Params<double, 5U, 32U>,
+                                                      Params<double, 1U, 64U>,
+                                                      Params<double, 4U, 64U>,
+                                                      Params<double, 5U, 64U>,
+
+                                                      Params<test_utils::half, 1U, 8U>,
+                                                      Params<test_utils::half, 4U, 8U>,
+                                                      Params<test_utils::half, 5U, 8U>,
+                                                      Params<test_utils::half, 1U, 16U>,
+                                                      Params<test_utils::half, 4U, 16U>,
+                                                      Params<test_utils::half, 5U, 16U>,
+                                                      Params<test_utils::half, 1U, 32U>,
+                                                      Params<test_utils::half, 4U, 32U>,
+                                                      Params<test_utils::half, 5U, 32U>,
+                                                      Params<test_utils::half, 1U, 64U>,
+                                                      Params<test_utils::half, 4U, 64U>,
+                                                      Params<test_utils::half, 5U, 64U>>;
 
 TYPED_TEST_SUITE(HipcubWarpExchangeTest, HipcubWarpExchangeTestParams);
 
@@ -258,7 +271,10 @@ TYPED_TEST(HipcubWarpExchangeTest, WarpExchangeStripedToBlocked)
     SKIP_IF_UNSUPPORTED_WARP_SIZE(warp_size);
 
     std::vector<T> input(items_count);
-    std::iota(input.begin(), input.end(), static_cast<T>(0));
+    for(int i = 0; i < input.size(); i++)
+    {
+        input[i] = test_utils::convert_to_device<T>(i);
+    }
 
     T* d_input{};
     HIP_CHECK(test_common_utils::hipMallocHelper(&d_input, items_count * sizeof(T)));
@@ -289,7 +305,11 @@ TYPED_TEST(HipcubWarpExchangeTest, WarpExchangeStripedToBlocked)
     HIP_CHECK(hipFree(d_output));
 
     auto expected = stripe_vector(input, warp_size, items_per_thread);
-    ASSERT_EQ(expected, output);
+    for(int i = 0; i < items_count; i++)
+    {
+        ASSERT_EQ(test_utils::convert_to_native(expected[i]),
+                  test_utils::convert_to_native(output[i]));
+    }
 }
 
 TYPED_TEST(HipcubWarpExchangeTest, WarpExchangeBlockedToStriped)
@@ -307,7 +327,11 @@ TYPED_TEST(HipcubWarpExchangeTest, WarpExchangeBlockedToStriped)
     SKIP_IF_UNSUPPORTED_WARP_SIZE(warp_size);
 
     std::vector<T> input(items_count);
-    std::iota(input.begin(), input.end(), static_cast<T>(0));
+    for(int i = 0; i < input.size(); i++)
+    {
+        input[i] = test_utils::convert_to_device<T>(i);
+    }
+
     input = stripe_vector(input, warp_size, items_per_thread);
 
     T* d_input{};
@@ -339,9 +363,16 @@ TYPED_TEST(HipcubWarpExchangeTest, WarpExchangeBlockedToStriped)
     HIP_CHECK(hipFree(d_output));
 
     std::vector<T> expected(items_count);
-    std::iota(expected.begin(), expected.end(), static_cast<T>(0));
+    for(int i = 0; i < expected.size(); i++)
+    {
+        expected[i] = test_utils::convert_to_device<T>(i);
+    }
 
-    ASSERT_EQ(expected, output);
+    for(int i = 0; i < items_count; i++)
+    {
+        ASSERT_EQ(test_utils::convert_to_native(expected[i]),
+                  test_utils::convert_to_native(output[i]));
+    }
 }
 
 TYPED_TEST(HipcubWarpExchangeTest, WarpExchangeScatterToStriped)
@@ -362,7 +393,10 @@ TYPED_TEST(HipcubWarpExchangeTest, WarpExchangeScatterToStriped)
     SKIP_IF_UNSUPPORTED_WARP_SIZE(warp_size);
 
     std::vector<T> input(items_count);
-    std::iota(input.begin(), input.end(), static_cast<T>(0));
+    for(int i = 0; i < input.size(); i++)
+    {
+        input[i] = test_utils::convert_to_device<T>(i);
+    }
 
     std::vector<OffsetT> ranks(items_count);
     for (size_t i = 0; i < items_count / items_per_warp; ++i)
@@ -407,5 +441,9 @@ TYPED_TEST(HipcubWarpExchangeTest, WarpExchangeScatterToStriped)
 
     const std::vector<T> expected = stripe_vector(input, ranks, warp_size, items_per_thread);
 
-    ASSERT_EQ(expected, output);
+    for(int i = 0; i < items_count; i++)
+    {
+        ASSERT_EQ(test_utils::convert_to_native(expected[i]),
+                  test_utils::convert_to_native(output[i]));
+    }
 }

--- a/test/hipcub/test_hipcub_warp_reduce.cpp
+++ b/test/hipcub/test_hipcub_warp_reduce.cpp
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2017-2020 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2023 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -44,6 +44,7 @@ public:
 typedef ::testing::Types<
     // shuffle based reduce
     // Integer
+    params<int, 1U>,
     params<int, 2U>,
     params<int, 4U>,
     params<int, 8U>,
@@ -53,6 +54,7 @@ typedef ::testing::Types<
     params<int, 64U>,
 #endif
     // Float
+    params<float, 1U>,
     params<float, 2U>,
     params<float, 4U>,
     params<float, 8U>,
@@ -75,10 +77,12 @@ typedef ::testing::Types<
     params<float, 7U>,
     params<float, 15U>
 #ifdef __HIP_PLATFORM_AMD__
-    ,params<float, 37U>,
+    ,
+    params<float, 37U>,
     params<float, 61U>
 #endif
-> HipcubWarpReduceTestParams;
+    >
+    HipcubWarpReduceTestParams;
 
 TYPED_TEST_SUITE(HipcubWarpReduceTests, HipcubWarpReduceTestParams);
 
@@ -220,7 +224,7 @@ TYPED_TEST(HipcubWarpReduceTests, Reduce)
         {
             auto diff = std::max<T>(std::abs(0.1f * expected[i]), T(0.01f));
             if(std::is_integral<T>::value) diff = 0;
-            ASSERT_NEAR(output[i], expected[i], diff);
+            ASSERT_NEAR(output[i], expected[i], diff) << "where index = " << i;
         }
 
         HIP_CHECK(hipFree(device_input));
@@ -315,7 +319,7 @@ TYPED_TEST(HipcubWarpReduceTests, ReduceValid)
                 auto idx = i * logical_warp_size + j;
                 value += input[idx];
             }
-            expected[i] = value;
+            expected[i] = valid ? value : input[i];
         }
 
         // Writing to device memory
@@ -366,7 +370,7 @@ TYPED_TEST(HipcubWarpReduceTests, ReduceValid)
         {
             auto diff = std::max<T>(std::abs(0.1f * expected[i]), T(0.01f));
             if(std::is_integral<T>::value) diff = 0;
-            ASSERT_NEAR(output[i], expected[i], diff);
+            ASSERT_NEAR(output[i], expected[i], diff) << "where index = " << i;
         }
 
         HIP_CHECK(hipFree(device_input));
@@ -556,7 +560,7 @@ TYPED_TEST(HipcubWarpReduceTests, HeadSegmentedReduceSum)
             {
                 auto diff = std::max<T>(std::abs(0.1f * expected[i]), T(0.01f));
                 if(std::is_integral<T>::value) diff = 0;
-                ASSERT_NEAR(output[i], expected[i], diff);
+                ASSERT_NEAR(output[i], expected[i], diff) << "where index = " << i;
             }
         }
 
@@ -758,7 +762,7 @@ TYPED_TEST(HipcubWarpReduceTests, TailSegmentedReduceSum)
             auto index = segment_indexes[i];
             auto diff = std::max<T>(std::abs(0.1f * expected[i]), T(0.01f));
             if(std::is_integral<T>::value) diff = 0;
-            ASSERT_NEAR(output[index], expected[index], diff);
+            ASSERT_NEAR(output[index], expected[index], diff) << "where index = " << i;
         }
 
         HIP_CHECK(hipFree(device_input));

--- a/test/hipcub/test_utils_argminmax.hpp
+++ b/test/hipcub/test_utils_argminmax.hpp
@@ -1,0 +1,117 @@
+// MIT License
+//
+// Copyright (c) 2017-2023 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN
+
+#ifndef HIPCUB_TEST_UTILS_ARGMINMAX_HPP
+#define HIPCUB_TEST_UTILS_ARGMINMAX_HPP
+
+#include <hipcub/thread/thread_operators.hpp>
+#include <type_traits>
+
+/**
+ * \brief Arg max functor - Because NVIDIA's hipcub::ArgMax doesn't work with bfloat16 (HOST-SIDE)
+ */
+struct ArgMax
+{
+    template<typename OffsetT,
+             class T,
+             std::enable_if_t<std::is_same<T, test_utils::half>::value
+                                  || std::is_same<T, test_utils::bfloat16>::value,
+                              bool>
+             = true>
+    HIPCUB_HOST_DEVICE __forceinline__ hipcub::KeyValuePair<OffsetT, T>
+                                       operator()(const hipcub::KeyValuePair<OffsetT, T>& a,
+                   const hipcub::KeyValuePair<OffsetT, T>& b) const
+    {
+        const hipcub::KeyValuePair<OffsetT, float> native_a(a.key, a.value);
+        const hipcub::KeyValuePair<OffsetT, float> native_b(b.key, b.value);
+
+        if((native_b.value > native_a.value)
+           || ((native_a.value == native_b.value) && (native_b.key < native_a.key)))
+            return b;
+        return a;
+    }
+};
+/**
+ * \brief Arg min functor - Because NVIDIA's hipcub::ArgMin doesn't work with bfloat16 (HOST-SIDE)
+ */
+struct ArgMin
+{
+    template<typename OffsetT,
+             class T,
+             std::enable_if_t<std::is_same<T, test_utils::half>::value
+                                  || std::is_same<T, test_utils::bfloat16>::value,
+                              bool>
+             = true>
+    HIPCUB_HOST_DEVICE __forceinline__ hipcub::KeyValuePair<OffsetT, T>
+                                       operator()(const hipcub::KeyValuePair<OffsetT, T>& a,
+                   const hipcub::KeyValuePair<OffsetT, T>& b) const
+    {
+        const hipcub::KeyValuePair<OffsetT, float> native_a(a.key, a.value);
+        const hipcub::KeyValuePair<OffsetT, float> native_b(b.key, b.value);
+
+        if((native_b.value < native_a.value)
+           || ((native_a.value == native_b.value) && (native_b.key < native_a.key)))
+            return b;
+        return a;
+    }
+};
+
+// Maximum to operator selector
+template<typename T>
+struct ArgMaxSelector
+{
+    typedef hipcub::ArgMax type;
+};
+
+template<>
+struct ArgMaxSelector<test_utils::half>
+{
+    typedef ArgMax type;
+};
+
+template<>
+struct ArgMaxSelector<test_utils::bfloat16>
+{
+    typedef ArgMax type;
+};
+
+// Minimum to operator selector
+template<typename T>
+struct ArgMinSelector
+{
+    typedef hipcub::ArgMin type;
+};
+
+#ifdef __HIP_PLATFORM_NVIDIA__
+template<>
+struct ArgMinSelector<test_utils::half>
+{
+    typedef ArgMin type;
+};
+
+template<>
+struct ArgMinSelector<test_utils::bfloat16>
+{
+    typedef ArgMin type;
+};
+#endif
+
+#endif //HIPCUB_TEST_UTILS_ARGMINMAX_HPP

--- a/test/hipcub/test_utils_data_generation.hpp
+++ b/test/hipcub/test_utils_data_generation.hpp
@@ -201,7 +201,7 @@ using convert_to_fundamental_t
     = std::conditional_t<is_half<T>::value || is_bfloat16<T>::value, float, T>;
 
 template<class T>
-inline auto convert_to_fundemental(T value)
+inline auto convert_to_fundamental(T value)
 {
     return static_cast<convert_to_fundamental_t<T>>(value);
 }

--- a/test/hipcub/test_utils_data_generation.hpp
+++ b/test/hipcub/test_utils_data_generation.hpp
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2021 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2021-2023 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -25,6 +25,8 @@
 
 // Std::memcpy and std::memcmp
 #include <cstring>
+
+#include <type_traits>
 
 #include "test_utils_half.hpp"
 #include "test_utils_bfloat16.hpp"
@@ -86,6 +88,123 @@ template<> class numeric_limits<test_utils::bfloat16> : public std::numeric_limi
     };
 };
 // End of extended numeric_limits
+
+template<class T>
+using is_half = std::is_same<test_utils::half, typename std::remove_cv<T>::type>;
+
+template<class T>
+using is_bfloat16 = std::is_same<test_utils::bfloat16, typename std::remove_cv<T>::type>;
+
+template<class T>
+using is_native_half = std::is_same<test_utils::native_half, typename std::remove_cv<T>::type>;
+
+template<class T>
+using is_native_bfloat16
+    = std::is_same<test_utils::native_bfloat16, typename std::remove_cv<T>::type>;
+
+template<class T>
+struct convert_to_native_t_impl
+{
+    using type = T;
+};
+
+template<>
+struct convert_to_native_t_impl<test_utils::bfloat16>
+{
+    using type = test_utils::native_bfloat16;
+};
+template<>
+struct convert_to_native_t_impl<test_utils::half>
+{
+    using type = test_utils::native_half;
+};
+
+template<class T>
+using convert_to_native_t = typename convert_to_native_t_impl<T>::type;
+
+// is_floating_point which supports custom_test_type<U> classes
+template<class T>
+struct is_special_floating_point
+    : std::integral_constant<bool,
+                             is_half<T>::value || is_bfloat16<T>::value || is_native_half<T>::value
+                                 || is_native_bfloat16<T>::value>
+{};
+
+template<class T>
+struct is_floating_point
+    : std::integral_constant<bool,
+                             std::is_floating_point<T>::value
+                                 || is_special_floating_point<T>::value>
+{};
+
+// is_integral which supports custom_test_type<U> classes
+template<class T>
+struct is_integral : std::integral_constant<bool, std::is_integral<T>::value>
+{};
+
+template<class T>
+struct is_arithmetic
+    : std::integral_constant<bool, is_integral<T>::value || is_floating_point<T>::value>
+{};
+
+// Converts possible device side types to their relevant host side native types
+inline test_utils::native_half convert_to_native(test_utils::half value)
+{
+    return test_utils::native_half(value);
+}
+
+inline test_utils::native_bfloat16 convert_to_native(const test_utils::bfloat16& value)
+{
+    return test_utils::native_bfloat16(value);
+}
+
+template<class T>
+inline auto convert_to_native(const T& value) ->
+    typename std::enable_if<!(is_half<T>::value || is_bfloat16<T>::value), T>::type
+{
+    return value;
+}
+
+// Converts possible host side native types to their relevant device side types
+template<class U, class T>
+inline auto convert_to_device(const T& value) ->
+    typename std::enable_if<is_half<U>::value, test_utils::half>::type
+{
+    return test_utils::native_to_half(value);
+}
+
+template<class U, class T>
+inline auto convert_to_device(T value) ->
+    typename std::enable_if<is_bfloat16<U>::value, test_utils::bfloat16>::type
+{
+#ifdef __HIP_PLATFORM_NVIDIA__
+    // __nv__bfloat16 has no cast from int and gets confused wether to
+    // cast via float or double.
+    if(std::is_integral<T>::value)
+    {
+        return test_utils::native_to_bfloat16(static_cast<float>(value));
+    }
+#endif
+
+    return test_utils::native_to_bfloat16(value);
+}
+
+template<class U, class T>
+inline auto convert_to_device(T value) ->
+    typename std::enable_if<!(is_half<U>::value || is_bfloat16<U>::value), U>::type
+{
+    return static_cast<U>(value);
+}
+
+template<class T>
+using convert_to_fundamental_t
+    = std::conditional_t<is_half<T>::value || is_bfloat16<T>::value, float, T>;
+
+template<class T>
+inline auto convert_to_fundemental(T value)
+{
+    return static_cast<convert_to_fundamental_t<T>>(value);
+}
 
 // Helper class to generate a vector of special values for any type
 template<class T>
@@ -187,7 +306,8 @@ inline auto get_random_data(size_t size, S min, U max, int seed_value)
     -> typename std::enable_if<!std::is_integral<T>::value && !is_custom_test_type<T>::value, std::vector<T>>::type
 {
     std::default_random_engine gen(seed_value);
-    using dis_type = typename std::conditional<std::is_same<test_utils::half, T>::value || std::is_same<test_utils::bfloat16, T>::value, float, T>::type;
+    using dis_type =
+        typename std::conditional<test_utils::is_special_floating_point<T>::value, float, T>::type;
     std::uniform_real_distribution<dis_type> distribution(static_cast<dis_type>(min), static_cast<dis_type>(max));
     std::vector<T> data(size);
     std::generate(
@@ -199,11 +319,13 @@ inline auto get_random_data(size_t size, S min, U max, int seed_value)
 }
 
 template<class T>
-inline auto get_random_data(size_t size, typename T::value_type min, typename T::value_type max, int seed_value)
-    -> typename std::enable_if<
-        is_custom_test_type<T>::value && std::is_integral<typename T::value_type>::value,
-        std::vector<T>
-        >::type
+inline auto get_random_data(size_t                 size,
+                            typename T::value_type min,
+                            typename T::value_type max,
+                            int                    seed_value) ->
+    typename std::enable_if<is_custom_test_type<T>::value
+                                && std::is_integral<typename T::value_type>::value,
+                            std::vector<T>>::type
 {
     std::default_random_engine gen(seed_value);
     using dis_type = typename std::conditional<
@@ -220,11 +342,13 @@ inline auto get_random_data(size_t size, typename T::value_type min, typename T:
 }
 
 template<class T>
-inline auto get_random_data(size_t size, typename T::value_type min, typename T::value_type max, int seed_value)
-    -> typename std::enable_if<
-        is_custom_test_type<T>::value && std::is_floating_point<typename T::value_type>::value,
-        std::vector<T>
-        >::type
+inline auto get_random_data(size_t                 size,
+                            typename T::value_type min,
+                            typename T::value_type max,
+                            int                    seed_value) ->
+    typename std::enable_if<is_custom_test_type<T>::value
+                                && std::is_floating_point<typename T::value_type>::value,
+                            std::vector<T>>::type
 {
     std::default_random_engine gen(seed_value);
     std::uniform_real_distribution<typename T::value_type> distribution(min, max);
@@ -234,8 +358,8 @@ inline auto get_random_data(size_t size, typename T::value_type min, typename T:
 }
 
 template<class T>
-inline auto get_random_value(T min, T max, int seed_value)
-    -> typename std::enable_if<std::is_arithmetic<T>::value, T>::type
+inline auto get_random_value(T min, T max, int seed_value) ->
+    typename std::enable_if<test_utils::is_arithmetic<T>::value, T>::type
 {
     return get_random_data<T>(1, min, max, seed_value)[0];
 }
@@ -247,10 +371,9 @@ inline std::vector<T> get_random_data01(size_t size, float p, int seed_value)
     std::default_random_engine gen(seed_value);
     std::bernoulli_distribution distribution(p);
     std::vector<T> data(size);
-    std::generate(
-        data.begin(), data.begin() + std::min(size, max_random_size),
-        [&]() { return distribution(gen); }
-    );
+    std::generate(data.begin(),
+                  data.begin() + std::min(size, max_random_size),
+                  [&]() { return convert_to_device<T>(distribution(gen)); });
     for(size_t i = max_random_size; i < size; i += max_random_size)
     {
         std::copy_n(data.begin(), std::min(size - i, max_random_size), data.begin() + i);
@@ -258,6 +381,6 @@ inline std::vector<T> get_random_data01(size_t size, float p, int seed_value)
     return data;
 }
 
-} // end test_utils namespace
+} // namespace test_utils
 
 #endif  // HIPCUB_TEST_HIPCUB_TEST_UTILS_DATA_GENERATION_HPP_

--- a/test/hipcub/test_utils_data_generation.hpp
+++ b/test/hipcub/test_utils_data_generation.hpp
@@ -35,6 +35,16 @@
 namespace test_utils
 {
 
+template<typename T>
+HIPCUB_HOST_DEVICE T set_half_bits(uint16_t value)
+{
+    T              half_value{};
+    unsigned char* char_representation = reinterpret_cast<unsigned char*>(&half_value);
+    char_representation[0]             = value;
+    char_representation[1]             = value >> 8;
+    return half_value;
+}
+
 // Numeric limits which also supports custom_test_type<U> classes
 template<class T>
 struct numeric_limits : std::numeric_limits<T>
@@ -47,44 +57,68 @@ template<> struct numeric_limits<test_utils::half> : public std::numeric_limits<
     static inline T min() {
         return T(0.00006104f);
     };
-    static inline T max() {
-        return T(65504.0f);
+    static inline T max()
+    {
+        return set_half_bits<T>(0x7bff);
     };
-    static inline T lowest() {
-        return T(-65504.0f);
+    static inline T lowest()
+    {
+        return set_half_bits<T>(0xfbff);
     };
-    static inline T infinity() {
-        return T(std::numeric_limits<float>::infinity());
+    static inline T infinity()
+    {
+        return set_half_bits<T>(0x7c00);
     };
     static inline T quiet_NaN() {
         return T(std::numeric_limits<float>::quiet_NaN());
     };
     static inline T signaling_NaN() {
         return T(std::numeric_limits<float>::signaling_NaN());
+    };
+    static inline T infinity_neg()
+    {
+        return set_half_bits<T>(0xfc00);
     };
 };
 
 template<> class numeric_limits<test_utils::bfloat16> : public std::numeric_limits<test_utils::bfloat16> {
     public:
     using T = test_utils::bfloat16;
-
-    static inline T max() {
-        return T(3.38953138925e+38f);
+    static inline T max()
+    {
+        return set_half_bits<T>(0x7f7f);
     };
-    static inline T min() {
+    static inline T min()
+    {
         return T(std::numeric_limits<float>::min());
     };
-    static inline T lowest() {
-        return T(-3.38953138925e+38f);
+    static inline T lowest()
+    {
+        return set_half_bits<T>(0xff7f);
     };
-    static inline T infinity() {
-        return T(std::numeric_limits<float>::infinity());
+    static inline T infinity()
+    {
+        return set_half_bits<T>(0x7f80);
     };
     static inline T quiet_NaN() {
         return T(std::numeric_limits<float>::quiet_NaN());
     };
     static inline T signaling_NaN() {
         return T(std::numeric_limits<float>::signaling_NaN());
+    };
+    static inline T infinity_neg()
+    {
+        return set_half_bits<T>(0xff80);
+    };
+};
+
+template<>
+class numeric_limits<float> : public std::numeric_limits<float>
+{
+public:
+    static inline float infinity_neg()
+    {
+        return -std::numeric_limits<float>::infinity();
     };
 };
 // End of extended numeric_limits

--- a/toolchain-linux.cmake
+++ b/toolchain-linux.cmake
@@ -14,29 +14,3 @@ endif()
 # set(CMAKE_C_COMPILER "hipcc")
 set(CMAKE_CXX_COMPILER "${rocm_bin}/hipcc")
 set(CMAKE_C_COMPILER "${rocm_bin}/hipcc")
-
-#set(CMAKE_CXX_LINKER "hipcc" )
-
-# TODO remove, just to speed up slow cmake
-# set(CMAKE_C_COMPILER_WORKS 1)
-# set(CMAKE_CXX_COMPILER_WORKS 1)
-#
-
-#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -IC:/hip/include -IC:/hip/lib/clang/12.0.0 -DWIN32 -D_CRT_SECURE_NO_WARNINGS")
-
-# flags for clang direct use
-#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -fms-extensions -fms-compatibility")
-# -Wno-ignored-attributes to avoid warning: __declspec attribute 'dllexport' is not supported [-Wignored-attributes] which is used by msvc compiler
-#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -fms-extensions -fms-compatibility -Wno-ignored-attributes")
-
-# flags for clang direct use with hip
-# -x hip causes linker error
-#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -x hip -IC:/hip/include/hip -D__HIP_PLATFORM_AMD__ -D__HIP_ROCclr__ -DHIP_CLANG_HCC_COMPAT_MODE=1")
-#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -IC:/hip/include/hip -D__HIP_PLATFORM_AMD__ -D__HIP_ROCclr__ -DHIP_CLANG_HCC_COMPAT_MODE=1")
-
-
-# set(GTEST_DIR "C:/rocm/Utils/GTestMSVC")
-# set(GTEST_INCLUDE_DIR "${GTEST_DIR}/include")
-# set(GTEST_LIBRARY "${GTEST_DIR}/lib/Release/gtest.lib")
-# set(GTEST_MAIN_LIBRARY "${GTEST_DIR}/lib/Release/gtest_main.lib")
-# set(GTEST_LIBRARIES "${GTEST_DIR}/lib/Release/gtest.lib;${GTEST_DIR}/lib/Release/gtest_main.lib")

--- a/toolchain-windows.cmake
+++ b/toolchain-windows.cmake
@@ -28,7 +28,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DWIN32 -D_CRT_SECURE_NO_WARNINGS")
 # -Wno-ignored-attributes to avoid warning: __declspec attribute 'dllexport' is not supported [-Wignored-attributes] which is used by msvc compiler
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -fms-extensions -fms-compatibility -Wno-ignored-attributes")
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__HIP_PLATFORM_AMD__ -D__HIP_ROCclr__ -DHIP_CLANG_HCC_COMPAT_MODE=1")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__HIP_PLATFORM_AMD__ -D__HIP_ROCclr__")
 
 if (DEFINED ENV{VCPKG_PATH})
   file(TO_CMAKE_PATH "$ENV{VCPKG_PATH}" VCPKG_PATH)


### PR DESCRIPTION
This PR adds improvements to existing algorithms/tests and solves several small bugs.
- `BlockRadixRank` and `BlockRadixRankMatch` are now implemented in terms of rocPRIM.
- hipCUB now matches CUB's 2.0.0 and 2.0.1 releases, except for some breaking changes left out of this PR.
- Extended floats are now present in more tests.
- Documentation is now updated to the current state of hipCUB.
- Fixed `DeviceSegmentedReduce::ArgMin` and `DeviceSegmentedReduce::ArgMax` for INF input .
- References to hcc have been removed.
- New overload of `StableSortKeysCopy` has been added to address part of CUB's 2.1.0 release.
- Several bug fixes and optimizations.