### PR TITLE
5.7 cherry pick - fix test device_radix_sort

### DIFF
--- a/test/hipcub/test_hipcub_device_radix_sort.hpp
+++ b/test/hipcub/test_hipcub_device_radix_sort.hpp
@@ -613,9 +613,10 @@ inline void sort_keys_over_4g()
 
     hipDeviceProp_t dev_prop;
     HIP_CHECK(hipGetDeviceProperties(&dev_prop, device_id));
+    
     // Radix sort requires 2 buffers of `size`, so a minimum of 8 GB of vram for this test.
     // This is more than some cards provide.
-    if(dev_prop.totalGlobalMem < size * 2 * sizeof(key_type))
+    if(static_cast<size_t>(dev_prop.totalGlobalMem * 0.9) < size * 2 * sizeof(key_type))
     {
         GTEST_SKIP() << "insufficient global memory";
     }


### PR DESCRIPTION
This 5.7 cherry pick fixes test device_radix_sort for Navi32 Multi VF.