### PR TITLE
silence nodiscard warning for FreeAllCached()

### DIFF
--- a/hipcub/include/hipcub/backend/rocprim/util_allocator.hpp
+++ b/hipcub/include/hipcub/backend/rocprim/util_allocator.hpp
@@ -637,7 +637,8 @@ struct CachingDeviceAllocator
     virtual ~CachingDeviceAllocator()
     {
         if (!skip_cleanup)
-            FreeAllCached();
+            // silence warning: ignoring return value of function declared with 'nodiscard' attribute [-Wunused-result]
+            (void)FreeAllCached();
     }
 
 };


### PR DESCRIPTION
silences warning: ignoring return value of function declared with 'nodiscard' attribute [-Wunused-result]

Fixes SWDEV-328782.