### PR TITLE
[windows][hipCUB] Removed usage of std::unary_function and std::binary_function to prevent syntax error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Full documentation for hipCUB is available at [https://rocm.docs.amd.com/project
 * Added `DeviceSelect::FlaggedIf` and its inplace overload.
 
 ### Changed
+* Removed usage of `std::unary_function` and `std::binary_function` in `test_hipcub_device_adjacent_difference.cpp`
 * Changed the subset of tests that are run for smoke tests such that the smoke test will complete with faster run-time and to never exceed 2GB of vram usage. Use `python rtest.py [--emulation|-e|--test|-t]=smoke` to run these tests.
 * The `rtest.py` options have changed. `rtest.py` is now run with at least either `--test|-t` or `--emulation|-e`, but not both options.
 * The NVIDIA backend now requires CUB, Thrust and libcu++ 2.5.0. If it is not found it will be downloaded from the NVIDIA CCCL repository.

--- a/test/hipcub/test_hipcub_device_adjacent_difference.cpp
+++ b/test/hipcub/test_hipcub_device_adjacent_difference.cpp
@@ -315,7 +315,7 @@ inline auto make_transform_iterator(InputIterator iterator, UnaryFunction transf
 }
 
 template<class T>
-struct conversion_op : public std::unary_function<T, discard_write<T>>
+struct conversion_op
 {
     HIPCUB_HOST_DEVICE
     auto operator()(const T i) const
@@ -325,7 +325,7 @@ struct conversion_op : public std::unary_function<T, discard_write<T>>
 };
 
 template<class T>
-struct flag_expected_op : public std::binary_function<T, T, discard_write<T>>
+struct flag_expected_op
 {
     bool left;
     T    expected;


### PR DESCRIPTION
std::unary_function and std::binary_function was removed in c++17 and is no longer supported.