### PR TITLE
Restore preprocessor hash character in inline assembly macros

### DIFF
--- a/hipcub/include/hipcub/backend/rocprim/thread/thread_load.hpp
+++ b/hipcub/include/hipcub/backend/rocprim/thread/thread_load.hpp
@@ -67,7 +67,7 @@ HIPCUB_DEVICE __forceinline__ T AsmThreadLoad(void * ptr)
     {                                                                                                         \
         interim_type retval;                                                                                  \
         asm volatile(#asm_operator " %0, %1 " llvm_cache_modifier "\n\t"                                      \
-                                   wait_inst wait_cmd "(%2)"                                                  \
+                                   #wait_inst wait_cmd "(%2)"                                                 \
                      : "=" #output_modifier(retval)                                                           \
                      : "v"(ptr), "I"(0x00));                                                                  \
         return retval;                                                                                        \

--- a/hipcub/include/hipcub/backend/rocprim/thread/thread_store.hpp
+++ b/hipcub/include/hipcub/backend/rocprim/thread/thread_store.hpp
@@ -69,7 +69,7 @@ HIPCUB_DEVICE __forceinline__ void AsmThreadStore(void * ptr, T val)
     {                                                                                                        \
         interim_type temp_val = val;                                                                         \
         asm volatile(#asm_operator " %0, %1 " llvm_cache_modifier "\n\t"                                     \
-                                   wait_inst wait_cmd "(%2)"                                                 \
+                                   #wait_inst wait_cmd "(%2)"                                                \
                      : : "v"(ptr), #output_modifier(temp_val), "I"(0x00));                                   \
     }
 


### PR DESCRIPTION
Commit 319a19ecffcda3e9a052c031c9ddb2c5beaa0ff1 removed a hash character (#) that was used the HIPCUB_ASM_THREAD_LOAD/STORE macros to ensure the preprocessor interpreted the wait_inst argument correctly. 
At the time, the removal of this character did not cause build errors.

Compiler changes since then have made the hash necessary. This change just adds it back in.