### PR TITLE
Update changelog with note about hipGraphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ Documentation for hipCUB is available at
   type (`key_type`) can be sorted via these overloads, if an appropriate decomposer is passed. The decomposer has to implement
   `operator(const key_type&)` which returns a `hipcub::tuple` of references pointing to members of `key_type`.
 
+* On AMD GPUs (using the HIP backend), it is possible to issue hipCUB API calls inside of
+  hipGraphs, with several exceptions:
+   * CachingDeviceAllocator
+   * GridBarrierLifetime
+   * DeviceSegmentedRadixSort
+   * DeviceRunLengthEncode
+  Currently, these classes rely on one or more synchronous calls to function correctly. Because of this, they cannot be used inside of hipGraphs.
+
 ### Changed
 
 * The NVIDIA backend now requires CUB, Thrust and libcu++ 2.2.0. If it is not found it will be downloaded from the NVIDIA CCCL repository.


### PR DESCRIPTION
The GridBarrierLifetime and CachingDeviceAllocator classes both issue synchronous calls to hipMalloc and hipFree.

This change modifies GridBarrierLifetime slightly so that it issues asynchronous calls instead. This allows the barrier to be used inside of hipGraphs. The GridBarrier unit test has also been updated to exercise the new changes inside of hipGraphs.

CachingDeviceAllocator is intended to be used together with multiple streams. It operates a bit like a memory pool that works across streams. For example, suppose a memory block is allocated in one stream. When it's freed, no call to hipFree actually occurs - instead, it is marked as "cached." If another stream later allocates a block of similar size, the cached memory block can be re-used (saving a call to hipMalloc).

While eliminating synchronous class from this class is technically possible, it is not very practical. hipGraphs created using stream-capture will capture calls issued into a single stream. Capturing an instance of (a fully asynchronous) CachingDeviceAllocator inside a graph could result in unexpected behaviour if it allocated or freed memory in streams other than the one being captured.

For this reason, I haven't modified CachingDeviceAllocator, and it retains its synchronous calls. I've added a note to the changelog about this, so that users are aware that it won't work within hipGraphs.