### PR TITLE
Cherry-pick cpp-check reported fixes

### DIFF
--- a/benchmark/benchmark_block_adjacent_difference.cpp
+++ b/benchmark/benchmark_block_adjacent_difference.cpp
@@ -97,7 +97,7 @@ struct subtract_left
 struct subtract_left_partial_tile
 {
     template <unsigned int BlockSize, unsigned int ItemsPerThread, bool WithTile, typename T>
-    __device__ static void run(const T* d_input, int* tile_sizes, T* d_output, unsigned int trials)
+    __device__ static void run(const T* d_input, const int* tile_sizes, T* d_output, unsigned int trials)
     {
         const unsigned int lid = threadIdx.x;
         const unsigned int block_offset = blockIdx.x * ItemsPerThread * BlockSize;
@@ -185,7 +185,7 @@ struct subtract_right
 struct subtract_right_partial_tile
 {
     template <unsigned int BlockSize, unsigned int ItemsPerThread, bool WithTile, typename T>
-    __device__ static void run(const T* d_input, int* tile_sizes, T* d_output, unsigned int trials)
+    __device__ static void run(const T* d_input, const int* tile_sizes, T* d_output, unsigned int trials)
     {
         const unsigned int lid = threadIdx.x;
         const unsigned int block_offset = blockIdx.x * ItemsPerThread * BlockSize;

--- a/benchmark/benchmark_block_discontinuity.cpp
+++ b/benchmark/benchmark_block_discontinuity.cpp
@@ -38,7 +38,7 @@ template<class T>
 struct custom_flag_op1
 {
     HIPCUB_HOST_DEVICE
-    bool operator()(const T& a, const T& b)
+    bool operator()(const T& a, const T& b) const
     {
         return (a == b);
     }

--- a/benchmark/benchmark_device_memory.cpp
+++ b/benchmark/benchmark_device_memory.cpp
@@ -348,24 +348,14 @@ void run_benchmark(benchmark::State& state, size_t size, const hipStream_t strea
 template<typename T>
 void run_benchmark_memcpy(benchmark::State& state, size_t size, const hipStream_t stream)
 {
-    std::vector<T> input;
-    if(std::is_floating_point<T>::value)
-    {
-        input = benchmark_utils::get_random_data<T>(size, (T)-1000, (T) + 1000);
-    }
-    else
-    {
-        input = benchmark_utils::get_random_data<T>(size,
-                                                    std::numeric_limits<T>::min(),
-                                                    std::numeric_limits<T>::max());
-    }
+    // Allocate device buffers
+    // Note: since this benchmark only tests memcpy performance between device buffers,
+    // we don't really need to copy data into these from the host - whatever happens
+    // to be in memory will suffice.
     T* d_input;
     T* d_output;
     HIP_CHECK(hipMalloc(reinterpret_cast<void**>(&d_input), size * sizeof(T)));
     HIP_CHECK(hipMalloc(reinterpret_cast<void**>(&d_output), size * sizeof(T)));
-
-    // Copy input from host to device
-    HIP_CHECK(hipMemcpy(d_input, input.data(), input.size() * sizeof(T), hipMemcpyHostToDevice));
 
     // Warm-up
     for(size_t i = 0; i < 10; i++)

--- a/benchmark/benchmark_device_memory.cpp
+++ b/benchmark/benchmark_device_memory.cpp
@@ -60,7 +60,7 @@ struct operation<no_operation, T, ItemsPerThread, BlockSize>
 {
     typedef empty_storage_type storage_type;
 
-    HIPCUB_DEVICE inline void operator()(storage_type& storage, T (&)[ItemsPerThread], T* = nullptr)
+    HIPCUB_DEVICE inline void operator()(storage_type& storage, T (&)[ItemsPerThread], T* = nullptr) const
     {}
 };
 
@@ -72,7 +72,7 @@ struct operation<custom_operation, T, ItemsPerThread, BlockSize>
 
     HIPCUB_DEVICE inline void operator()(storage_type& storage,
                                          T (&input)[ItemsPerThread],
-                                         T* global_mem_output = nullptr)
+                                         T* global_mem_output = nullptr) const
     {
         (void)storage;
         (void)global_mem_output;
@@ -363,6 +363,10 @@ void run_benchmark_memcpy(benchmark::State& state, size_t size, const hipStream_
     T* d_output;
     HIP_CHECK(hipMalloc(reinterpret_cast<void**>(&d_input), size * sizeof(T)));
     HIP_CHECK(hipMalloc(reinterpret_cast<void**>(&d_output), size * sizeof(T)));
+
+    // Copy input from host to device
+    HIP_CHECK(hipMemcpy(d_input, input.data(), input.size() * sizeof(T), hipMemcpyHostToDevice));
+
     // Warm-up
     for(size_t i = 0; i < 10; i++)
     {

--- a/benchmark/benchmark_device_select.cpp
+++ b/benchmark/benchmark_device_select.cpp
@@ -38,7 +38,6 @@ void run_flagged_benchmark(benchmark::State& state,
 {
     std::vector<T> input;
     std::vector<FlagType> flags = benchmark_utils::get_random_data01<FlagType>(size, true_probability);
-    std::vector<unsigned int> selected_count_output(1);
     if(std::is_floating_point<T>::value)
     {
         input = benchmark_utils::get_random_data<T>(size, T(-1000), T(1000));
@@ -160,7 +159,6 @@ void run_selectop_benchmark(benchmark::State& state,
                             float true_probability)
 {
     std::vector<T> input = benchmark_utils::get_random_data<T>(size, T(0), T(1000));
-    std::vector<unsigned int> selected_count_output(1);
 
     auto select_op = [true_probability] __device__ (const T& value) -> bool
     {
@@ -278,7 +276,6 @@ void run_unique_benchmark(benchmark::State& state,
             input[i] = op(acc, input01[i]);
         }
     }
-    std::vector<unsigned int> selected_count_output(1);
 
     T * d_input;
     T * d_output;

--- a/benchmark/benchmark_utils.hpp
+++ b/benchmark/benchmark_utils.hpp
@@ -206,7 +206,7 @@ struct custom_type
     U y;
 
     HIPCUB_HOST_DEVICE inline
-    constexpr custom_type() {}
+    constexpr custom_type() : x(T()), y(U()) {}
 
     HIPCUB_HOST_DEVICE inline
     constexpr custom_type(T xx, U yy) : x(xx), y(yy)
@@ -220,10 +220,8 @@ struct custom_type
 
     template<class V, class W = V>
     HIPCUB_HOST_DEVICE inline
-    custom_type(const custom_type<V,W>& other)
+    custom_type(const custom_type<V,W>& other) : x(other.x), y(other.y)
     {
-        x = other.x;
-        y = other.y;
     }
 
     #ifndef HIPCUB_CUB_API

--- a/benchmark/benchmark_warp_scan.cpp
+++ b/benchmark/benchmark_warp_scan.cpp
@@ -98,7 +98,6 @@ struct broadcast
 
         using wscan_t = hipcub::WarpScan<T, WarpSize>;
         __shared__ typename wscan_t::TempStorage storage;
-        auto                                     scan_op = hipcub::Sum();
 #pragma nounroll
         for(unsigned int trial = 0; trial < Trials; trial++)
         {

--- a/benchmark/cmdparser.hpp
+++ b/benchmark/cmdparser.hpp
@@ -95,7 +95,7 @@ namespace cli {
                 CmdBase(name, alternative, description, required, dominant, ArgumentCountChecker<T>::Variadic) {
             }
 
-            virtual bool parse(std::ostream& output, std::ostream& error) {
+            virtual bool parse(std::ostream& output, std::ostream& error) override {
                 try {
                     CallbackArgs args { arguments, output, error };
                     value = callback(args);
@@ -105,7 +105,7 @@ namespace cli {
                 }
             }
 
-            virtual std::string print_value() const {
+            virtual std::string print_value() const override {
                 return "";
             }
 
@@ -117,10 +117,10 @@ namespace cli {
         class CmdArgument final : public CmdBase {
         public:
             explicit CmdArgument(const std::string& name, const std::string& alternative, const std::string& description, bool required, bool dominant) :
-                CmdBase(name, alternative, description, required, dominant, ArgumentCountChecker<T>::Variadic) {
+                CmdBase(name, alternative, description, required, dominant, ArgumentCountChecker<T>::Variadic), value(T()) {
             }
 
-            virtual bool parse(std::ostream&, std::ostream&) {
+            virtual bool parse(std::ostream&, std::ostream&) override {
                 try {
                     value = Parser::parse(arguments, value);
                     return true;
@@ -129,7 +129,7 @@ namespace cli {
                 }
             }
 
-            virtual std::string print_value() const {
+            virtual std::string print_value() const override {
                 return stringify(value);
             }
 

--- a/test/hipcub/bfloat16.hpp
+++ b/test/hipcub/bfloat16.hpp
@@ -143,7 +143,7 @@ struct bfloat16_t
 
     /// Get raw storage
     __host__ __device__ __forceinline__
-    uint16_t raw()
+    uint16_t raw() const
     {
         return this->__x;
     }
@@ -156,7 +156,7 @@ struct bfloat16_t
 
     /// Inequality
     __host__ __device__ __forceinline__
-    bool operator !=(const bfloat16_t &other)
+    bool operator !=(const bfloat16_t &other) const
     {
         return (this->__x != other.__x);
     }

--- a/test/hipcub/experimental/sparse_matrix.hpp
+++ b/test/hipcub/experimental/sparse_matrix.hpp
@@ -144,7 +144,7 @@ struct CooMatrix
         OffsetT            col;
         ValueT             val;
 
-        CooTuple() {}
+        CooTuple() : row(OffsetT(), col(OffsetT()), val(ValueT()) {}
         CooTuple(OffsetT row, OffsetT col) : row(row), col(col) {}
         CooTuple(OffsetT row, OffsetT col, ValueT val) : row(row), col(col), val(val) {}
 
@@ -250,7 +250,7 @@ struct CooMatrix
      * Builds a COO sparse from a relabeled CSR matrix.
      */
     template <typename CsrMatrixT>
-    void InitCsrRelabel(CsrMatrixT &csr_matrix, OffsetT* relabel_indices)
+    void InitCsrRelabel(CsrMatrixT &csr_matrix, const OffsetT* relabel_indices)
     {
         if (coo_tuples)
         {
@@ -282,7 +282,7 @@ struct CooMatrix
     /**
      * Builds a METIS COO sparse from the given file.
      */
-    void InitMetis(const string &metis_filename)
+    void InitMetis(const string &metis_filename) const
     {
         if (coo_tuples)
         {
@@ -807,7 +807,7 @@ struct CsrMatrix
         Clear();
     }
 
-    GraphStats Stats()
+    GraphStats Stats() const
     {
         GraphStats stats;
         stats.num_rows = num_rows;
@@ -912,8 +912,6 @@ struct CsrMatrix
 
         double s_xx     = ss_x / num_nonzeros;
         double s_yy     = ss_y / num_nonzeros;
-
-        double deming_slope = (s_yy - s_xx + sqrt(((s_yy - s_xx) * (s_yy - s_xx)) + (4 * s_xy * s_xy))) / (2 * s_xy);
 
         stats.pearson_r = (num_nonzeros * s_xy) / (sqrt(ss_x) * sqrt(ss_y));
 
@@ -1077,7 +1075,7 @@ struct OrderByLow
     OffsetT* row_degrees;
     OrderByLow(OffsetT* row_degrees) : row_degrees(row_degrees) {}
 
-    bool operator()(const OffsetT &a, const OffsetT &b)
+    bool operator()(const OffsetT &a, const OffsetT &b) const
     {
         if (row_degrees[a] < row_degrees[b])
             return true;
@@ -1095,7 +1093,7 @@ struct OrderByHigh
     OffsetT* row_degrees;
     OrderByHigh(OffsetT* row_degrees) : row_degrees(row_degrees) {}
 
-    bool operator()(const OffsetT &a, const OffsetT &b)
+    bool operator()(const OffsetT &a, const OffsetT &b) const
     {
         if (row_degrees[a] > row_degrees[b])
             return true;

--- a/test/hipcub/half.hpp
+++ b/test/hipcub/half.hpp
@@ -187,21 +187,21 @@ struct half_t
 
     /// Get raw storage
     __host__ __device__ __forceinline__
-    uint16_t raw()
+    uint16_t raw() const
     {
         return this->__x;
     }
 
     /// Equality
     __host__ __device__ __forceinline__
-    bool operator ==(const half_t &other)
+    bool operator ==(const half_t &other) const
     {
         return (this->__x == other.__x);
     }
 
     /// Inequality
     __host__ __device__ __forceinline__
-    bool operator !=(const half_t &other)
+    bool operator !=(const half_t &other) const
     {
         return (this->__x != other.__x);
     }

--- a/test/hipcub/identity_iterator.hpp
+++ b/test/hipcub/identity_iterator.hpp
@@ -85,34 +85,34 @@ public:
     }
 
     HIPCUB_HOST_DEVICE inline
-    reference operator[](difference_type n) const
+    reference operator[](const difference_type& n) const
     {
         return *(ptr_ + n);
     }
 
     HIPCUB_HOST_DEVICE inline
-    identity_iterator operator+(difference_type distance) const
+    identity_iterator operator+(const difference_type& distance) const
     {
         auto i = ptr_ + distance;
         return identity_iterator(i);
     }
 
     HIPCUB_HOST_DEVICE inline
-    identity_iterator& operator+=(difference_type distance)
+    identity_iterator& operator+=(const difference_type& distance)
     {
         ptr_ += distance;
         return *this;
     }
 
     HIPCUB_HOST_DEVICE inline
-    identity_iterator operator-(difference_type distance) const
+    identity_iterator operator-(const difference_type& distance) const
     {
         auto i = ptr_ - distance;
         return identity_iterator(i);
     }
 
     HIPCUB_HOST_DEVICE inline
-    identity_iterator& operator-=(difference_type distance)
+    identity_iterator& operator-=(const difference_type& distance)
     {
         ptr_ -= distance;
         return *this;

--- a/test/hipcub/test_hipcub_block_adjacent_difference.cpp
+++ b/test/hipcub/test_hipcub_block_adjacent_difference.cpp
@@ -55,7 +55,7 @@ template<class T>
 struct custom_flag_op1
 {
     HIPCUB_HOST_DEVICE
-    bool operator()(const T& a, const T& b, int b_index)
+    bool operator()(const T& a, const T& b, int b_index) const
     {
         return (a == b) || (b_index % 10 == 0);
     }

--- a/test/hipcub/test_hipcub_block_discontinuity.cpp
+++ b/test/hipcub/test_hipcub_block_discontinuity.cpp
@@ -54,7 +54,7 @@ template<class T>
 struct custom_flag_op1
 {
     HIPCUB_HOST_DEVICE
-    bool operator()(const T& a, const T& b)
+    bool operator()(const T& a, const T& b) const
     {
         return (a == b);
     }

--- a/test/hipcub/test_hipcub_device_reduce.cpp
+++ b/test/hipcub/test_hipcub_device_reduce.cpp
@@ -298,7 +298,7 @@ struct ArgMinDispatch
                     OutputIteratorT d_out,
                     int             num_items,
                     hipStream_t     stream,
-                    bool            debug_synchronous)
+                    bool            debug_synchronous) const
     {
         return hipcub::DeviceReduce::ArgMin(d_temp_storage,
                                             temp_storage_bytes,
@@ -319,7 +319,7 @@ struct ArgMaxDispatch
                     OutputIteratorT d_out,
                     int             num_items,
                     hipStream_t     stream,
-                    bool            debug_synchronous)
+                    bool            debug_synchronous) const
     {
         return hipcub::DeviceReduce::ArgMax(d_temp_storage,
                                             temp_storage_bytes,

--- a/test/hipcub/test_hipcub_device_scan.cpp
+++ b/test/hipcub/test_hipcub_device_scan.cpp
@@ -782,12 +782,12 @@ public:
     __host__ __device__ single_index_iterator& operator=(const single_index_iterator&) = default;
 
     // clang-format off
-    __host__ __device__ bool operator==(const single_index_iterator& rhs) { return index_ == rhs.index_; }
-    __host__ __device__ bool operator!=(const single_index_iterator& rhs) { return !(this == rhs);       }
+    __host__ __device__ bool operator==(const single_index_iterator& rhs) const { return index_ == rhs.index_; }
+    __host__ __device__ bool operator!=(const single_index_iterator& rhs) const { return !(this == rhs);       }
 
     __host__ __device__ reference operator*() { return value_type{value_, index_ == expected_index_}; }
 
-    __host__ __device__ reference operator[](const difference_type distance) { return *(*this + distance); }
+    __host__ __device__ reference operator[](const difference_type distance) const { return *(*this + distance); }
 
     __host__ __device__ single_index_iterator& operator+=(const difference_type rhs) { index_ += rhs; return *this; }
     __host__ __device__ single_index_iterator& operator-=(const difference_type rhs) { index_ -= rhs; return *this; }

--- a/test/hipcub/test_hipcub_device_segmented_reduce.cpp
+++ b/test/hipcub/test_hipcub_device_segmented_reduce.cpp
@@ -575,7 +575,7 @@ struct ArgMinDispatch
                     OffsetIteratorT d_begin_offsets,
                     OffsetIteratorT d_end_offsets,
                     hipStream_t     stream,
-                    bool            debug_synchronous)
+                    bool            debug_synchronous) const
     {
         return hipcub::DeviceSegmentedReduce::ArgMin(d_temp_storage,
                                                      temp_storage_bytes,
@@ -600,7 +600,7 @@ struct ArgMaxDispatch
                     OffsetIteratorT d_begin_offsets,
                     OffsetIteratorT d_end_offsets,
                     hipStream_t     stream,
-                    bool            debug_synchronous)
+                    bool            debug_synchronous) const
     {
         return hipcub::DeviceSegmentedReduce::ArgMax(d_temp_storage,
                                                      temp_storage_bytes,
@@ -812,8 +812,6 @@ void test_argminmax_allinf(TypeParam value, TypeParam empty_value)
         SCOPED_TRACE(testing::Message() << "with seed= " << seed_value);
 
         // Generate data and calculate expected results
-        std::vector<key_value> aggregates_expected;
-
         std::vector<input_type> values_input(size, value);
 
         std::vector<offset_type> offsets;

--- a/test/hipcub/test_hipcub_device_spmv.cpp
+++ b/test/hipcub/test_hipcub_device_spmv.cpp
@@ -110,8 +110,8 @@ template <
     typename OffsetType>
 void SpmvGold(
     CsrMatrix<T, OffsetType>&  a,
-    T*                         vector_x,
-    T*                         vector_y_in,
+    const T*                         vector_x,
+    const T*                         vector_y_in,
     T*                         vector_y_out,
     T                          alpha,
     T                          beta)

--- a/test/hipcub/test_hipcub_grid.cpp
+++ b/test/hipcub/test_hipcub_grid.cpp
@@ -93,7 +93,7 @@ template<
     typename OffsetT
 >
 __global__ void KernelGridEvenShare(
-    T* device_output,
+    const T* device_output,
     T* device_output_reductions,
     hipcub::GridEvenShare<OffsetT>  even_share)
 {
@@ -208,7 +208,7 @@ template<
     typename OffsetT
 >
 __global__ void KernelGridQueue(
-    T* device_output,
+    const T* device_output,
     T* device_output_reductions,
     OffsetT num_tiles,
     hipcub::GridQueue<OffsetT> tile_queue)

--- a/test/hipcub/test_hipcub_iterators.cpp
+++ b/test/hipcub/test_hipcub_iterators.cpp
@@ -93,7 +93,7 @@ struct TransformOp
 struct SelectOp
 {
     template <typename T>
-    __host__ __device__ __forceinline__ bool operator()(T input)
+    __host__ __device__ __forceinline__ bool operator()(T input) const
     {
         (void) input;
         return true;

--- a/test/hipcub/test_hipcub_util_ptx.cpp
+++ b/test/hipcub/test_hipcub_util_ptx.cpp
@@ -39,7 +39,7 @@ struct custom_notaligned
     unsigned int u;
 
     HIPCUB_HOST_DEVICE
-    custom_notaligned() {};
+    custom_notaligned() : i(0), d(0), f(0), u(0) {};
     HIPCUB_HOST_DEVICE
     ~custom_notaligned() {};
 };
@@ -142,7 +142,7 @@ TYPED_TEST(HipcubUtilPtxTests, ShuffleUp)
 
     if (logical_warp_size > current_device_warp_size)
     {
-        printf("Unsupported test warp size: %d Current device warp size: %d.    Skipping test\n",
+        printf("Unsupported test warp size: %u Current device warp size: %u.    Skipping test\n",
             logical_warp_size, current_device_warp_size);
         GTEST_SKIP();
     }
@@ -259,7 +259,7 @@ TYPED_TEST(HipcubUtilPtxTests, ShuffleDown)
 
     if (logical_warp_size > current_device_warp_size)
     {
-        printf("Unsupported test warp size: %d Current device warp size: %d.    Skipping test\n",
+        printf("Unsupported test warp size: %u Current device warp size: %u.    Skipping test\n",
             logical_warp_size, current_device_warp_size);
         GTEST_SKIP();
     }
@@ -374,7 +374,7 @@ TYPED_TEST(HipcubUtilPtxTests, ShuffleIndex)
 
     if (logical_warp_size > current_device_warp_size)
     {
-        printf("Unsupported test warp size: %d Current device warp size: %d.    Skipping test\n",
+        printf("Unsupported test warp size: %u Current device warp size: %u.    Skipping test\n",
             logical_warp_size, current_device_warp_size);
         GTEST_SKIP();
     }

--- a/test/hipcub/test_hipcub_warp_reduce.cpp
+++ b/test/hipcub/test_hipcub_warp_reduce.cpp
@@ -149,7 +149,7 @@ TYPED_TEST(HipcubWarpReduceTests, Reduce)
     if( (logical_warp_size > current_device_warp_size) ||
         (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
-        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %d.    Skipping test\n",
+        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %u.    Skipping test\n",
             logical_warp_size, block_size, current_device_warp_size);
         GTEST_SKIP();
     }
@@ -295,7 +295,7 @@ TYPED_TEST(HipcubWarpReduceTests, ReduceValid)
     if( (logical_warp_size > current_device_warp_size) ||
         (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
-        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %d.    Skipping test\n",
+        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %u.    Skipping test\n",
             logical_warp_size, block_size, current_device_warp_size);
         GTEST_SKIP();
     }
@@ -440,7 +440,7 @@ TYPED_TEST(HipcubWarpReduceTests, HeadSegmentedReduceSum)
     if( (logical_warp_size > current_device_warp_size) ||
         (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
-        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %d.    Skipping test\n",
+        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %u.    Skipping test\n",
             logical_warp_size, block_size, current_device_warp_size);
         GTEST_SKIP();
     }
@@ -633,7 +633,7 @@ TYPED_TEST(HipcubWarpReduceTests, TailSegmentedReduceSum)
     if( (logical_warp_size > current_device_warp_size) ||
         (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
-        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %d.    Skipping test\n",
+        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %u.    Skipping test\n",
             logical_warp_size, block_size, current_device_warp_size);
         GTEST_SKIP();
     }

--- a/test/hipcub/test_hipcub_warp_scan.cpp
+++ b/test/hipcub/test_hipcub_warp_scan.cpp
@@ -148,7 +148,7 @@ TYPED_TEST(HipcubWarpScanTests, InclusiveScan)
     if( (logical_warp_size > current_device_warp_size) ||
         (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
-        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %d.    Skipping test\n",
+        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %u.    Skipping test\n",
             logical_warp_size, block_size, current_device_warp_size);
         GTEST_SKIP();
     }
@@ -314,7 +314,7 @@ TYPED_TEST(HipcubWarpScanTests, InclusiveScanReduce)
     if( (logical_warp_size > current_device_warp_size) ||
         (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
-        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %d.    Skipping test\n",
+        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %u.    Skipping test\n",
             logical_warp_size, block_size, current_device_warp_size);
         GTEST_SKIP();
     }
@@ -495,7 +495,7 @@ TYPED_TEST(HipcubWarpScanTests, ExclusiveScan)
     if( (logical_warp_size > current_device_warp_size) ||
         (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
-        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %d.    Skipping test\n",
+        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %u.    Skipping test\n",
             logical_warp_size, block_size, current_device_warp_size);
         GTEST_SKIP();
     }
@@ -657,7 +657,7 @@ TYPED_TEST(HipcubWarpScanTests, ExclusiveReduceScan)
     if( (logical_warp_size > current_device_warp_size) ||
         (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
-        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %d.    Skipping test\n",
+        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %u.    Skipping test\n",
             logical_warp_size, block_size, current_device_warp_size);
         GTEST_SKIP();
     }
@@ -852,7 +852,7 @@ TYPED_TEST(HipcubWarpScanTests, Scan)
     if( (logical_warp_size > current_device_warp_size) ||
         (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
-        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %d.    Skipping test\n",
+        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %u.    Skipping test\n",
             logical_warp_size, block_size, current_device_warp_size);
         GTEST_SKIP();
     }
@@ -1014,7 +1014,7 @@ TYPED_TEST(HipcubWarpScanTests, InclusiveScanCustomType)
     if( (logical_warp_size > current_device_warp_size) ||
         (current_device_warp_size != ws32 && current_device_warp_size != ws64) ) // Only WarpSize 32 and 64 is supported
     {
-        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %d.    Skipping test\n",
+        printf("Unsupported test warp size/computed block size: %zu/%zu. Current device warp size: %u.    Skipping test\n",
             logical_warp_size, block_size, current_device_warp_size);
         GTEST_SKIP();
     }

--- a/test/hipcub/test_utils_custom_test_types.hpp
+++ b/test/hipcub/test_utils_custom_test_types.hpp
@@ -47,10 +47,8 @@ struct custom_test_type
 
     template<class U>
     HIPCUB_HOST_DEVICE inline
-        custom_test_type(const custom_test_type<U>& other)
+        custom_test_type(const custom_test_type<U>& other) : x(other.x), y(other.y)
     {
-        x = other.x;
-        y = other.y;
     }
 
 #ifndef HIPCUB_CUB_API
@@ -132,10 +130,8 @@ struct custom_test_type<test_utils::half>
 
     template<class U>
     HIPCUB_HOST_DEVICE inline
-        custom_test_type(const custom_test_type<U>& other)
+        custom_test_type(const custom_test_type<U>& other) : x(other.x), y(other.y)
     {
-        x = other.x;
-        y = other.y;
     }
 
     HIPCUB_HOST_DEVICE inline
@@ -208,10 +204,8 @@ struct custom_test_type<test_utils::bfloat16>
 
     template<class U>
     HIPCUB_HOST_DEVICE inline
-        custom_test_type(const custom_test_type<U>& other)
+        custom_test_type(const custom_test_type<U>& other) : x(other.x), y(other.y)
     {
-        x = other.x;
-        y = other.y;
     }
 
     HIPCUB_HOST_DEVICE inline

--- a/test/hipcub/test_utils_data_generation.hpp
+++ b/test/hipcub/test_utils_data_generation.hpp
@@ -258,7 +258,7 @@ struct special_values {
         }else {
             using traits          = hipcub::NumericTraits<T>;
             using unsigned_bits   = typename traits::UnsignedBits;
-            auto nan_with_payload = [](unsigned_bits payload)
+            auto nan_with_payload = [](const unsigned_bits& payload)
             {
                 T             value = test_utils::numeric_limits<T>::quiet_NaN();
                 unsigned_bits int_value;


### PR DESCRIPTION
Fix cpp-check reported issues
    
Fixed a number of issues that static analysis picked up:
  - Made some functions const since they don't modify member state
  - Made some parameters const, since they're never modified
  - Fixes for several benchmark/test functions
    - Removed unused variable declarations
    - Added missing input data transfer from host to device
    - Added some member variables to constructor initializer list
    - Added override keyword in several places
    - Fixed up item placeholders in some printf statements
    - Removed host to data transfer from memcpy benchmark.
      - Since this benchmark only tests memcpy performance between device buffers, we don't really need to copy data into these from the host.