### PR TITLE
366827 - Disable file reorg backward compatibility support by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,8 +98,8 @@ option(DOWNLOAD_CUB "Download CUB and thrust. Do not search for CUB package" OFF
 option(BUILD_BENCHMARK "Build benchmarks" OFF)
 option(BUILD_EXAMPLE "Build Examples" OFF)
 option(BUILD_ADDRESS_SANITIZER "Build with address sanitizer enabled" OFF)
-#Set the header wrapper ON by default. 
-option(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY "Build with file/folder reorg with backward compatibility enabled" ON)
+#Set the header wrapper OFF by default.
+option(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY "Build with file/folder reorg with backward compatibility enabled" OFF)
 
 if(BUILD_ADDRESS_SANITIZER)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address -shared-libasan")

--- a/install
+++ b/install
@@ -36,7 +36,7 @@ build_relocatable=false
 install_dependencies=false
 build_address_sanitizer=false
 build_benchmark=false
-build_freorg_bkwdcomp=true
+build_freorg_bkwdcomp=false
 
 # #################################################
 # Parameter parsing


### PR DESCRIPTION
Changes Proposed
- File Reorg backward compatibility option set to OFF
- Backward Compatibility flag in install script set to false by default.