### PR TITLE
 Treat Doxygen warnings as errors

### DIFF
--- a/docs/.doxygen/Doxyfile
+++ b/docs/.doxygen/Doxyfile
@@ -754,7 +754,7 @@ WARN_NO_PARAMDOC       = NO
 # a warning is encountered.
 # The default value is: NO.
 
-WARN_AS_ERROR          = NO
+WARN_AS_ERROR          = YES
 
 # The WARN_FORMAT tag determines the format of the warning messages that doxygen
 # can produce. The string should contain the $file, $line, and $text tags, which
@@ -838,7 +838,7 @@ EXCLUDE_SYMLINKS       = NO
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories for example use the pattern */test/*
 
-EXCLUDE_PATTERNS       = */detail/*
+EXCLUDE_PATTERNS       = */detail/*,*/backend/*
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
 # (namespaces, classes, functions, etc.) that should be excluded from the

--- a/hipcub/include/hipcub/backend/rocprim/block/block_merge_sort.hpp
+++ b/hipcub/include/hipcub/backend/rocprim/block/block_merge_sort.hpp
@@ -203,7 +203,6 @@ private:
   const unsigned int linear_tid;
 
 public:
-  /// \smemstorage{BlockMergeSort}
   struct TempStorage : Uninitialized<_TempStorage> {};
 
   BlockMergeSortStrategy() = delete;
@@ -704,7 +703,6 @@ private:
  *   arithmetic types into ascending/descending order.
  *
  * @par A Simple Example
- * @blockcollective{BlockMergeSort}
  * @par
  * The code snippet below illustrates a sort of 512 integer keys that are
  * partitioned across 128 threads * where each thread owns 4 consecutive items.

--- a/hipcub/include/hipcub/backend/rocprim/block/block_radix_rank.hpp
+++ b/hipcub/include/hipcub/backend/rocprim/block/block_radix_rank.hpp
@@ -86,15 +86,14 @@ struct DigitExtractorAdopter
  * \tparam SMEM_CONFIG          <b>[optional]</b> Shared memory bank mode (default: \p hipSharedMemBankSizeFourByte)
  * \tparam BLOCK_DIM_Y          <b>[optional]</b> The thread block length in threads along the Y dimension (default: 1)
  * \tparam BLOCK_DIM_Z          <b>[optional]</b> The thread block length in threads along the Z dimension (default: 1)
- * \tparam ARCH                 <b>[optional]</b> \ptxversion
+ * \tparam ARCH                 <b>[optional]</b> ptx version
  *
  * \par Overview
  * Blah...
  * - Keys must be in a form suitable for radix ranking (i.e., unsigned bits).
- * - \blocked
  *
  * \par Performance Considerations
- * - \granularity
+ * - granularity
  *
  * \par Examples
  * \par

--- a/hipcub/include/hipcub/backend/rocprim/block/block_raking_layout.hpp
+++ b/hipcub/include/hipcub/backend/rocprim/block/block_raking_layout.hpp
@@ -57,7 +57,7 @@ BEGIN_HIPCUB_NAMESPACE
  *
  * \tparam T                        The data type to be exchanged.
  * \tparam BLOCK_THREADS            The thread block size in threads.
- * \tparam PTX_ARCH                 <b>[optional]</b> \ptxversion
+ * \tparam PTX_ARCH                 <b>[optional]</b> ptx version
  */
 template<typename T, int BLOCK_THREADS, int ARCH = HIPCUB_ARCH /* ignored */
          >

--- a/hipcub/include/hipcub/backend/rocprim/block/block_run_length_decode.hpp
+++ b/hipcub/include/hipcub/backend/rocprim/block/block_run_length_decode.hpp
@@ -316,7 +316,6 @@ public:
    * \p item_offsets can be used to retrieve each run-length decoded item's relative index within its run. E.g., the
    * run-length encoded array of `3, 1, 4` with the respective run lengths of `2, 1, 3` would yield the run-length
    * decoded array of `3, 3, 1, 4, 4, 4` with the relative offsets of `0, 1, 0, 0, 1, 2`.
-   * \smemreuse
    *
    * \param[out] decoded_items The run-length decoded items to be returned in a blocked arrangement
    * \param[out] item_offsets The run-length decoded items' relative offset within the run they belong to

--- a/hipcub/include/hipcub/backend/rocprim/block/block_shuffle.hpp
+++ b/hipcub/include/hipcub/backend/rocprim/block/block_shuffle.hpp
@@ -85,9 +85,6 @@ public:
 
   /**
    * \brief Each <em>thread<sub>i</sub></em> obtains the \p input provided by <em>thread</em><sub><em>i</em>+<tt>distance</tt></sub>. The offset \p distance may be negative.
-   *
-   * \par
-   * - \smemreuse
    */
   HIPCUB_DEVICE inline void Offset(
       T   input,                  ///< [in] The input item from the calling thread (<em>thread<sub>i</sub></em>)
@@ -99,24 +96,16 @@ public:
 
   /**
  * \brief Each <em>thread<sub>i</sub></em> obtains the \p input provided by <em>thread</em><sub><em>i</em>+<tt>distance</tt></sub>.
- *
- * \par
- * - \smemreuse
  */
   HIPCUB_DEVICE inline void Rotate(
       T   input,                  ///< [in] The calling thread's input item
-      T&  output,                 ///< [out] The \p input item from thread <em>thread</em><sub>(<em>i</em>+<tt>distance></tt>)%<tt><BLOCK_THREADS></tt></sub> (may be aliased to \p input).  This value is not updated for <em>thread</em><sub>BLOCK_THREADS-1</sub>
+      T&  output,                 ///< [out] The \p input item from thread <em>thread</em><sub>(<em>i</em>+<tt>distance></tt>)%<tt>\<BLOCK_THREADS\></tt></sub> (may be aliased to \p input).  This value is not updated for <em>thread</em><sub>BLOCK_THREADS-1</sub>
       unsigned int distance = 1)  ///< [in] Offset distance (0 < \p distance < <tt>BLOCK_THREADS</tt>)
   {
     base_type::rotate(input,output,distance);
   }
   /**
   * \brief The thread block rotates its [<em>blocked arrangement</em>](index.html#sec5sec3) of \p input items, shifting it up by one item
-  *
-  * \par
-  * - \blocked
-  * - \granularity
-  * - \smemreuse
   */
   template <int ITEMS_PER_THREAD>
   HIPCUB_DEVICE inline void Up(
@@ -129,11 +118,6 @@ public:
 
    /**
    * \brief The thread block rotates its [<em>blocked arrangement</em>](index.html#sec5sec3) of \p input items, shifting it up by one item.  All threads receive the \p input provided by <em>thread</em><sub><tt>BLOCK_THREADS-1</tt></sub>.
-   *
-   * \par
-   * - \blocked
-   * - \granularity
-   * - \smemreuse
    */
   template <int ITEMS_PER_THREAD>
   HIPCUB_DEVICE inline void Up(
@@ -146,11 +130,6 @@ public:
 
    /**
    * \brief The thread block rotates its [<em>blocked arrangement</em>](index.html#sec5sec3) of \p input items, shifting it down by one item
-   *
-   * \par
-   * - \blocked
-   * - \granularity
-   * - \smemreuse
    */
   template <int ITEMS_PER_THREAD>
   HIPCUB_DEVICE inline void Down(
@@ -162,11 +141,6 @@ public:
 
    /**
    * \brief The thread block rotates its [<em>blocked arrangement</em>](index.html#sec5sec3) of input items, shifting it down by one item.  All threads receive \p input[0] provided by <em>thread</em><sub><tt>0</tt></sub>.
-   *
-   * \par
-   * - \blocked
-   * - \granularity
-   * - \smemreuse
    */
   template <int ITEMS_PER_THREAD>
   HIPCUB_DEVICE inline void Down(

--- a/hipcub/include/hipcub/backend/rocprim/thread/thread_scan.hpp
+++ b/hipcub/include/hipcub/backend/rocprim/thread/thread_scan.hpp
@@ -54,8 +54,8 @@ namespace internal {
      typename    T,
      typename    ScanOp>
  __device__ __forceinline__ T ThreadScanExclusive(
-     T                   inclusive,
-     T                   exclusive,
+     T                   inclusive,              ///< [in] Initial value for inclusive aggregate
+     T                   exclusive,              ///< [in] Initial value for exclusive aggregate
      T                   *input,                 ///< [in] Input array
      T                   *output,                ///< [out] Output array (may be aliased to \p input)
      ScanOp              scan_op,                ///< [in] Binary scan operator
@@ -131,7 +131,7 @@ namespace internal {
      typename    T,
      typename    ScanOp>
  __device__ __forceinline__ T ThreadScanInclusive(
-     T                   inclusive,
+     T                   inclusive,              ///< [in] Initial value for inclusive aggregate
      T                   *input,                 ///< [in] Input array
      T                   *output,                ///< [out] Output array (may be aliased to \p input)
      ScanOp              scan_op,                ///< [in] Binary scan operator

--- a/hipcub/include/hipcub/backend/rocprim/warp/warp_merge_sort.hpp
+++ b/hipcub/include/hipcub/backend/rocprim/warp/warp_merge_sort.hpp
@@ -63,7 +63,7 @@ BEGIN_HIPCUB_NAMESPACE
  *   keys-only sort)
  *
  * @tparam PTX_ARCH
- *   <b>[optional]</b> \ptxversion
+ *   <b>[optional]</b> ptx version
  *
  * @par Overview
  *   WarpMergeSort arranges items into ascending order using a comparison


### PR DESCRIPTION
* Turned on WARN_AS_ERROR in the Doxyfile
* Added "backend/" to excluded directories in Doxyfile, since it just makes calls into CUB/rocPRIM, each of which have their own existing documentation.
* Fixed scenarios generating warnings when the documentation is built:
  - Removed unsupported tags/commands
  - Added escape characters
  - Added missing parameter documentation