### PR TITLE
Include device_copy header

### DIFF
--- a/hipcub/include/hipcub/backend/rocprim/hipcub.hpp
+++ b/hipcub/include/hipcub/backend/rocprim/hipcub.hpp
@@ -51,6 +51,7 @@
 
 // Device
 #include "device/device_adjacent_difference.hpp"
+#include "device/device_copy.hpp"
 #include "device/device_histogram.hpp"
 #include "device/device_memcpy.hpp"
 #include "device/device_merge_sort.hpp"


### PR DESCRIPTION
The device/device_copy.hpp header was missing from the main hipcub.hpp header file. This change just adds it back.