### PR TITLE
Navi32 multiVF failing test

### DIFF
--- a/test/hipcub/test_hipcub_device_radix_sort.hpp
+++ b/test/hipcub/test_hipcub_device_radix_sort.hpp
@@ -615,7 +615,7 @@ inline void sort_keys_over_4g()
     HIP_CHECK(hipGetDeviceProperties(&dev_prop, device_id));
     // Radix sort requires 2 buffers of `size`, so a minimum of 8 GB of vram for this test.
     // This is more than some cards provide.
-    if(dev_prop.totalGlobalMem < size * 2 * sizeof(key_type))
+    if(static_cast<size_t>(dev_prop.totalGlobalMem * 0.9) < size * 2 * sizeof(key_type))
     {
         GTEST_SKIP() << "insufficient global memory";
     }

--- a/test/hipcub/test_hipcub_device_radix_sort.hpp
+++ b/test/hipcub/test_hipcub_device_radix_sort.hpp
@@ -613,6 +613,7 @@ inline void sort_keys_over_4g()
 
     hipDeviceProp_t dev_prop;
     HIP_CHECK(hipGetDeviceProperties(&dev_prop, device_id));
+    
     // Radix sort requires 2 buffers of `size`, so a minimum of 8 GB of vram for this test.
     // This is more than some cards provide.
     if(static_cast<size_t>(dev_prop.totalGlobalMem * 0.9) < size * 2 * sizeof(key_type))


### PR DESCRIPTION
Modify the device_radix_sort test (when requiring more than 4G) to check the memory before running the test. In this case, for Navi32 in the multiVF system it is necessary to keep at least 10% of the total global memory.