### PR TITLE
Fix doxygen strip from path

### DIFF
--- a/docs/doxygen/Doxyfile
+++ b/docs/doxygen/Doxyfile
@@ -163,7 +163,7 @@ FULL_PATH_NAMES        = YES
 # will be relative from the directory where doxygen is started.
 # This tag requires that the tag FULL_PATH_NAMES is set to YES.
 
-STRIP_FROM_PATH        = ../hipcub/include/
+STRIP_FROM_PATH        = ../../hipcub/include
 
 # The STRIP_FROM_INC_PATH tag can be used to strip a user-defined part of the
 # path mentioned in the documentation of a class, which tells the reader which


### PR DESCRIPTION
The STRIP_FROM_PATH value should be at the same level as the input

To avoid including the whole path