### PR TITLE
Fix ambiguous call to min function

### DIFF
--- a/hipcub/include/hipcub/backend/rocprim/device/device_spmv.hpp
+++ b/hipcub/include/hipcub/backend/rocprim/device/device_spmv.hpp
@@ -139,7 +139,7 @@ template <typename ValueT>
         }
         else
         {
-            size_t block_size = min(num_cols, DeviceSpmv::CsrMVKernel_MaxThreads);
+            size_t block_size = min(static_cast<int>(num_cols), DeviceSpmv::CsrMVKernel_MaxThreads);
             size_t grid_size = num_rows;
             CsrMVKernel<<<grid_size, block_size, 0, stream>>>(spmv_params);
             status = hipGetLastError();


### PR DESCRIPTION
The CsrMV function currently makes a call to min(int, uint32_t). Previously, clang headers only defined min(int, int), so this would cause the second argument to be implicitly cast to int.

However, in the future Clang will add overloaded versions of min like min(uint32_t, uint32_t) - see [this issue](https://github.com/ROCm/hipCUB/issues/343). This will make the call ambiguous, since the compiler does not know whether to cast the first argument to uint32_t, or to cast the second argument to int.

This change adds an explicit cast here to prevent future problems.