### PR TITLE
StreamHPC 2024-01-16

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -411,6 +411,8 @@ test:nvcc_install:
 
 test:doc:
   stage: test
+  variables:
+    SPHINX_DIR: $DOCS_DIR/sphinx
   extends:
     - .rules:test
     - .build:docs

--- a/.jenkins/precheckin.groovy
+++ b/.jenkins/precheckin.groovy
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-// This shared library is available at https://github.com/ROCmSoftwarePlatform/rocJENKINS/
+// This shared library is available at https://github.com/ROCm/rocJENKINS/
 @Library('rocJenkins@pong') _
 
 // This file is for internal AMD use.

--- a/.jenkins/staticanalysis.groovy
+++ b/.jenkins/staticanalysis.groovy
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-// This shared library is available at https://github.com/ROCmSoftwarePlatform/rocJENKINS/
+// This shared library is available at https://github.com/ROCm/rocJENKINS/
 @Library('rocJenkins@pong') _
 
 // This is file for internal AMD use.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 Documentation for hipCUB is available at
 [https://rocm.docs.amd.com/projects/hipCUB/en/latest/](https://rocm.docs.amd.com/projects/hipCUB/en/latest/).
 
+## (Unreleased) hipCUB-3.2.0 for ROCm 6.2.0
+
+### Fixed
+
+* Fixed the derivation for the accumulator type for device scan algorithms in the rocPRIM backend being different compared to CUB.
+  It now derives the accumulator type as the result of the binary operator.
+
 ## (Unreleased) hipCUB-3.1.0 for ROCm 6.1.0
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Documentation for hipCUB is available at
 
 * Fixed the derivation for the accumulator type for device scan algorithms in the rocPRIM backend being different compared to CUB.
   It now derives the accumulator type as the result of the binary operator.
-- The NVIDIA backend now requires CUB, Thrust and libcu++ 2.2.0. If it is not found it will be downloaded from the NVIDIA CCCL repository.
+* The NVIDIA backend now requires CUB, Thrust and libcu++ 2.2.0. If it is not found it will be downloaded from the NVIDIA CCCL repository.
 
 ## (Unreleased) hipCUB-3.1.0 for ROCm 6.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Documentation for hipCUB is available at
 
 * Fixed the derivation for the accumulator type for device scan algorithms in the rocPRIM backend being different compared to CUB.
   It now derives the accumulator type as the result of the binary operator.
+- The NVIDIA backend now requires CUB, Thrust and libcu++ 2.2.0. If it is not found it will be downloaded from the NVIDIA CCCL repository.
 
 ## (Unreleased) hipCUB-3.1.0 for ROCm 6.1.0
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,7 @@ if(BUILD_ADDRESS_SANITIZER)
 endif()
 
 # Setup VERSION
-set(VERSION_STRING "3.0.0")
+set(VERSION_STRING "3.2.0")
 rocm_setup_version(VERSION ${VERSION_STRING})
 
 # Print configuration summary

--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ python3 -m http.server
   * The [rocPRIM](https://github.com/ROCm/rocPRIM) library
     * Automatically downloaded and built by the CMake script
     * Requires CMake 3.16.9 or later
-
 * For NVIDIA GPUs:
   * CUDA Toolkit
   * CUB library

--- a/benchmark/benchmark_device_segmented_reduce.cpp
+++ b/benchmark/benchmark_device_segmented_reduce.cpp
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2020 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -89,8 +89,6 @@ void run_benchmark(benchmark::State& state,
 
     OutputT * d_aggregates_output;
     HIP_CHECK(hipMalloc(&d_aggregates_output, segments_count * sizeof(OutputT)));
-
-    hipcub::Sum reduce_op;
 
     void * d_temporary_storage = nullptr;
     size_t temporary_storage_bytes = 0;

--- a/benchmark/benchmark_device_select.cpp
+++ b/benchmark/benchmark_device_select.cpp
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2020 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -386,8 +386,8 @@ void run_unique_by_key_benchmark(benchmark::State& state,
         }
     }
 
-    const auto input_values = benchmark_utils::get_random_data<ValueT>(size, ValueT(-1000), ValueT(1000));
-    unsigned int selected_count_output = 0;
+    const auto input_values
+        = benchmark_utils::get_random_data<ValueT>(size, ValueT(-1000), ValueT(1000));
 
     KeyT* d_keys_input;
     ValueT* d_values_input;
@@ -399,7 +399,7 @@ void run_unique_by_key_benchmark(benchmark::State& state,
     HIP_CHECK(hipMalloc(&d_values_input, input_values.size() * sizeof(input_values[0])));
     HIP_CHECK(hipMalloc(&d_keys_output, input_keys.size() * sizeof(input_keys[0])));
     HIP_CHECK(hipMalloc(&d_values_output, input_values.size() * sizeof(input_values[0])));
-    HIP_CHECK(hipMalloc(&d_selected_count_output, sizeof(selected_count_output)));
+    HIP_CHECK(hipMalloc(&d_selected_count_output, sizeof(*d_selected_count_output)));
 
     HIP_CHECK(
         hipMemcpy(

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -193,7 +193,7 @@ else()
     message(STATUS "rocPRIM not found. Fetching...")
     FetchContent_Declare(
             prim
-            GIT_REPOSITORY https://github.com/ROCmSoftwarePlatform/rocPRIM.git
+            GIT_REPOSITORY https://github.com/ROCm/rocPRIM.git
             GIT_TAG        develop
     )
     FetchContent_MakeAvailable(prim)

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2017-2023 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2017-2024 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -139,62 +139,49 @@ endif(USER_BUILD_BENCHMARK)
 
 # CUB (only for CUDA platform)
 if(HIP_COMPILER STREQUAL "nvcc")
-
+  set(CCCL_MINIMUM_VERSION 2.2.0)
   if(NOT DOWNLOAD_CUB)
-    find_package(cub QUIET)
-    find_package(thrust QUIET)
+    find_package(CUB ${CCCL_MINIMUM_VERSION} CONFIG)
+    find_package(Thrust ${CCCL_MINIMUM_VERSION} CONFIG)
+    find_package(libcudacxx ${CCCL_MINIMUM_VERSION} CONFIG)
   endif()
 
-  if(NOT DEFINED CUB_INCLUDE_DIR)
-    file(
-            DOWNLOAD https://github.com/NVIDIA/cub/archive/2.1.0.zip
-            ${CMAKE_CURRENT_BINARY_DIR}/cub-2.1.0.zip
-            STATUS cub_download_status LOG cub_download_log
-    )
-    list(GET cub_download_status 0 cub_download_error_code)
-    if(cub_download_error_code)
+  if (NOT CUB_FOUND OR NOT Thrust_FOUND OR NOT libcudacxx_FOUND)
+    if(CUB_FOUND OR Thrust_FOUND OR libcudacxx_FOUND)
+      message(WARNING "Found one of CUB, Thrust or libcu++, but not all of them.
+                       This can lead to mixing different potentially incompatible versions.")
+    endif()
+
+    message(STATUS "CUB, Thrust or libcu++ not found, downloading and extracting CCCL ${CCCL_MINIMUM_VERSION}")
+    file(DOWNLOAD https://github.com/NVIDIA/cccl/archive/refs/tags/v${CCCL_MINIMUM_VERSION}.zip
+                  ${CMAKE_CURRENT_BINARY_DIR}/cccl-${CCCL_MINIMUM_VERSION}.zip
+         STATUS cccl_download_status LOG cccl_download_log)
+
+    list(GET cccl_download_status 0 cccl_download_error_code)
+    if(cccl_download_error_code)
       message(FATAL_ERROR "Error: downloading "
-              "https://github.com/NVIDIA/cub/archive/2.1.0.zip failed "
-              "error_code: ${cub_download_error_code} "
-              "log: ${cub_download_log} "
-              )
+              "https://github.com/NVIDIA/cccl/archive/refs/tags/v${CCCL_MINIMUM_VERSION}.zip failed "
+              "error_code: ${cccl_download_error_code} "
+              "log: ${cccl_download_log}")
     endif()
 
-    execute_process(
-            COMMAND ${CMAKE_COMMAND} -E tar xzf ${CMAKE_CURRENT_BINARY_DIR}/cub-2.1.0.zip
-            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-            RESULT_VARIABLE cub_unpack_error_code
-    )
-    if(cub_unpack_error_code)
-      message(FATAL_ERROR "Error: unpacking ${CMAKE_CURRENT_BINARY_DIR}/cub-2.1.0.zip failed")
-    endif()
-    set(CUB_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/cub-2.1.0/ CACHE PATH "")
-  endif()
-
-  if(NOT DEFINED THRUST_INCLUDE_DIR)
-    file(
-            DOWNLOAD https://github.com/NVIDIA/thrust/archive/2.1.0.zip
-            ${CMAKE_CURRENT_BINARY_DIR}/thrust-2.1.0.zip
-            STATUS thrust_download_status LOG thrust_download_log
-    )
-    list(GET thrust_download_status 0 thrust_download_error_code)
-    if(thrust_download_error_code)
-      message(FATAL_ERROR "Error: downloading "
-              "https://github.com/NVIDIA/thrust/archive/2.1.0.zip failed "
-              "error_code: ${thrust_download_error_code} "
-              "log: ${thrust_download_log} "
-              )
+    if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.18)
+      file(ARCHIVE_EXTRACT INPUT ${CMAKE_CURRENT_BINARY_DIR}/cccl-${CCCL_MINIMUM_VERSION}.zip)
+    else()
+      execute_process(COMMAND "${CMAKE_COMMAND}" -E tar xf ${CMAKE_CURRENT_BINARY_DIR}/cccl-${CCCL_MINIMUM_VERSION}.zip
+                      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+                      RESULT_VARIABLE cccl_unpack_error_code)
+      if(cccl_unpack_error_code)
+        message(FATAL_ERROR "Error: unpacking ${CMAKE_CURRENT_BINARY_DIR}/cccl-${CCCL_MINIMUM_VERSION}.zip failed")
+      endif()
     endif()
 
-    execute_process(
-            COMMAND ${CMAKE_COMMAND} -E tar xzf ${CMAKE_CURRENT_BINARY_DIR}/thrust-2.1.0.zip
-            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-            RESULT_VARIABLE thrust_unpack_error_code
-    )
-    if(thrust_unpack_error_code)
-      message(FATAL_ERROR "Error: unpacking ${CMAKE_CURRENT_BINARY_DIR}/thrust-2.1.0.zip failed")
-    endif()
-    set(THRUST_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/thrust-2.1.0/ CACHE PATH "")
+    find_package(CUB ${CCCL_MINIMUM_VERSION} CONFIG REQUIRED NO_DEFAULT_PATH
+                 PATHS ${CMAKE_CURRENT_BINARY_DIR}/cccl-${CCCL_MINIMUM_VERSION}/cub)
+    find_package(Thrust ${CCCL_MINIMUM_VERSION} CONFIG REQUIRED NO_DEFAULT_PATH
+                 PATHS ${CMAKE_CURRENT_BINARY_DIR}/cccl-${CCCL_MINIMUM_VERSION}/thrust)
+    find_package(libcudacxx ${CCCL_MINIMUM_VERSION} CONFIG REQUIRED NO_DEFAULT_PATH
+                 PATHS ${CMAKE_CURRENT_BINARY_DIR}/cccl-${CCCL_MINIMUM_VERSION}/libcudacxx)
   endif()
 else()
   # rocPRIM (only for ROCm platform)

--- a/hipcub/CMakeLists.txt
+++ b/hipcub/CMakeLists.txt
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2018-2023 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2018-2024 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -61,13 +61,7 @@ else()
   # hipcub_cub target is only for internal use.
   add_library(hipcub_cub INTERFACE)
   target_link_libraries(hipcub_cub
-    INTERFACE
-      hipcub
-  )
-  target_include_directories(hipcub_cub
-    INTERFACE
-      ${CUB_INCLUDE_DIR}
-      ${THRUST_INCLUDE_DIR}
+    INTERFACE hipcub CUB::CUB Thrust::Thrust libcudacxx::libcudacxx
   )
 endif()
 

--- a/hipcub/include/hipcub/backend/rocprim/device/device_scan.hpp
+++ b/hipcub/include/hipcub/backend/rocprim/device/device_scan.hpp
@@ -30,15 +30,14 @@
 #ifndef HIPCUB_ROCPRIM_DEVICE_DEVICE_SCAN_HPP_
 #define HIPCUB_ROCPRIM_DEVICE_DEVICE_SCAN_HPP_
 
-#include <iostream>
 #include "../../../config.hpp"
-
 #include "../thread/thread_operators.hpp"
-#include "rocprim/types/future_value.hpp"
 
 #include <rocprim/device/config_types.hpp>
 #include <rocprim/device/device_scan.hpp>
 #include <rocprim/device/device_scan_by_key.hpp>
+#include <rocprim/type_traits.hpp>
+#include <rocprim/types/future_value.hpp>
 
 BEGIN_HIPCUB_NAMESPACE
 
@@ -80,9 +79,9 @@ public:
                              hipStream_t stream = 0,
                              bool debug_synchronous = false)
     {
-        using acc_t = typename rocprim::detail::match_result_type<
+        using acc_t = ::rocprim::invoke_result_binary_op_t<
             typename std::iterator_traits<InputIteratorT>::value_type,
-            ScanOpT>::type;
+            ScanOpT>;
 
         return ::rocprim::inclusive_scan<::rocprim::default_config,
                                          InputIteratorT,
@@ -136,9 +135,9 @@ public:
                              hipStream_t stream = 0,
                              bool debug_synchronous = false)
     {
-        using acc_t =
-            typename rocprim::detail::match_result_type<rocprim::detail::input_type_t<InitValueT>,
-                                                        ScanOpT>::type;
+        using acc_t
+            = ::rocprim::invoke_result_binary_op_t<rocprim::detail::input_type_t<InitValueT>,
+                                                   ScanOpT>;
 
         return ::rocprim::exclusive_scan<::rocprim::default_config,
                                          InputIteratorT,
@@ -174,9 +173,9 @@ public:
                              hipStream_t stream = 0,
                              bool debug_synchronous = false)
     {
-        using acc_t =
-            typename rocprim::detail::match_result_type<rocprim::detail::input_type_t<InitValueT>,
-                                                        ScanOpT>::type;
+        using acc_t
+            = ::rocprim::invoke_result_binary_op_t<rocprim::detail::input_type_t<InitValueT>,
+                                                   ScanOpT>;
 
         return ::rocprim::exclusive_scan<::rocprim::default_config,
                                          InputIteratorT,
@@ -247,9 +246,8 @@ public:
                                   hipStream_t stream = 0,
                                   bool debug_synchronous = false)
     {
-        using acc_t =
-            typename rocprim::detail::match_result_type<rocprim::detail::input_type_t<InitValueT>,
-                                                        ScanOpT>::type;
+        using acc_t = rocprim::invoke_result_binary_op_t<rocprim::detail::input_type_t<InitValueT>,
+                                                         ScanOpT>;
 
         return ::rocprim::exclusive_scan_by_key<::rocprim::default_config,
                                                 KeysInputIteratorT,
@@ -319,9 +317,9 @@ public:
                                   hipStream_t stream = 0,
                                   bool debug_synchronous = false)
     {
-        using acc_t = typename rocprim::detail::match_result_type<
+        using acc_t = ::rocprim::invoke_result_binary_op_t<
             typename std::iterator_traits<ValuesInputIteratorT>::value_type,
-            ScanOpT>::type;
+            ScanOpT>;
 
         return ::rocprim::inclusive_scan_by_key<::rocprim::default_config,
                                                 KeysInputIteratorT,

--- a/hipcub/include/hipcub/backend/rocprim/device/device_scan.hpp
+++ b/hipcub/include/hipcub/backend/rocprim/device/device_scan.hpp
@@ -34,7 +34,9 @@
 #include "../../../config.hpp"
 
 #include "../thread/thread_operators.hpp"
+#include "rocprim/types/future_value.hpp"
 
+#include <rocprim/device/config_types.hpp>
 #include <rocprim/device/device_scan.hpp>
 #include <rocprim/device/device_scan_by_key.hpp>
 
@@ -78,12 +80,22 @@ public:
                              hipStream_t stream = 0,
                              bool debug_synchronous = false)
     {
-        return ::rocprim::inclusive_scan(
-            d_temp_storage, temp_storage_bytes,
-            d_in, d_out, num_items,
-            scan_op,
-            stream, debug_synchronous
-        );
+        using acc_t = typename rocprim::detail::match_result_type<
+            typename std::iterator_traits<InputIteratorT>::value_type,
+            ScanOpT>::type;
+
+        return ::rocprim::inclusive_scan<::rocprim::default_config,
+                                         InputIteratorT,
+                                         OutputIteratorT,
+                                         ScanOpT,
+                                         acc_t>(d_temp_storage,
+                                                temp_storage_bytes,
+                                                d_in,
+                                                d_out,
+                                                num_items,
+                                                scan_op,
+                                                stream,
+                                                debug_synchronous);
     }
 
     template <
@@ -124,12 +136,22 @@ public:
                              hipStream_t stream = 0,
                              bool debug_synchronous = false)
     {
-        return ::rocprim::exclusive_scan(
-            d_temp_storage, temp_storage_bytes,
-            d_in, d_out, init_value, num_items,
-            scan_op,
-            stream, debug_synchronous
-        );
+        using acc_t = typename rocprim::detail::match_result_type<rocprim::detail::input_type_t<InitValueT>, ScanOpT>::type;
+
+        return ::rocprim::exclusive_scan<::rocprim::default_config,
+                                         InputIteratorT,
+                                         OutputIteratorT,
+                                         InitValueT,
+                                         ScanOpT,
+                                         acc_t>(d_temp_storage,
+                                                temp_storage_bytes,
+                                                d_in,
+                                                d_out,
+                                                init_value,
+                                                num_items,
+                                                scan_op,
+                                                stream,
+                                                debug_synchronous);
     }
 
     template <
@@ -150,12 +172,22 @@ public:
                              hipStream_t stream = 0,
                              bool debug_synchronous = false)
     {
-        return ::rocprim::exclusive_scan(
-            d_temp_storage, temp_storage_bytes,
-            d_in, d_out, init_value, num_items,
-            scan_op,
-            stream, debug_synchronous
-        );
+        using acc_t = typename rocprim::detail::match_result_type<rocprim::detail::input_type_t<InitValueT>, ScanOpT>::type;
+
+        return ::rocprim::exclusive_scan<::rocprim::default_config,
+                                         InputIteratorT,
+                                         OutputIteratorT,
+                                         InitValueT,
+                                         ScanOpT,
+                                         acc_t>(d_temp_storage,
+                                                temp_storage_bytes,
+                                                d_in,
+                                                d_out,
+                                                init_value,
+                                                num_items,
+                                                scan_op,
+                                                stream,
+                                                debug_synchronous);
     }
 
     template <
@@ -211,12 +243,26 @@ public:
                                   hipStream_t stream = 0,
                                   bool debug_synchronous = false)
     {
-        return ::rocprim::exclusive_scan_by_key(
-            d_temp_storage, temp_storage_bytes,
-            d_keys_in, d_values_in, d_values_out,
-            init_value, static_cast<size_t>(num_items),
-            scan_op, equality_op, stream, debug_synchronous
-        );
+        using acc_t = typename rocprim::detail::match_result_type<rocprim::detail::input_type_t<InitValueT>, ScanOpT>::type;
+
+        return ::rocprim::exclusive_scan_by_key<::rocprim::default_config,
+                                                KeysInputIteratorT,
+                                                ValuesInputIteratorT,
+                                                ValuesOutputIteratorT,
+                                                InitValueT,
+                                                ScanOpT,
+                                                EqualityOpT,
+                                                acc_t>(d_temp_storage,
+                                                       temp_storage_bytes,
+                                                       d_keys_in,
+                                                       d_values_in,
+                                                       d_values_out,
+                                                       init_value,
+                                                       static_cast<size_t>(num_items),
+                                                       scan_op,
+                                                       equality_op,
+                                                       stream,
+                                                       debug_synchronous);
     }
 
     template <
@@ -267,12 +313,26 @@ public:
                                   hipStream_t stream = 0,
                                   bool debug_synchronous = false)
     {
-        return ::rocprim::inclusive_scan_by_key(
-            d_temp_storage, temp_storage_bytes,
-            d_keys_in, d_values_in, d_values_out,
-            static_cast<size_t>(num_items), scan_op,
-            equality_op, stream, debug_synchronous
-        );
+        using acc_t = typename rocprim::detail::match_result_type<
+            typename std::iterator_traits<ValuesInputIteratorT>::value_type,
+            ScanOpT>::type;
+
+        return ::rocprim::inclusive_scan_by_key<::rocprim::default_config,
+                                                KeysInputIteratorT,
+                                                ValuesInputIteratorT,
+                                                ValuesOutputIteratorT,
+                                                ScanOpT,
+                                                EqualityOpT,
+                                                acc_t>(d_temp_storage,
+                                                       temp_storage_bytes,
+                                                       d_keys_in,
+                                                       d_values_in,
+                                                       d_values_out,
+                                                       static_cast<size_t>(num_items),
+                                                       scan_op,
+                                                       equality_op,
+                                                       stream,
+                                                       debug_synchronous);
     }
 
 };

--- a/hipcub/include/hipcub/backend/rocprim/device/device_scan.hpp
+++ b/hipcub/include/hipcub/backend/rocprim/device/device_scan.hpp
@@ -136,7 +136,9 @@ public:
                              hipStream_t stream = 0,
                              bool debug_synchronous = false)
     {
-        using acc_t = typename rocprim::detail::match_result_type<rocprim::detail::input_type_t<InitValueT>, ScanOpT>::type;
+        using acc_t =
+            typename rocprim::detail::match_result_type<rocprim::detail::input_type_t<InitValueT>,
+                                                        ScanOpT>::type;
 
         return ::rocprim::exclusive_scan<::rocprim::default_config,
                                          InputIteratorT,
@@ -172,7 +174,9 @@ public:
                              hipStream_t stream = 0,
                              bool debug_synchronous = false)
     {
-        using acc_t = typename rocprim::detail::match_result_type<rocprim::detail::input_type_t<InitValueT>, ScanOpT>::type;
+        using acc_t =
+            typename rocprim::detail::match_result_type<rocprim::detail::input_type_t<InitValueT>,
+                                                        ScanOpT>::type;
 
         return ::rocprim::exclusive_scan<::rocprim::default_config,
                                          InputIteratorT,
@@ -243,7 +247,9 @@ public:
                                   hipStream_t stream = 0,
                                   bool debug_synchronous = false)
     {
-        using acc_t = typename rocprim::detail::match_result_type<rocprim::detail::input_type_t<InitValueT>, ScanOpT>::type;
+        using acc_t =
+            typename rocprim::detail::match_result_type<rocprim::detail::input_type_t<InitValueT>,
+                                                        ScanOpT>::type;
 
         return ::rocprim::exclusive_scan_by_key<::rocprim::default_config,
                                                 KeysInputIteratorT,
@@ -334,7 +340,6 @@ public:
                                                        stream,
                                                        debug_synchronous);
     }
-
 };
 
 END_HIPCUB_NAMESPACE

--- a/hipcub/include/hipcub/backend/rocprim/device/device_scan.hpp
+++ b/hipcub/include/hipcub/backend/rocprim/device/device_scan.hpp
@@ -177,12 +177,17 @@ public:
     {
         using in_value_type = typename std::iterator_traits<ValuesInputIteratorT>::value_type;
 
-        return ::rocprim::exclusive_scan_by_key(
-            d_temp_storage, temp_storage_bytes,
-            d_keys_in, d_values_in, d_values_out,
-            static_cast<in_value_type>(0), static_cast<size_t>(num_items),
-            ::hipcub::Sum(), equality_op, stream, debug_synchronous
-        );
+        return ExclusiveScanByKey(d_temp_storage,
+                                  temp_storage_bytes,
+                                  d_keys_in,
+                                  d_values_in,
+                                  d_values_out,
+                                  ::hipcub::Sum(),
+                                  static_cast<in_value_type>(0),
+                                  static_cast<size_t>(num_items),
+                                  equality_op,
+                                  stream,
+                                  debug_synchronous);
     }
 
     template <
@@ -231,12 +236,16 @@ public:
                                  hipStream_t stream = 0,
                                  bool debug_synchronous = false)
     {
-        return ::rocprim::inclusive_scan_by_key(
-            d_temp_storage, temp_storage_bytes,
-            d_keys_in, d_values_in, d_values_out,
-            static_cast<size_t>(num_items), ::hipcub::Sum(),
-            equality_op, stream, debug_synchronous
-        );
+        return InclusiveScanByKey(d_temp_storage,
+                                  temp_storage_bytes,
+                                  d_keys_in,
+                                  d_values_in,
+                                  d_values_out,
+                                  ::hipcub::Sum(),
+                                  num_items,
+                                  equality_op,
+                                  stream,
+                                  debug_synchronous);
     }
 
     template <
@@ -265,6 +274,7 @@ public:
             equality_op, stream, debug_synchronous
         );
     }
+
 };
 
 END_HIPCUB_NAMESPACE

--- a/hipcub/include/hipcub/backend/rocprim/device/device_scan.hpp
+++ b/hipcub/include/hipcub/backend/rocprim/device/device_scan.hpp
@@ -1,7 +1,7 @@
 /******************************************************************************
  * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
  * Copyright (c) 2011-2018, NVIDIA CORPORATION.  All rights reserved.
- * Modifications Copyright (c) 2017-2020, Advanced Micro Devices, Inc.  All rights reserved.
+ * Modifications Copyright (c) 2017-2024, Advanced Micro Devices, Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/hipcub/include/hipcub/backend/rocprim/device/device_segmented_reduce.hpp
+++ b/hipcub/include/hipcub/backend/rocprim/device/device_segmented_reduce.hpp
@@ -1,7 +1,7 @@
 /******************************************************************************
  * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
  * Copyright (c) 2011-2018, NVIDIA CORPORATION.  All rights reserved.
- * Modifications Copyright (c) 2017-2023, Advanced Micro Devices, Inc.  All rights reserved.
+ * Modifications Copyright (c) 2017-2024, Advanced Micro Devices, Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -38,6 +38,7 @@
 #include "../iterator/arg_index_input_iterator.hpp"
 #include "../thread/thread_operators.hpp"
 #include "device_reduce.hpp"
+#include "rocprim/type_traits.hpp"
 
 #include <rocprim/device/device_segmented_reduce.hpp>
 
@@ -131,7 +132,7 @@ inline hipError_t segmented_arg_minmax(void*          temporary_storage,
 {
     using input_type = typename std::iterator_traits<InputIterator>::value_type;
     using result_type =
-        typename ::rocprim::detail::match_result_type<input_type, BinaryFunction>::type;
+        typename ::rocprim::invoke_result_binary_op<input_type, BinaryFunction>::type;
 
     using config = ::rocprim::detail::wrapped_reduce_config<Config, result_type>;
 

--- a/hipcub/include/hipcub/backend/rocprim/iterator/cache_modified_input_iterator.hpp
+++ b/hipcub/include/hipcub/backend/rocprim/iterator/cache_modified_input_iterator.hpp
@@ -1,7 +1,7 @@
 /******************************************************************************
  * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
  * Copyright (c) 2011-2018, NVIDIA CORPORATION.  All rights reserved.
- * Modifications Copyright (c) 2017-2020, Advanced Micro Devices, Inc.  All rights reserved.
+ * Modifications Copyright (c) 2017-2024, Advanced Micro Devices, Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -145,13 +145,13 @@ public:
     }
 
     /// Equal to
-    __host__ __device__ __forceinline__ bool operator==(const self_type& rhs)
+    __host__ __device__ __forceinline__ bool operator==(const self_type& rhs) const
     {
         return (ptr == rhs.ptr);
     }
 
     /// Not equal to
-    __host__ __device__ __forceinline__ bool operator!=(const self_type& rhs)
+    __host__ __device__ __forceinline__ bool operator!=(const self_type& rhs) const
     {
         return (ptr != rhs.ptr);
     }

--- a/hipcub/include/hipcub/backend/rocprim/iterator/cache_modified_output_iterator.hpp
+++ b/hipcub/include/hipcub/backend/rocprim/iterator/cache_modified_output_iterator.hpp
@@ -1,7 +1,7 @@
 /******************************************************************************
  * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
  * Copyright (c) 2011-2018, NVIDIA CORPORATION.  All rights reserved.
- * Modifications Copyright (c) 2017-2020, Advanced Micro Devices, Inc.  All rights reserved.
+ * Modifications Copyright (c) 2017-2024, Advanced Micro Devices, Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -162,13 +162,13 @@ public:
     }
 
     /// Equal to
-    __host__ __device__ __forceinline__ bool operator==(const self_type& rhs)
+    __host__ __device__ __forceinline__ bool operator==(const self_type& rhs) const
     {
         return (ptr == rhs.ptr);
     }
 
     /// Not equal to
-    __host__ __device__ __forceinline__ bool operator!=(const self_type& rhs)
+    __host__ __device__ __forceinline__ bool operator!=(const self_type& rhs) const
     {
         return (ptr != rhs.ptr);
     }

--- a/hipcub/include/hipcub/backend/rocprim/iterator/discard_output_iterator.hpp
+++ b/hipcub/include/hipcub/backend/rocprim/iterator/discard_output_iterator.hpp
@@ -1,7 +1,7 @@
 /******************************************************************************
  * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
  * Copyright (c) 2011-2018, NVIDIA CORPORATION.  All rights reserved.
- * Modifications Copyright (c) 2020, Advanced Micro Devices, Inc.  All rights reserved.
+ * Modifications Copyright (c) 2020-2024, Advanced Micro Devices, Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -201,7 +201,7 @@ public:
     * @typedef self_type
     * @brief Equal to
     */
-    __host__ __device__ __forceinline__ bool operator==(const self_type& rhs)
+    __host__ __device__ __forceinline__ bool operator==(const self_type& rhs) const
     {
         return (offset == rhs.offset);
     }
@@ -210,7 +210,7 @@ public:
     * @typedef self_type
     * @brief Not equal to
     */
-    __host__ __device__ __forceinline__ bool operator!=(const self_type& rhs)
+    __host__ __device__ __forceinline__ bool operator!=(const self_type& rhs) const
     {
         return (offset != rhs.offset);
     }

--- a/hipcub/include/hipcub/backend/rocprim/thread/thread_operators.hpp
+++ b/hipcub/include/hipcub/backend/rocprim/thread/thread_operators.hpp
@@ -1,7 +1,7 @@
 /******************************************************************************
  * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
  * Copyright (c) 2011-2018, NVIDIA CORPORATION.  All rights reserved.
- * Modifications Copyright (c) 2017-2023, Advanced Micro Devices, Inc.  All rights reserved.
+ * Modifications Copyright (c) 2017-2024, Advanced Micro Devices, Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -34,7 +34,7 @@
 
 #include "../util_type.hpp"
 
-#include <rocprim/detail/match_result_type.hpp>
+#include <rocprim/type_traits.hpp>
 
 BEGIN_HIPCUB_NAMESPACE
 
@@ -276,7 +276,7 @@ using non_void_value_t =
 
 // Invoke result type.
 template<typename Invokable, typename... Args>
-using invoke_result_t = typename ::rocprim::detail::invoke_result<Invokable, Args...>::type;
+using invoke_result_t = ::rocprim::invoke_result_t<Invokable, Args...>;
 
 /// Intermediate accumulator type.
 template<typename Invokable, typename InitT, typename InputT>
@@ -293,7 +293,7 @@ using accumulator_t = std::decay_t<invoke_result_t<Invokable, InitT, InputT>>;
 // rocPRIM (as well as Thrust) uses result type of BinaryFunction instead (if not void):
 //
 // using input_type = typename std::iterator_traits<InputIterator>::value_type;
-// using result_type = typename ::rocprim::detail::match_result_type<
+// using result_type = typename ::rocprim::invoke_result_binary_op<
 //     input_type, BinaryFunction
 // >::type;
 //

--- a/test/extra/CMakeLists.txt
+++ b/test/extra/CMakeLists.txt
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2017-2023 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2017-2024 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -42,62 +42,49 @@ include(VerifyCompiler)
 
 # CUB (only for CUDA platform)
 if(HIP_COMPILER STREQUAL "nvcc")
-
+  set(CCCL_MINIMUM_VERSION 2.2.0)
   if(NOT DOWNLOAD_CUB)
-    find_package(cub QUIET)
-    find_package(thrust QUIET)
+    find_package(CUB ${CCCL_MINIMUM_VERSION} CONFIG)
+    find_package(Thrust ${CCCL_MINIMUM_VERSION} CONFIG)
+    find_package(libcudacxx ${CCCL_MINIMUM_VERSION} CONFIG)
   endif()
 
-  if(NOT DEFINED CUB_INCLUDE_DIR)
-    file(
-      DOWNLOAD https://github.com/NVIDIA/cub/archive/2.1.0.zip
-      ${CMAKE_CURRENT_BINARY_DIR}/cub-2.1.0.zip
-      STATUS cub_download_status LOG cub_download_log
-    )
-    list(GET cub_download_status 0 cub_download_error_code)
-    if(cub_download_error_code)
+  if (NOT CUB_FOUND OR NOT Thrust_FOUND OR NOT libcudacxx_FOUND)
+    if(CUB_FOUND OR Thrust_FOUND OR libcudacxx_FOUND)
+      message(WARNING "Found one of CUB, Thrust or libcu++, but not all of them.
+                      This can lead to mixing different potentially incompatible versions.")
+    endif()
+
+    message(STATUS "CUB, Thrust or libcu++ not found, downloading and extracting CCCL ${CCCL_MINIMUM_VERSION}")
+    file(DOWNLOAD https://github.com/NVIDIA/cccl/archive/refs/tags/v${CCCL_MINIMUM_VERSION}.zip
+                  ${CMAKE_CURRENT_BINARY_DIR}/cccl-${CCCL_MINIMUM_VERSION}.zip
+        STATUS cccl_download_status LOG cccl_download_log)
+
+    list(GET cccl_download_status 0 cccl_download_error_code)
+    if(cccl_download_error_code)
       message(FATAL_ERROR "Error: downloading "
-        "https://github.com/NVIDIA/cub/archive/2.1.0.zip failed "
-        "error_code: ${cub_download_error_code} "
-        "log: ${cub_download_log} "
-      )
+              "https://github.com/NVIDIA/cccl/archive/refs/tags/v${CCCL_MINIMUM_VERSION}.zip failed "
+              "error_code: ${cccl_download_error_code} "
+              "log: ${cccl_download_log}")
     endif()
 
-    execute_process(
-      COMMAND ${CMAKE_COMMAND} -E tar xzf ${CMAKE_CURRENT_BINARY_DIR}/cub-2.1.0.zip
-      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-      RESULT_VARIABLE cub_unpack_error_code
-    )
-    if(cub_unpack_error_code)
-      message(FATAL_ERROR "Error: unpacking ${CMAKE_CURRENT_BINARY_DIR}/cub-2.1.0.zip failed")
-    endif()
-    set(CUB_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/cub-2.1.0/ CACHE PATH "")
-  endif()
-
-  if(NOT DEFINED THRUST_INCLUDE_DIR)
-    file(
-      DOWNLOAD https://github.com/NVIDIA/thrust/archive/2.1.0.zip
-      ${CMAKE_CURRENT_BINARY_DIR}/thrust-2.1.0.zip
-      STATUS thrust_download_status LOG thrust_download_log
-    )
-    list(GET thrust_download_status 0 thrust_download_error_code)
-    if(thrust_download_error_code)
-      message(FATAL_ERROR "Error: downloading "
-        "https://github.com/NVIDIA/thrust/archive/2.1.0.zip failed "
-        "error_code: ${thrust_download_error_code} "
-        "log: ${thrust_download_log} "
-      )
+    if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.18)
+      file(ARCHIVE_EXTRACT INPUT ${CMAKE_CURRENT_BINARY_DIR}/cccl-${CCCL_MINIMUM_VERSION}.zip)
+    else()
+      execute_process(COMMAND "${CMAKE_COMMAND}" -E tar xf ${CMAKE_CURRENT_BINARY_DIR}/cccl-${CCCL_MINIMUM_VERSION}.zip
+                      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+                      RESULT_VARIABLE cccl_unpack_error_code)
+      if(cccl_unpack_error_code)
+        message(FATAL_ERROR "Error: unpacking ${CMAKE_CURRENT_BINARY_DIR}/cccl-${CCCL_MINIMUM_VERSION}.zip failed")
+      endif()
     endif()
 
-    execute_process(
-      COMMAND ${CMAKE_COMMAND} -E tar xzf ${CMAKE_CURRENT_BINARY_DIR}/thrust-2.1.0.zip
-      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-      RESULT_VARIABLE thrust_unpack_error_code
-    )
-    if(thrust_unpack_error_code)
-      message(FATAL_ERROR "Error: unpacking ${CMAKE_CURRENT_BINARY_DIR}/thrust-2.1.0.zip failed")
-    endif()
-    set(THRUST_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/thrust-2.1.0/ CACHE PATH "")
+    find_package(CUB ${CCCL_MINIMUM_VERSION} CONFIG REQUIRED NO_DEFAULT_PATH
+                PATHS ${CMAKE_CURRENT_BINARY_DIR}/cccl-${CCCL_MINIMUM_VERSION}/cub)
+    find_package(Thrust ${CCCL_MINIMUM_VERSION} CONFIG REQUIRED NO_DEFAULT_PATH
+                PATHS ${CMAKE_CURRENT_BINARY_DIR}/cccl-${CCCL_MINIMUM_VERSION}/thrust)
+    find_package(libcudacxx ${CCCL_MINIMUM_VERSION} CONFIG REQUIRED NO_DEFAULT_PATH
+                PATHS ${CMAKE_CURRENT_BINARY_DIR}/cccl-${CCCL_MINIMUM_VERSION}/libcudacxx)
   endif()
 else()
   # rocPRIM (only for ROCm platform)
@@ -140,15 +127,8 @@ function(add_hipcub_test TEST_NAME TEST_SOURCES)
   if(HIP_COMPILER STREQUAL "nvcc")
     set_property(TARGET ${TEST_TARGET} PROPERTY CUDA_STANDARD 14)
     set_source_files_properties(${TEST_SOURCES} PROPERTIES LANGUAGE CUDA)
-    target_link_libraries(${TEST_TARGET}
-      PRIVATE
-        hip::hipcub
-    )
-    target_include_directories(${TEST_TARGET}
-      PRIVATE
-        $<BUILD_INTERFACE:${CUB_INCLUDE_DIR}>
-        $<BUILD_INTERFACE:${THRUST_INCLUDE_DIR}>
-    )
+    target_link_libraries(${TEST_TARGET} PRIVATE
+                          hip::hipcub CUB::CUB Thrust::Thrust libcudacxx::libcudacxx)
   elseif(HIP_COMPILER STREQUAL "clang")
     target_link_libraries(${TEST_TARGET}
       PRIVATE

--- a/test/extra/CMakeLists.txt
+++ b/test/extra/CMakeLists.txt
@@ -96,7 +96,7 @@ else()
     message(STATUS "rocPRIM not found. Fetching...")
     FetchContent_Declare(
       prim
-      GIT_REPOSITORY https://github.com/ROCmSoftwarePlatform/rocPRIM.git
+      GIT_REPOSITORY https://github.com/ROCm/rocPRIM.git
       GIT_TAG        develop
     )
     FetchContent_MakeAvailable(prim)

--- a/test/hipcub/CMakeLists.txt
+++ b/test/hipcub/CMakeLists.txt
@@ -1,5 +1,5 @@
 # MIT License #
-# Copyright (c) 2017-2023 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2017-2024 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -179,7 +179,6 @@ ${TEST_TYPE_SLICE_COUNT} test type slice(s) for test target ${TEST_TARGET}")
     message(FATAL_ERROR "no .cpp files generated for target ${TEST_TARGET}")
   endif()
 
-  set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_CLEAN_FILES "${TEST_TARGET}.parallel")
   add_hipcub_test_internal(${TEST_NAME} "${SOURCES}" ${TEST_TARGET})
   target_include_directories("${TEST_TARGET}" PRIVATE "../../test/hipcub")
 endfunction()

--- a/test/hipcub/identity_iterator.hpp
+++ b/test/hipcub/identity_iterator.hpp
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2017-2021 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2024 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -45,8 +45,7 @@ public:
         : ptr_(ptr)
     { }
 
-    HIPCUB_HOST_DEVICE inline
-    ~identity_iterator() = default;
+    inline ~identity_iterator() = default;
 
     HIPCUB_HOST_DEVICE inline
     identity_iterator& operator++()

--- a/test/hipcub/test_hipcub_block_run_length_decode.cpp
+++ b/test/hipcub/test_hipcub_block_run_length_decode.cpp
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2021-2023 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -179,7 +179,10 @@ TYPED_TEST(HipcubBlockRunLengthDecodeTest, TestDecode)
             std::numeric_limits<ItemT>::max(),
             seed_value
         );
+        // Not strictly required, but fixes a spurious GCC warning and good practice anyways
+        run_items.reserve(run_items.size() + empty_run_items.size());
         run_items.insert(run_items.end(), empty_run_items.begin(), empty_run_items.end());
+        run_lengths.reserve(run_lengths.size() + num_trailing_empty_runs);
         run_lengths.insert(run_lengths.end(), num_trailing_empty_runs, static_cast<LengthT>(0));
 
         std::vector<ItemT> expected;

--- a/test/hipcub/test_hipcub_block_shuffle.cpp
+++ b/test/hipcub/test_hipcub_block_shuffle.cpp
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2017-2023 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2024 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -30,6 +30,8 @@
 
 // required test headers
 #include "test_utils.hpp"
+
+#include <type_traits>
 
 // Params for tests
 template<
@@ -110,7 +112,9 @@ TYPED_TEST(HipcubBlockShuffleTests, BlockOffset)
         int distance = rand() % std::min(size_t(10), block_size/2) - std::min(size_t(10), block_size/2);
         SCOPED_TRACE(testing::Message() << "with seed= " << seed_value <<" & distance = "<<distance);
         // Generate data
-        std::vector<type> input_data = test_utils::get_random_data<type>(size, -100, 100, seed_value);
+        const int         min_value = std::is_unsigned<type>::value ? 0 : -100;
+        std::vector<type> input_data
+            = test_utils::get_random_data<type>(size, min_value, 100, seed_value);
         std::vector<type> output_data(input_data);
 
         // Preparing device
@@ -198,7 +202,9 @@ TYPED_TEST(HipcubBlockShuffleTests, BlockRotate)
         int distance = rand() % std::min(size_t(5), block_size/2);
         SCOPED_TRACE(testing::Message() << "with seed= " << seed_value <<" & distance = "<<distance);
         // Generate data
-        std::vector<type> input_data = test_utils::get_random_data<type>(size, -100, 100, seed_value);
+        const int         min_value = std::is_unsigned<type>::value ? 0 : -100;
+        std::vector<type> input_data
+            = test_utils::get_random_data<type>(size, min_value, 100, seed_value);
         std::vector<type> output_data(input_data);
 
         // Preparing device
@@ -283,7 +289,9 @@ TYPED_TEST(HipcubBlockShuffleTests, BlockUp)
         unsigned int seed_value = seed_index < random_seeds_count  ? rand() : seeds[seed_index - random_seeds_count];
         SCOPED_TRACE(testing::Message() << "with seed= " << seed_value);
         // Generate data
-        std::vector<type> input_data = test_utils::get_random_data<type>(ItemsPerThread * size, -100, 100, seed_value);
+        const int         min_value = std::is_unsigned<type>::value ? 0 : -100;
+        std::vector<type> input_data
+            = test_utils::get_random_data<type>(ItemsPerThread * size, min_value, 100, seed_value);
         std::vector<type> output_data(input_data);
 
         std::vector<type*>  arr_input(size);
@@ -381,7 +389,9 @@ TYPED_TEST(HipcubBlockShuffleTests, BlockDown)
         SCOPED_TRACE(testing::Message() << "with seed= " << seed_value);
 
         // Generate data
-        std::vector<type> input_data = test_utils::get_random_data<type>(ItemsPerThread * size, -100, 100, seed_value);
+        const int         min_value = std::is_unsigned<type>::value ? 0 : -100;
+        std::vector<type> input_data
+            = test_utils::get_random_data<type>(ItemsPerThread * size, min_value, 100, seed_value);
         std::vector<type> output_data(input_data);
 
         std::vector<type*>  arr_input(size);

--- a/test/hipcub/test_hipcub_warp_reduce.cpp
+++ b/test/hipcub/test_hipcub_warp_reduce.cpp
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2017-2023 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2024 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -318,7 +318,7 @@ TYPED_TEST(HipcubWarpReduceTests, ReduceValid)
         for(size_t i = 0; i < output.size(); i++)
         {
             T value = 0;
-            for(size_t j = 0; j < valid; j++)
+            for(int j = 0; j < valid; ++j)
             {
                 auto idx = i * logical_warp_size + j;
                 value += input[idx];


### PR DESCRIPTION
- **Note: this PR depends on https://github.com/ROCm/rocPRIM/pull/509**
- This PR does not include the updates for parity with CUB 2.2. Those changes are intended to be provided in a follow-up PR.
- Fixed `operator==` and `operator!=` not being `const` on some iterators
- Fixed proper accumulator type selection for the device scan algorithms
- On the CUDA backend, bumped dependency to CCCL@v2.2
- Miscellaneous fixes on the CUDA backend
- Updated GitHub URLs to point to new ROCm organization