### PR TITLE
Enable verbose output and test timeout limit of 15 minutes in Jenkins

### DIFF
--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -31,7 +31,7 @@ def runTestCommand (platform, project)
 {
     String sudo = auxiliary.sudo(platform.jenkinsLabel)
 
-    def testCommand = "ctest --output-on-failure"
+    def testCommand = "ctest --output-on-failure --verbose --timeout 900"
     def command = """#!/usr/bin/env bash
                 set -x
                 cd ${project.paths.project_build_prefix}


### PR DESCRIPTION
Verbose output should allow us to at least see which exact test case is hanging on Jenkins (see #377 ) and other useful information.
The current CI timeout limit is about 5 hours, trimming ctest timeout to 15 minutes allows us to get a faster return on CI runs that hang from ctest but still allows for extreme unit test case durations (I think the longest hipCUB test executable duration currently possible is a bit under 3 minutes, so 15 minutes is still plenty)