### PR TITLE
Include FetchContent before usage

### DIFF
--- a/cmake/ROCmCMakeBuildToolsDependency.cmake
+++ b/cmake/ROCmCMakeBuildToolsDependency.cmake
@@ -32,6 +32,7 @@ if(NOT ROCM_FOUND)
   else()
     set(SOURCE_SUBDIR_ARG)
   endif()
+  include(FetchContent)
   FetchContent_Declare(
     rocm-cmake
     URL  https://github.com/RadeonOpenCompute/rocm-cmake/archive/refs/tags/rocm-5.2.0.tar.gz


### PR DESCRIPTION
The `find_package` call for rocm-cmake was moved out of Dependencies.cmake for ordering reasons, but the `include(FetchContent)` call was not copied.