### PR TITLE
Correct fix for ambiguous min function call

### DIFF
--- a/hipcub/include/hipcub/backend/rocprim/device/device_spmv.hpp
+++ b/hipcub/include/hipcub/backend/rocprim/device/device_spmv.hpp
@@ -136,7 +136,7 @@ HIPCUB_RUNTIME_FUNCTION static hipError_t CsrMV(void*       d_temp_storage,
         return hipError_t(0);
     } else
     {
-        size_t block_size = min(static_cast<int>(num_cols), DeviceSpmv::CsrMVKernel_MaxThreads);
+        size_t block_size = min(num_cols, static_cast<int>(DeviceSpmv::CsrMVKernel_MaxThreads));
         size_t grid_size  = num_rows;
 
         std::chrono::high_resolution_clock::time_point start;


### PR DESCRIPTION
The CsrMV function currently makes a call to min(int, uint32_t). Previously, clang headers only defined min(int, int), so this would cause the second argument to be implicitly cast to int.

However, in the future Clang will add overloaded versions of min like min(uint32_t, uint32_t) - see this issue. This will make the call ambiguous, since the compiler does not know whether to cast the first argument to uint32_t, or to cast the second argument to int.

Previously, an explicit cast was added to prevent future problems. However, the cast was added to the wrong argument. This fix moves the cast to the correct argument.