### PR TITLE
Switch to GTEST_SKIP for gfx94x checks

### DIFF
--- a/test/hipcub/test_hipcub_iterators.cpp
+++ b/test/hipcub/test_hipcub_iterators.cpp
@@ -348,8 +348,7 @@ TYPED_TEST(HipcubIteratorTests, TestTexObj)
     std::string deviceName = std::string(props.gcnArchName);
     if (deviceName.rfind("gfx94", 0) == 0) {
         // This is a gfx94x device, so skip this test
-        SCOPED_TRACE(testing::Message() << "Skipping texture cache text for " << deviceName);
-        return;
+        GTEST_SKIP() << "Test not run on gfx94x as texture cache API is not supported";
     }
 
     HIP_CHECK(hipSetDevice(device_id));
@@ -416,8 +415,7 @@ TYPED_TEST(HipcubIteratorTests, TestTexRef)
     std::string deviceName = std::string(props.gcnArchName);
     if (deviceName.rfind("gfx94", 0) == 0) {
         // This is a gfx94x device, so skip this test
-        SCOPED_TRACE(testing::Message() << "Skipping texture cache text for " << deviceName);
-        return;
+        GTEST_SKIP() << "Test not run on gfx94x as texture cache API is not supported";
     }
 
     HIP_CHECK(hipSetDevice(device_id));
@@ -488,8 +486,7 @@ TYPED_TEST(HipcubIteratorTests, TestTexTransform)
     std::string deviceName = std::string(props.gcnArchName);
     if (deviceName.rfind("gfx94", 0) == 0) {
         // This is a gfx94x device, so skip this test
-        SCOPED_TRACE(testing::Message() << "Skipping texture cache text for " << deviceName);
-        return;
+        GTEST_SKIP() << "Test not run on gfx94x as texture cache API is not supported";
     }
 
     HIP_CHECK(hipSetDevice(device_id));
@@ -542,6 +539,6 @@ TYPED_TEST(HipcubIteratorTests, TestTexTransform)
         g_allocator.DeviceFree(d_data);
     }
 }
-#if defined(__gfx940__) || defined(__gfx941__) || defined(__gfx942__)
-#pragma message "Skipping texture cache iterator test compilation for gfx94x as it is not supported."
-#else
+#endif
+
+

--- a/test/hipcub/test_hipcub_iterators.cpp
+++ b/test/hipcub/test_hipcub_iterators.cpp
@@ -335,9 +335,7 @@ TYPED_TEST(HipcubIteratorTests, TestTransform)
 
     g_allocator.DeviceFree(d_data);
 }
-#if defined(__gfx940__) || defined(__gfx941__) || defined(__gfx942__)
-#pragma message "Skipping texture cache iterator test compilation for gfx94x as it is not supported."
-#else
+
 TYPED_TEST(HipcubIteratorTests, TestTexObj)
 {
     int device_id = test_common_utils::obtain_device_from_ctest();
@@ -539,4 +537,3 @@ TYPED_TEST(HipcubIteratorTests, TestTexTransform)
         g_allocator.DeviceFree(d_data);
     }
 }
-#endif

--- a/test/hipcub/test_hipcub_iterators.cpp
+++ b/test/hipcub/test_hipcub_iterators.cpp
@@ -540,5 +540,3 @@ TYPED_TEST(HipcubIteratorTests, TestTexTransform)
     }
 }
 #endif
-
-

--- a/test/hipcub/test_hipcub_iterators.cpp
+++ b/test/hipcub/test_hipcub_iterators.cpp
@@ -335,7 +335,9 @@ TYPED_TEST(HipcubIteratorTests, TestTransform)
 
     g_allocator.DeviceFree(d_data);
 }
-
+#if defined(__gfx940__) || defined(__gfx941__) || defined(__gfx942__)
+#pragma message "Skipping texture cache iterator test compilation for gfx94x as it is not supported."
+#else
 TYPED_TEST(HipcubIteratorTests, TestTexObj)
 {
     int device_id = test_common_utils::obtain_device_from_ctest();
@@ -540,3 +542,6 @@ TYPED_TEST(HipcubIteratorTests, TestTexTransform)
         g_allocator.DeviceFree(d_data);
     }
 }
+#if defined(__gfx940__) || defined(__gfx941__) || defined(__gfx942__)
+#pragma message "Skipping texture cache iterator test compilation for gfx94x as it is not supported."
+#else


### PR DESCRIPTION
When I tried running these tests on gfx94x, I did not see any of the SCOPED_TRACE messages.  I think SCOPED_TRACE only prints if there's an explicit assert failure in gtest in the same scope.(https://github.com/google/googletest/blob/main/docs/advanced.md#using-assertions-in-sub-routines)

I think GTEST_SKIP would serve our purposes better.