### PR TITLE
Avoid printing 128-bit values on test failure

### DIFF
--- a/test/hipcub/test_utils_data_generation.hpp
+++ b/test/hipcub/test_utils_data_generation.hpp
@@ -123,6 +123,22 @@ public:
 };
 // End of extended numeric_limits
 
+#if HIPCUB_IS_INT128_ENABLED
+template<class T>
+using is_int128 = std::is_same<__int128_t, typename std::remove_cv<T>::type>;
+template<class T>
+using is_uint128 = std::is_same<__uint128_t, typename std::remove_cv<T>::type>;
+#else
+struct dummy_type
+{
+    static constexpr bool value = false;
+};
+template<class T>
+using is_int128 = dummy_type;
+template<class T>
+using is_uint128 = dummy_type;
+#endif
+
 template<class T>
 using is_half = std::is_same<test_utils::half, typename std::remove_cv<T>::type>;
 


### PR DESCRIPTION
The block_radix_sort test suite sometimes calls GTests's comparison macro ASSERT_EQ and prints to an output stream as part of the call, like this:
`ASSERT_EQ(val1, val2) << "at index: " << index;`

On Windows, if val1 or val2 is a 128-bit value, this can cause linker errors because GTests's "PrintTo" function has no overload for those types (the values are printed if the test fails).

This change adds a check to see if 128-bit values are being tested, and if so, performs the test in such a way that the values will not be printed in the case where the test fails.