### PR TITLE
Fix hipGraph memory leaks

### DIFF
--- a/test/hipcub/test_hipcub_device_adjacent_difference.cpp
+++ b/test/hipcub/test_hipcub_device_adjacent_difference.cpp
@@ -215,11 +215,9 @@ TYPED_TEST(HipcubDeviceAdjacentDifference, SubtractLeftCopy)
             HIP_CHECK(
                 test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
-            hipGraph_t graph;
-            if(TestFixture::params::use_graphs)
-            {
-                graph = test_utils::createGraphHelper(stream);
-            }
+            test_utils::GraphHelper gHelper;
+            if (TestFixture::params::use_graphs)
+                gHelper.startStreamCapture(stream);
 
             HIP_CHECK(dispatch_adjacent_difference(left_constant,
                                                    copy_constant,
@@ -231,11 +229,8 @@ TYPED_TEST(HipcubDeviceAdjacentDifference, SubtractLeftCopy)
                                                    op,
                                                    stream));
 
-            hipGraphExec_t graph_instance;
-            if(TestFixture::params::use_graphs)
-            {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
-            }
+            if (TestFixture::params::use_graphs)
+                gHelper.createAndLaunchGraph(stream);
 
             std::vector<output_type> output(size);
             HIP_CHECK(hipMemcpy(output.data(),
@@ -253,16 +248,12 @@ TYPED_TEST(HipcubDeviceAdjacentDifference, SubtractLeftCopy)
             ASSERT_NO_FATAL_FAILURE(test_utils::assert_bit_eq(output, expected));
 
             if(TestFixture::params::use_graphs)
-            {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
-            }
+                gHelper.cleanupGraphHelper();
         }
     }
 
     if(TestFixture::params::use_graphs)
-    {
         HIP_CHECK(hipStreamDestroy(stream));
-    }
 }
 
 // Params for tests

--- a/test/hipcub/test_hipcub_device_for.cpp
+++ b/test/hipcub/test_hipcub_device_for.cpp
@@ -115,20 +115,15 @@ TYPED_TEST(HipcubDeviceForTests, ForEach)
             std::vector<T> expected(input);
             std::for_each(expected.begin(), expected.end(), plus<T>());
 
-            hipGraph_t graph;
-            if(TestFixture::use_graphs)
-            {
-                graph = test_utils::createGraphHelper(stream);
-            }
+            test_utils::GraphHelper gHelper;
+            if (TestFixture::use_graphs)
+                gHelper.startStreamCapture(stream);
 
             // Run
             HIP_CHECK(hipcub::ForEach(d_input, d_input + size, plus<T>(), stream));
 
-            hipGraphExec_t graph_instance;
-            if(TestFixture::use_graphs)
-            {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
-            }
+            if (TestFixture::use_graphs)
+                gHelper.createAndLaunchGraph(stream);
 
             HIP_CHECK(hipGetLastError());
             HIP_CHECK(hipDeviceSynchronize());
@@ -144,18 +139,14 @@ TYPED_TEST(HipcubDeviceForTests, ForEach)
             ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(output, expected));
 
             if(TestFixture::use_graphs)
-            {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
-            }
+                gHelper.cleanupGraphHelper();
 
             HIP_CHECK(hipFree(d_input));
         }
     }
 
     if(TestFixture::use_graphs)
-    {
         HIP_CHECK(hipStreamDestroy(stream));
-    }
 }
 
 template<class T>
@@ -283,20 +274,15 @@ TYPED_TEST(HipcubDeviceForTests, ForEachN)
             std::vector<T> expected(input);
             std::for_each(expected.begin(), expected.begin() + n, plus<T>());
 
-            hipGraph_t graph;
-            if(TestFixture::use_graphs)
-            {
-                graph = test_utils::createGraphHelper(stream);
-            }
+            test_utils::GraphHelper gHelper;
+            if (TestFixture::use_graphs)
+                gHelper.startStreamCapture(stream);
 
             // Run
             HIP_CHECK(hipcub::ForEachN(d_input, n, plus<T>(), stream));
 
-            hipGraphExec_t graph_instance;
-            if(TestFixture::use_graphs)
-            {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
-            }
+            if (TestFixture::use_graphs)
+                gHelper.createAndLaunchGraph(stream);
 
             HIP_CHECK(hipGetLastError());
             HIP_CHECK(hipDeviceSynchronize());
@@ -312,18 +298,14 @@ TYPED_TEST(HipcubDeviceForTests, ForEachN)
             ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(output, expected));
 
             if(TestFixture::use_graphs)
-            {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
-            }
+                gHelper.cleanupGraphHelper();
 
             HIP_CHECK(hipFree(d_input));
         }
     }
 
     if(TestFixture::use_graphs)
-    {
         HIP_CHECK(hipStreamDestroy(stream));
-    }
 }
 
 template<class T>

--- a/test/hipcub/test_hipcub_device_histogram.cpp
+++ b/test/hipcub/test_hipcub_device_histogram.cpp
@@ -273,11 +273,9 @@ TYPED_TEST(HipcubDeviceHistogramEven, Even)
             void * d_temporary_storage;
             HIP_CHECK(test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
-            hipGraph_t graph;
-            if(TestFixture::params::use_graphs)
-            {
-                graph = test_utils::createGraphHelper(stream);
-            }
+            test_utils::GraphHelper gHelper;
+            if (TestFixture::params::use_graphs)
+                gHelper.startStreamCapture(stream);
 
             if(rows == 1)
             {
@@ -306,11 +304,8 @@ TYPED_TEST(HipcubDeviceHistogramEven, Even)
                                                                  stream));
             }
 
-            hipGraphExec_t graph_instance;
-            if(TestFixture::params::use_graphs)
-            {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
-            }
+            if (TestFixture::params::use_graphs)
+                gHelper.createAndLaunchGraph(stream);
 
             std::vector<counter_type> histogram(bins);
             HIP_CHECK(
@@ -331,16 +326,12 @@ TYPED_TEST(HipcubDeviceHistogramEven, Even)
             }
 
             if(TestFixture::params::use_graphs)
-            {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
-            }
+                gHelper.cleanupGraphHelper();
         }
     }
 
     if(TestFixture::params::use_graphs)
-    {
         HIP_CHECK(hipStreamDestroy(stream));
-    }
 }
 
 // Test HistogramEven overflow
@@ -625,11 +616,9 @@ TYPED_TEST(HipcubDeviceHistogramRange, Range)
             void * d_temporary_storage;
             HIP_CHECK(test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
-            hipGraph_t graph;
-            if(TestFixture::params::use_graphs)
-            {
-                graph = test_utils::createGraphHelper(stream);
-            }
+            test_utils::GraphHelper gHelper;
+            if (TestFixture::params::use_graphs)
+                gHelper.startStreamCapture(stream);
 
             if(rows == 1)
             {
@@ -656,11 +645,8 @@ TYPED_TEST(HipcubDeviceHistogramRange, Range)
                                                                   stream));
             }
 
-            hipGraphExec_t graph_instance;
-            if(TestFixture::params::use_graphs)
-            {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
-            }
+            if (TestFixture::params::use_graphs)
+                gHelper.createAndLaunchGraph(stream);
 
             std::vector<counter_type> histogram(bins);
             HIP_CHECK(
@@ -682,15 +668,11 @@ TYPED_TEST(HipcubDeviceHistogramRange, Range)
             }
 
             if(TestFixture::params::use_graphs)
-            {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
-            }
+                gHelper.cleanupGraphHelper();
         }
     }
     if(TestFixture::params::use_graphs)
-    {
         HIP_CHECK(hipStreamDestroy(stream));
-    }
 }
 
 template<class SampleType,
@@ -936,11 +918,9 @@ TYPED_TEST(HipcubDeviceHistogramMultiEven, MultiEven)
             void * d_temporary_storage;
             HIP_CHECK(test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
-            hipGraph_t graph;
-            if(TestFixture::params::use_graphs)
-            {
-                graph = test_utils::createGraphHelper(stream);
-            }
+            test_utils::GraphHelper gHelper;
+            if (TestFixture::params::use_graphs)
+                gHelper.startStreamCapture(stream);
 
             if(rows == 1)
             {
@@ -971,11 +951,8 @@ TYPED_TEST(HipcubDeviceHistogramMultiEven, MultiEven)
                     stream)));
             }
 
-            hipGraphExec_t graph_instance;
-            if(TestFixture::params::use_graphs)
-            {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
-            }
+            if (TestFixture::params::use_graphs)
+                gHelper.createAndLaunchGraph(stream);
 
             std::vector<counter_type> histogram[active_channels];
             for(unsigned int channel = 0; channel < active_channels; channel++)
@@ -1005,16 +982,12 @@ TYPED_TEST(HipcubDeviceHistogramMultiEven, MultiEven)
             }
 
             if(TestFixture::params::use_graphs)
-            {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
-            }
+                gHelper.cleanupGraphHelper();
         }
     }
 
     if(TestFixture::params::use_graphs)
-    {
         HIP_CHECK(hipStreamDestroy(stream));
-    }
 }
 
 template<class SampleType,
@@ -1278,11 +1251,9 @@ TYPED_TEST(HipcubDeviceHistogramMultiRange, MultiRange)
             void * d_temporary_storage;
             HIP_CHECK(test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
-            hipGraph_t graph;
-            if(TestFixture::params::use_graphs)
-            {
-                graph = test_utils::createGraphHelper(stream);
-            }
+            test_utils::GraphHelper gHelper;
+            if (TestFixture::params::use_graphs)
+                gHelper.startStreamCapture(stream);
 
             if(rows == 1)
             {
@@ -1311,11 +1282,8 @@ TYPED_TEST(HipcubDeviceHistogramMultiRange, MultiRange)
                     stream)));
             }
 
-            hipGraphExec_t graph_instance;
-            if(TestFixture::params::use_graphs)
-            {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
-            }
+            if (TestFixture::params::use_graphs)
+                gHelper.createAndLaunchGraph(stream);
 
             std::vector<counter_type> histogram[active_channels];
             for(unsigned int channel = 0; channel < active_channels; channel++)
@@ -1346,14 +1314,10 @@ TYPED_TEST(HipcubDeviceHistogramMultiRange, MultiRange)
             }
 
             if(TestFixture::params::use_graphs)
-            {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
-            }
+                gHelper.cleanupGraphHelper();
         }
     }
 
     if(TestFixture::params::use_graphs)
-    {
         HIP_CHECK(hipStreamDestroy(stream));
-    }
 }

--- a/test/hipcub/test_hipcub_device_merge_sort.cpp
+++ b/test/hipcub/test_hipcub_device_merge_sort.cpp
@@ -129,11 +129,9 @@ TYPED_TEST(HipcubDeviceMergeSort, SortKeys)
             HIP_CHECK(
                 test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
-            hipGraph_t graph;
-            if(TestFixture::params::use_graphs)
-            {
-                graph = test_utils::createGraphHelper(stream);
-            }
+            test_utils::GraphHelper gHelper;
+            if (TestFixture::params::use_graphs)
+                gHelper.startStreamCapture(stream);
 
             HIP_CHECK(hipcub::DeviceMergeSort::SortKeys(d_temporary_storage,
                                                         temporary_storage_bytes,
@@ -142,11 +140,8 @@ TYPED_TEST(HipcubDeviceMergeSort, SortKeys)
                                                         compare_function(),
                                                         stream));
 
-            hipGraphExec_t graph_instance;
-            if(TestFixture::params::use_graphs)
-            {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
-            }
+            if (TestFixture::params::use_graphs)
+                gHelper.createAndLaunchGraph(stream);
 
             HIP_CHECK(hipFree(d_temporary_storage));
 
@@ -164,16 +159,12 @@ TYPED_TEST(HipcubDeviceMergeSort, SortKeys)
             ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(is_sorted_result, true));
 
             if(TestFixture::params::use_graphs)
-            {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
-            }
+                gHelper.cleanupGraphHelper();
         }
     }
 
     if(TestFixture::params::use_graphs)
-    {
         HIP_CHECK(hipStreamDestroy(stream));
-    }
 }
 
 TYPED_TEST(HipcubDeviceMergeSort, SortKeysCopy)
@@ -237,11 +228,9 @@ TYPED_TEST(HipcubDeviceMergeSort, SortKeysCopy)
             HIP_CHECK(
                 test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
-            hipGraph_t graph;
-            if(TestFixture::params::use_graphs)
-            {
-                graph = test_utils::createGraphHelper(stream);
-            }
+            test_utils::GraphHelper gHelper;
+            if (TestFixture::params::use_graphs)
+                gHelper.startStreamCapture(stream);
 
             HIP_CHECK(hipcub::DeviceMergeSort::SortKeysCopy(d_temporary_storage,
                                                             temporary_storage_bytes,
@@ -250,11 +239,9 @@ TYPED_TEST(HipcubDeviceMergeSort, SortKeysCopy)
                                                             size,
                                                             compare_function(),
                                                             stream));
-            hipGraphExec_t graph_instance;
-            if(TestFixture::params::use_graphs)
-            {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
-            }
+
+            if (TestFixture::params::use_graphs)
+                gHelper.createAndLaunchGraph(stream);
 
             HIP_CHECK(hipFree(d_temporary_storage));
             HIP_CHECK(hipFree(d_keys_input));
@@ -273,16 +260,12 @@ TYPED_TEST(HipcubDeviceMergeSort, SortKeysCopy)
             ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(is_sorted_result, true));
 
             if(TestFixture::params::use_graphs)
-            {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
-            }
+                gHelper.cleanupGraphHelper();
         }
     }
 
     if(TestFixture::params::use_graphs)
-    {
         HIP_CHECK(hipStreamDestroy(stream));
-    }
 }
 
 TYPED_TEST(HipcubDeviceMergeSort, StableSortKeys)
@@ -342,11 +325,9 @@ TYPED_TEST(HipcubDeviceMergeSort, StableSortKeys)
             HIP_CHECK(
                 test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
-            hipGraph_t graph;
-            if(TestFixture::params::use_graphs)
-            {
-                graph = test_utils::createGraphHelper(stream);
-            }
+            test_utils::GraphHelper gHelper;
+            if (TestFixture::params::use_graphs)
+                gHelper.startStreamCapture(stream);
 
             HIP_CHECK(hipcub::DeviceMergeSort::SortKeys(d_temporary_storage,
                                                         temporary_storage_bytes,
@@ -355,11 +336,8 @@ TYPED_TEST(HipcubDeviceMergeSort, StableSortKeys)
                                                         compare_function(),
                                                         stream));
 
-            hipGraphExec_t graph_instance;
-            if(TestFixture::params::use_graphs)
-            {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
-            }
+            if (TestFixture::params::use_graphs)
+                gHelper.createAndLaunchGraph(stream);
 
             HIP_CHECK(hipFree(d_temporary_storage));
 
@@ -378,16 +356,12 @@ TYPED_TEST(HipcubDeviceMergeSort, StableSortKeys)
             ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(keys_output, expected));
 
             if(TestFixture::params::use_graphs)
-            {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
-            }
+                gHelper.cleanupGraphHelper();
         }
     }
 
     if(TestFixture::params::use_graphs)
-    {
         HIP_CHECK(hipStreamDestroy(stream));
-    }
 }
 
 TYPED_TEST(HipcubDeviceMergeSort, StableSortKeysCopy)
@@ -449,11 +423,9 @@ TYPED_TEST(HipcubDeviceMergeSort, StableSortKeysCopy)
             HIP_CHECK(
                 test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
-            hipGraph_t graph;
-            if(TestFixture::params::use_graphs)
-            {
-                graph = test_utils::createGraphHelper(stream);
-            }
+            test_utils::GraphHelper gHelper;
+            if (TestFixture::params::use_graphs)
+                gHelper.startStreamCapture(stream);
 
             HIP_CHECK(hipcub::DeviceMergeSort::StableSortKeysCopy(d_temporary_storage,
                                                                   temporary_storage_bytes,
@@ -463,11 +435,8 @@ TYPED_TEST(HipcubDeviceMergeSort, StableSortKeysCopy)
                                                                   compare_function(),
                                                                   stream));
 
-            hipGraphExec_t graph_instance;
-            if(TestFixture::params::use_graphs)
-            {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
-            }
+            if (TestFixture::params::use_graphs)
+                gHelper.createAndLaunchGraph(stream);
 
             HIP_CHECK(hipFree(d_temporary_storage));
             HIP_CHECK(hipFree(d_keys_input));
@@ -487,16 +456,12 @@ TYPED_TEST(HipcubDeviceMergeSort, StableSortKeysCopy)
             ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(keys_output, expected));
 
             if(TestFixture::params::use_graphs)
-            {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
-            }
+                gHelper.cleanupGraphHelper();
         }
     }
 
     if(TestFixture::params::use_graphs)
-    {
         HIP_CHECK(hipStreamDestroy(stream));
-    }
 }
 
 TYPED_TEST(HipcubDeviceMergeSort, SortPairs)
@@ -587,11 +552,9 @@ TYPED_TEST(HipcubDeviceMergeSort, SortPairs)
             HIP_CHECK(
                 test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
-            hipGraph_t graph;
-            if(TestFixture::params::use_graphs)
-            {
-                graph = test_utils::createGraphHelper(stream);
-            }
+            test_utils::GraphHelper gHelper;
+            if (TestFixture::params::use_graphs)
+                gHelper.startStreamCapture(stream);
 
             HIP_CHECK(hipcub::DeviceMergeSort::SortPairs(d_temporary_storage,
                                                          temporary_storage_bytes,
@@ -601,11 +564,8 @@ TYPED_TEST(HipcubDeviceMergeSort, SortPairs)
                                                          compare_op,
                                                          stream));
 
-            hipGraphExec_t graph_instance;
-            if(TestFixture::params::use_graphs)
-            {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
-            }
+            if (TestFixture::params::use_graphs)
+                gHelper.createAndLaunchGraph(stream);
 
             HIP_CHECK(hipFree(d_temporary_storage));
 
@@ -636,16 +596,12 @@ TYPED_TEST(HipcubDeviceMergeSort, SortPairs)
             ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(values_output, values_expected));
 
             if(TestFixture::params::use_graphs)
-            {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
-            }
+                gHelper.cleanupGraphHelper();
         }
     }
 
     if(TestFixture::params::use_graphs)
-    {
         HIP_CHECK(hipStreamDestroy(stream));
-    }
 }
 
 TYPED_TEST(HipcubDeviceMergeSort, SortPairsCopy)
@@ -752,11 +708,9 @@ TYPED_TEST(HipcubDeviceMergeSort, SortPairsCopy)
             HIP_CHECK(
                 test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
-            hipGraph_t graph;
-            if(TestFixture::params::use_graphs)
-            {
-                graph = test_utils::createGraphHelper(stream);
-            }
+            test_utils::GraphHelper gHelper;
+            if (TestFixture::params::use_graphs)
+                gHelper.startStreamCapture(stream);
 
             HIP_CHECK(hipcub::DeviceMergeSort::SortPairsCopy(d_temporary_storage,
                                                              temporary_storage_bytes,
@@ -768,11 +722,8 @@ TYPED_TEST(HipcubDeviceMergeSort, SortPairsCopy)
                                                              compare_op,
                                                              stream));
 
-            hipGraphExec_t graph_instance;
-            if(TestFixture::params::use_graphs)
-            {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
-            }
+            if (TestFixture::params::use_graphs)
+                gHelper.createAndLaunchGraph(stream);
 
             HIP_CHECK(hipFree(d_temporary_storage));
             HIP_CHECK(hipFree(d_keys_input));
@@ -797,16 +748,12 @@ TYPED_TEST(HipcubDeviceMergeSort, SortPairsCopy)
             ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(values_output, values_expected));
 
             if(TestFixture::params::use_graphs)
-            {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
-            }
+                gHelper.cleanupGraphHelper();
         }
     }
 
     if(TestFixture::params::use_graphs)
-    {
         HIP_CHECK(hipStreamDestroy(stream));
-    }
 }
 
 TYPED_TEST(HipcubDeviceMergeSort, StableSortPairs)
@@ -896,11 +843,9 @@ TYPED_TEST(HipcubDeviceMergeSort, StableSortPairs)
             HIP_CHECK(
                 test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
-            hipGraph_t graph;
-            if(TestFixture::params::use_graphs)
-            {
-                graph = test_utils::createGraphHelper(stream);
-            }
+            test_utils::GraphHelper gHelper;
+            if (TestFixture::params::use_graphs)
+                gHelper.startStreamCapture(stream);
 
             HIP_CHECK(hipcub::DeviceMergeSort::StableSortPairs(d_temporary_storage,
                                                                temporary_storage_bytes,
@@ -910,11 +855,8 @@ TYPED_TEST(HipcubDeviceMergeSort, StableSortPairs)
                                                                compare_op,
                                                                stream));
 
-            hipGraphExec_t graph_instance;
-            if(TestFixture::params::use_graphs)
-            {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
-            }
+            if (TestFixture::params::use_graphs)
+                gHelper.createAndLaunchGraph(stream);
 
             HIP_CHECK(hipFree(d_temporary_storage));
 
@@ -945,14 +887,10 @@ TYPED_TEST(HipcubDeviceMergeSort, StableSortPairs)
             ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(values_output, values_expected));
 
             if(TestFixture::params::use_graphs)
-            {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
-            }
+                gHelper.cleanupGraphHelper();
         }
     }
 
     if(TestFixture::params::use_graphs)
-    {
         HIP_CHECK(hipStreamDestroy(stream));
-    }
 }

--- a/test/hipcub/test_hipcub_device_partition.cpp
+++ b/test/hipcub/test_hipcub_device_partition.cpp
@@ -153,11 +153,9 @@ TYPED_TEST(HipcubDevicePartitionTests, Flagged)
             HIP_CHECK(hipMalloc(&d_temp_storage, temp_storage_size_bytes));
             HIP_CHECK(hipDeviceSynchronize());
 
-            hipGraph_t graph;
-            if(TestFixture::use_graphs)
-            {
-                graph = test_utils::createGraphHelper(stream);
-            }
+            test_utils::GraphHelper gHelper;
+            if (TestFixture::use_graphs)
+                gHelper.startStreamCapture(stream);
 
             // Run
             HIP_CHECK(hipcub::DevicePartition::Flagged(
@@ -170,11 +168,8 @@ TYPED_TEST(HipcubDevicePartitionTests, Flagged)
                 input.size(),
                 stream));
 
-            hipGraphExec_t graph_instance;
-            if(TestFixture::use_graphs)
-            {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
-            }
+            if (TestFixture::use_graphs)
+                gHelper.createAndLaunchGraph(stream);
 
             HIP_CHECK(hipDeviceSynchronize());
 
@@ -208,9 +203,7 @@ TYPED_TEST(HipcubDevicePartitionTests, Flagged)
                                                           expected_rejected.size()));
 
             if(TestFixture::use_graphs)
-            {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
-            }
+                gHelper.cleanupGraphHelper();
 
             HIP_CHECK(hipFree(d_input));
             HIP_CHECK(hipFree(d_flags));
@@ -221,9 +214,7 @@ TYPED_TEST(HipcubDevicePartitionTests, Flagged)
     }
 
     if(TestFixture::use_graphs)
-    {
         HIP_CHECK(hipStreamDestroy(stream));
-    }
 }
 
 // NOTE: The following lambdas cannot be inside the test because of nvcc
@@ -330,11 +321,9 @@ TYPED_TEST(HipcubDevicePartitionTests, If)
             HIP_CHECK(hipMalloc(&d_temp_storage, temp_storage_size_bytes));
             HIP_CHECK(hipDeviceSynchronize());
 
-            hipGraph_t graph;
-            if(TestFixture::use_graphs)
-            {
-                graph = test_utils::createGraphHelper(stream);
-            }
+            test_utils::GraphHelper gHelper;
+            if (TestFixture::use_graphs)
+                gHelper.startStreamCapture(stream);
 
             // Run
             HIP_CHECK(hipcub::DevicePartition::If(
@@ -347,11 +336,8 @@ TYPED_TEST(HipcubDevicePartitionTests, If)
                 select_op,
                 stream));
 
-            hipGraphExec_t graph_instance;
-            if(TestFixture::use_graphs)
-            {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
-            }
+            if (TestFixture::use_graphs)
+                gHelper.createAndLaunchGraph(stream);
 
             HIP_CHECK(hipDeviceSynchronize());
 
@@ -385,9 +371,7 @@ TYPED_TEST(HipcubDevicePartitionTests, If)
                                                           expected_rejected.size()));
 
             if(TestFixture::use_graphs)
-            {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
-            }
+                gHelper.cleanupGraphHelper();
 
             HIP_CHECK(hipFree(d_input));
             HIP_CHECK(hipFree(d_output));
@@ -397,9 +381,7 @@ TYPED_TEST(HipcubDevicePartitionTests, If)
     }
 
     if(TestFixture::use_graphs)
-    {
         HIP_CHECK(hipStreamDestroy(stream));
-    }
 }
 
 namespace
@@ -513,11 +495,9 @@ TYPED_TEST(HipcubDevicePartitionTests, IfThreeWay)
             void* d_temp_storage = nullptr;
             HIP_CHECK(hipMalloc(&d_temp_storage, temp_storage_size_bytes));
 
-            hipGraph_t graph;
-            if(TestFixture::use_graphs)
-            {
-                graph = test_utils::createGraphHelper(stream);
-            }
+            test_utils::GraphHelper gHelper;
+            if (TestFixture::use_graphs)
+                gHelper.startStreamCapture(stream);
 
             // Run
             HIP_CHECK(hipcub::DevicePartition::If(
@@ -533,11 +513,8 @@ TYPED_TEST(HipcubDevicePartitionTests, IfThreeWay)
                 second_op,
                 stream));
 
-            hipGraphExec_t graph_instance;
-            if(TestFixture::use_graphs)
-            {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
-            }
+            if (TestFixture::use_graphs)
+                gHelper.createAndLaunchGraph(stream);
 
             HIP_CHECK(hipDeviceSynchronize());
 
@@ -571,9 +548,7 @@ TYPED_TEST(HipcubDevicePartitionTests, IfThreeWay)
             ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(output, expected));
 
             if(TestFixture::use_graphs)
-            {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
-            }
+                gHelper.cleanupGraphHelper();
 
             HIP_CHECK(hipFree(d_input));
             HIP_CHECK(hipFree(d_first_output));
@@ -585,7 +560,5 @@ TYPED_TEST(HipcubDevicePartitionTests, IfThreeWay)
     }
 
     if(TestFixture::use_graphs)
-    {
         HIP_CHECK(hipStreamDestroy(stream));
-    }
 }

--- a/test/hipcub/test_hipcub_device_radix_sort.hpp
+++ b/test/hipcub/test_hipcub_device_radix_sort.hpp
@@ -288,11 +288,9 @@ void sort_keys()
             HIP_CHECK(
                 test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
-            hipGraph_t graph;
-            if(TestFixture::params::use_graphs)
-            {
-                graph = test_utils::createGraphHelper(stream);
-            }
+            test_utils::GraphHelper gHelper;
+            if (TestFixture::params::use_graphs)
+                gHelper.startStreamCapture(stream);
 
             HIP_CHECK(invoke_sort_keys<descending>(d_temporary_storage,
                                                    temporary_storage_bytes,
@@ -303,11 +301,8 @@ void sort_keys()
                                                    end_bit,
                                                    stream));
 
-            hipGraphExec_t graph_instance;
-            if(TestFixture::params::use_graphs)
-            {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
-            }
+            if (TestFixture::params::use_graphs)
+                gHelper.createAndLaunchGraph(stream);
 
             HIP_CHECK(hipFree(d_temporary_storage));
             HIP_CHECK(hipFree(d_keys_input));
@@ -323,16 +318,12 @@ void sort_keys()
             ASSERT_NO_FATAL_FAILURE(test_utils::assert_bit_eq(keys_output, expected));
 
             if(TestFixture::params::use_graphs)
-            {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
-            }
+                gHelper.cleanupGraphHelper();
         }
     }
 
     if(TestFixture::params::use_graphs)
-    {
         HIP_CHECK(hipStreamDestroy(stream));
-    }
 }
 
 template<bool Descending, class Key, class Value>
@@ -560,11 +551,9 @@ void sort_pairs()
             HIP_CHECK(
                 test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
-            hipGraph_t graph;
-            if(TestFixture::params::use_graphs)
-            {
-                graph = test_utils::createGraphHelper(stream);
-            }
+            test_utils::GraphHelper gHelper;
+            if (TestFixture::params::use_graphs)
+                gHelper.startStreamCapture(stream);
 
             HIP_CHECK(invoke_sort_pairs<descending>(d_temporary_storage,
                                                     temporary_storage_bytes,
@@ -577,11 +566,8 @@ void sort_pairs()
                                                     end_bit,
                                                     stream));
 
-            hipGraphExec_t graph_instance;
-            if(TestFixture::params::use_graphs)
-            {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
-            }
+            if (TestFixture::params::use_graphs)
+                gHelper.createAndLaunchGraph(stream);
 
             HIP_CHECK(hipFree(d_temporary_storage));
             HIP_CHECK(hipFree(d_keys_input));
@@ -614,16 +600,12 @@ void sort_pairs()
             ASSERT_NO_FATAL_FAILURE(test_utils::assert_bit_eq(values_output, values_expected));
 
             if(TestFixture::params::use_graphs)
-            {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
-            }
+                gHelper.cleanupGraphHelper();
         }
     }
 
     if(TestFixture::params::use_graphs)
-    {
         HIP_CHECK(hipStreamDestroy(stream));
-    }
 }
 
 template<bool Descending, class Key>
@@ -798,11 +780,9 @@ void sort_keys_double_buffer()
             HIP_CHECK(
                 test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
-            hipGraph_t graph;
-            if(TestFixture::params::use_graphs)
-            {
-                graph = test_utils::createGraphHelper(stream);
-            }
+            test_utils::GraphHelper gHelper;
+            if (TestFixture::params::use_graphs)
+                gHelper.startStreamCapture(stream);
 
             HIP_CHECK(invoke_sort_keys<descending>(d_temporary_storage,
                                                    temporary_storage_bytes,
@@ -812,11 +792,8 @@ void sort_keys_double_buffer()
                                                    end_bit,
                                                    stream));
 
-            hipGraphExec_t graph_instance;
-            if(TestFixture::params::use_graphs)
-            {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
-            }
+            if (TestFixture::params::use_graphs)
+                gHelper.createAndLaunchGraph(stream);
 
             HIP_CHECK(hipFree(d_temporary_storage));
 
@@ -832,16 +809,12 @@ void sort_keys_double_buffer()
             ASSERT_NO_FATAL_FAILURE(test_utils::assert_bit_eq(keys_output, expected));
 
             if(TestFixture::params::use_graphs)
-            {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
-            }
+                gHelper.cleanupGraphHelper();
         }
     }
 
     if(TestFixture::params::use_graphs)
-    {
         HIP_CHECK(hipStreamDestroy(stream));
-    }
 }
 
 template<bool Descending, class Key, class Value>
@@ -1050,11 +1023,9 @@ void sort_pairs_double_buffer()
             HIP_CHECK(
                 test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
-            hipGraph_t graph;
-            if(TestFixture::params::use_graphs)
-            {
-                graph = test_utils::createGraphHelper(stream);
-            }
+            test_utils::GraphHelper gHelper;
+            if (TestFixture::params::use_graphs)
+                gHelper.startStreamCapture(stream);
 
             HIP_CHECK(invoke_sort_pairs<descending>(d_temporary_storage,
                                                     temporary_storage_bytes,
@@ -1065,11 +1036,8 @@ void sort_pairs_double_buffer()
                                                     end_bit,
                                                     stream));
 
-            hipGraphExec_t graph_instance;
-            if(TestFixture::params::use_graphs)
-            {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
-            }
+            if (TestFixture::params::use_graphs)
+                gHelper.createAndLaunchGraph(stream);
 
             HIP_CHECK(hipFree(d_temporary_storage));
 
@@ -1102,16 +1070,12 @@ void sort_pairs_double_buffer()
             ASSERT_NO_FATAL_FAILURE(test_utils::assert_bit_eq(values_output, values_expected));
 
             if(TestFixture::params::use_graphs)
-            {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
-            }
+                gHelper.cleanupGraphHelper();
         }
     }
 
     if(TestFixture::params::use_graphs)
-    {
         HIP_CHECK(hipStreamDestroy(stream));
-    }
 }
 
 inline void sort_keys_over_4g()

--- a/test/hipcub/test_hipcub_device_reduce.cpp
+++ b/test/hipcub/test_hipcub_device_reduce.cpp
@@ -156,11 +156,9 @@ TYPED_TEST(HipcubDeviceReduceTests, ReduceSum)
             HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
             HIP_CHECK(hipDeviceSynchronize());
 
-            hipGraph_t graph;
-            if(TestFixture::use_graphs)
-            {
-                graph = test_utils::createGraphHelper(stream);
-            }
+            test_utils::GraphHelper gHelper;
+            if (TestFixture::use_graphs)
+                gHelper.startStreamCapture(stream);
 
             // Run
             reduce_selector.reduce_sum(d_temp_storage,
@@ -170,11 +168,8 @@ TYPED_TEST(HipcubDeviceReduceTests, ReduceSum)
                                        input.size(),
                                        stream);
 
-            hipGraphExec_t graph_instance;
-            if(TestFixture::use_graphs)
-            {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
-            }
+            if (TestFixture::use_graphs)
+                gHelper.createAndLaunchGraph(stream);
 
             HIP_CHECK(hipPeekAtLastError());
             HIP_CHECK(hipDeviceSynchronize());
@@ -193,9 +188,7 @@ TYPED_TEST(HipcubDeviceReduceTests, ReduceSum)
                                         test_utils::precision<U>::value * size));
 
             if(TestFixture::use_graphs)
-            {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
-            }
+                gHelper.cleanupGraphHelper();
 
             HIP_CHECK(hipFree(d_input));
             HIP_CHECK(hipFree(d_output));
@@ -204,9 +197,7 @@ TYPED_TEST(HipcubDeviceReduceTests, ReduceSum)
     }
 
     if(TestFixture::use_graphs)
-    {
         HIP_CHECK(hipStreamDestroy(stream));
-    }
 }
 
 TYPED_TEST(HipcubDeviceReduceTests, ReduceMinimum)
@@ -277,11 +268,9 @@ TYPED_TEST(HipcubDeviceReduceTests, ReduceMinimum)
             HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
             HIP_CHECK(hipDeviceSynchronize());
 
-            hipGraph_t graph;
-            if(TestFixture::use_graphs)
-            {
-                graph = test_utils::createGraphHelper(stream);
-            }
+            test_utils::GraphHelper gHelper;
+            if (TestFixture::use_graphs)
+                gHelper.startStreamCapture(stream);
 
             // Run
             HIP_CHECK(hipcub::DeviceReduce::Min(d_temp_storage,
@@ -291,11 +280,8 @@ TYPED_TEST(HipcubDeviceReduceTests, ReduceMinimum)
                                                 input.size(),
                                                 stream));
 
-            hipGraphExec_t graph_instance;
-            if(TestFixture::use_graphs)
-            {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
-            }
+            if (TestFixture::use_graphs)
+                gHelper.createAndLaunchGraph(stream);
 
             HIP_CHECK(hipPeekAtLastError());
             HIP_CHECK(hipDeviceSynchronize());
@@ -316,9 +302,7 @@ TYPED_TEST(HipcubDeviceReduceTests, ReduceMinimum)
                     : std::max(test_utils::precision<T>::value, test_utils::precision<U>::value)));
 
             if(TestFixture::use_graphs)
-            {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
-            }
+                gHelper.cleanupGraphHelper();
 
             HIP_CHECK(hipFree(d_input));
             HIP_CHECK(hipFree(d_output));
@@ -327,9 +311,7 @@ TYPED_TEST(HipcubDeviceReduceTests, ReduceMinimum)
     }
 
     if(TestFixture::use_graphs)
-    {
         HIP_CHECK(hipStreamDestroy(stream));
-    }
 }
 
 struct ArgMinDispatch
@@ -445,11 +427,9 @@ void test_argminmax(typename TestFixture::input_type empty_value)
             HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
             HIP_CHECK(hipDeviceSynchronize());
 
-            hipGraph_t graph;
-            if(TestFixture::use_graphs)
-            {
-                graph = test_utils::createGraphHelper(stream);
-            }
+            test_utils::GraphHelper gHelper;
+            if (TestFixture::use_graphs)
+                gHelper.startStreamCapture(stream);
 
             // Run
             HIP_CHECK(function(d_temp_storage,
@@ -459,11 +439,8 @@ void test_argminmax(typename TestFixture::input_type empty_value)
                                input.size(),
                                stream));
 
-            hipGraphExec_t graph_instance;
-            if(TestFixture::use_graphs)
-            {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
-            }
+            if (TestFixture::use_graphs)
+                gHelper.createAndLaunchGraph(stream);
 
             HIP_CHECK(hipPeekAtLastError());
             HIP_CHECK(hipDeviceSynchronize());
@@ -484,16 +461,12 @@ void test_argminmax(typename TestFixture::input_type empty_value)
                                         test_utils::precision<T>::value * size));
 
             if(TestFixture::use_graphs)
-            {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
-            }
+                gHelper.cleanupGraphHelper();
         }
     }
 
     if(TestFixture::use_graphs)
-    {
         HIP_CHECK(hipStreamDestroy(stream));
-    }
 }
 
 TYPED_TEST(HipcubDeviceReduceTests, ReduceArgMinimum)
@@ -696,11 +669,9 @@ TYPED_TEST(HipcubDeviceReduceTests, TransformReduce)
             // allocate temporary storage
             HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
 
-            hipGraph_t graph;
-            if(TestFixture::use_graphs)
-            {
-                graph = test_utils::createGraphHelper(stream);
-            }
+            test_utils::GraphHelper gHelper;
+            if (TestFixture::use_graphs)
+                gHelper.startStreamCapture(stream);
 
             // Run
             HIP_CHECK(hipcub::DeviceReduce::TransformReduce(d_temp_storage,
@@ -713,11 +684,8 @@ TYPED_TEST(HipcubDeviceReduceTests, TransformReduce)
                                                             init,
                                                             stream));
 
-            hipGraphExec_t graph_instance;
-            if(TestFixture::use_graphs)
-            {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
-            }
+            if (TestFixture::use_graphs)
+                gHelper.createAndLaunchGraph(stream);
 
             HIP_CHECK(hipPeekAtLastError());
             HIP_CHECK(hipDeviceSynchronize());
@@ -735,9 +703,7 @@ TYPED_TEST(HipcubDeviceReduceTests, TransformReduce)
                                         test_utils::precision<U>::value * size));
 
             if(TestFixture::use_graphs)
-            {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
-            }
+                gHelper.cleanupGraphHelper();
 
             HIP_CHECK(hipFree(d_input));
             HIP_CHECK(hipFree(d_output));
@@ -746,9 +712,7 @@ TYPED_TEST(HipcubDeviceReduceTests, TransformReduce)
     }
 
     if(TestFixture::use_graphs)
-    {
         HIP_CHECK(hipStreamDestroy(stream));
-    }
 }
 
 // ---------------------------------------------------------

--- a/test/hipcub/test_hipcub_device_reduce_by_key.cpp
+++ b/test/hipcub/test_hipcub_device_reduce_by_key.cpp
@@ -209,11 +209,9 @@ TYPED_TEST(HipcubDeviceReduceByKey, ReduceByKey)
             void * d_temporary_storage;
             HIP_CHECK(test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
-            hipGraph_t graph;
-            if(TestFixture::params::use_graphs)
-            {
-                graph = test_utils::createGraphHelper(stream);
-            }
+            test_utils::GraphHelper gHelper;
+            if (TestFixture::params::use_graphs)
+                gHelper.startStreamCapture(stream);
 
             HIP_CHECK(hipcub::DeviceReduce::ReduceByKey(d_temporary_storage,
                                                         temporary_storage_bytes,
@@ -226,11 +224,8 @@ TYPED_TEST(HipcubDeviceReduceByKey, ReduceByKey)
                                                         size,
                                                         stream));
 
-            hipGraphExec_t graph_instance;
-            if(TestFixture::params::use_graphs)
-            {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
-            }
+            if (TestFixture::params::use_graphs)
+                gHelper.createAndLaunchGraph(stream);
 
             HIP_CHECK(hipFree(d_temporary_storage));
 
@@ -276,14 +271,10 @@ TYPED_TEST(HipcubDeviceReduceByKey, ReduceByKey)
                                             * TestFixture::params::max_segment_length));
 
             if(TestFixture::params::use_graphs)
-            {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
-            }
+                gHelper.cleanupGraphHelper();
         }
     }
 
     if(TestFixture::params::use_graphs)
-    {
         HIP_CHECK(hipStreamDestroy(stream));
-    }
 }

--- a/test/hipcub/test_hipcub_device_scan.cpp
+++ b/test/hipcub/test_hipcub_device_scan.cpp
@@ -258,20 +258,15 @@ TYPED_TEST(HipcubDeviceScanTests, InclusiveScan)
             // allocate temporary storage
             HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
 
-            hipGraph_t graph;
-            if(TestFixture::use_graphs)
-            {
-                graph = test_utils::createGraphHelper(stream);
-            }
+            test_utils::GraphHelper gHelper;
+            if (TestFixture::use_graphs)
+                gHelper.startStreamCapture(stream);
 
             // Run
             call(d_temp_storage, temp_storage_size_bytes);
 
-            hipGraphExec_t graph_instance;
-            if(TestFixture::use_graphs)
-            {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
-            }
+            if (TestFixture::use_graphs)
+                gHelper.createAndLaunchGraph(stream);
 
             HIP_CHECK(hipPeekAtLastError());
             HIP_CHECK(hipDeviceSynchronize());
@@ -298,9 +293,7 @@ TYPED_TEST(HipcubDeviceScanTests, InclusiveScan)
                 test_utils::assert_near(output, expected, single_op_precision * size));
 
             if(TestFixture::use_graphs)
-            {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
-            }
+                gHelper.cleanupGraphHelper();
 
             HIP_CHECK(hipFree(d_input));
             if(!inplace)
@@ -312,9 +305,7 @@ TYPED_TEST(HipcubDeviceScanTests, InclusiveScan)
     }
 
     if(TestFixture::use_graphs)
-    {
         HIP_CHECK(hipStreamDestroy(stream));
-    }
 }
 
 TYPED_TEST(HipcubDeviceScanTests, InclusiveScanByKey)
@@ -444,11 +435,9 @@ TYPED_TEST(HipcubDeviceScanTests, InclusiveScanByKey)
             HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
             HIP_CHECK(hipDeviceSynchronize());
 
-            hipGraph_t graph;
-            if(TestFixture::use_graphs)
-            {
-                graph = test_utils::createGraphHelper(stream);
-            }
+            test_utils::GraphHelper gHelper;
+            if (TestFixture::use_graphs)
+                gHelper.startStreamCapture(stream);
 
             // Run
             if(std::is_same<scan_op_type, hipcub::Sum>::value)
@@ -475,11 +464,8 @@ TYPED_TEST(HipcubDeviceScanTests, InclusiveScanByKey)
                                                                  stream));
             }
 
-            hipGraphExec_t graph_instance;
-            if(TestFixture::use_graphs)
-            {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
-            }
+            if (TestFixture::use_graphs)
+                gHelper.createAndLaunchGraph(stream);
 
             HIP_CHECK(hipPeekAtLastError());
             HIP_CHECK(hipDeviceSynchronize());
@@ -496,9 +482,7 @@ TYPED_TEST(HipcubDeviceScanTests, InclusiveScanByKey)
                 test_utils::assert_near(output, expected, single_op_precision * size));
 
             if(TestFixture::use_graphs)
-            {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
-            }
+                gHelper.cleanupGraphHelper();
 
             HIP_CHECK(hipFree(d_keys));
             HIP_CHECK(hipFree(d_input));
@@ -508,9 +492,7 @@ TYPED_TEST(HipcubDeviceScanTests, InclusiveScanByKey)
     }
 
     if(TestFixture::use_graphs)
-    {
         HIP_CHECK(hipStreamDestroy(stream));
-    }
 }
 
 TYPED_TEST(HipcubDeviceScanTests, ExclusiveScan)
@@ -668,20 +650,15 @@ TYPED_TEST(HipcubDeviceScanTests, ExclusiveScan)
             // allocate temporary storage
             HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
 
-            hipGraph_t graph;
-            if(TestFixture::use_graphs)
-            {
-                graph = test_utils::createGraphHelper(stream);
-            }
+            test_utils::GraphHelper gHelper;
+            if (TestFixture::use_graphs)
+                gHelper.startStreamCapture(stream);
 
             // Run
             call(d_temp_storage, temp_storage_size_bytes);
 
-            hipGraphExec_t graph_instance;
-            if(TestFixture::use_graphs)
-            {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
-            }
+            if (TestFixture::use_graphs)
+                gHelper.createAndLaunchGraph(stream);
 
             HIP_CHECK(hipPeekAtLastError());
             HIP_CHECK(hipDeviceSynchronize());
@@ -708,9 +685,7 @@ TYPED_TEST(HipcubDeviceScanTests, ExclusiveScan)
                 test_utils::assert_near(output, expected, single_op_precision * size));
 
             if(TestFixture::use_graphs)
-            {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
-            }
+                gHelper.cleanupGraphHelper();
 
             HIP_CHECK(hipFree(d_input));
             if(!inplace)
@@ -722,9 +697,7 @@ TYPED_TEST(HipcubDeviceScanTests, ExclusiveScan)
     }
 
     if(TestFixture::use_graphs)
-    {
         HIP_CHECK(hipStreamDestroy(stream));
-    }
 }
 
 TYPED_TEST(HipcubDeviceScanTests, ExclusiveScanByKey)
@@ -867,11 +840,9 @@ TYPED_TEST(HipcubDeviceScanTests, ExclusiveScanByKey)
             HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
             HIP_CHECK(hipDeviceSynchronize());
 
-            hipGraph_t graph;
-            if(TestFixture::use_graphs)
-            {
-                graph = test_utils::createGraphHelper(stream);
-            }
+            test_utils::GraphHelper gHelper;
+            if (TestFixture::use_graphs)
+                gHelper.startStreamCapture(stream);
 
             // Run
             if(std::is_same<scan_op_type, hipcub::Sum>::value)
@@ -899,11 +870,8 @@ TYPED_TEST(HipcubDeviceScanTests, ExclusiveScanByKey)
                                                                  stream));
             }
 
-            hipGraphExec_t graph_instance;
-            if(TestFixture::use_graphs)
-            {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
-            }
+            if (TestFixture::use_graphs)
+                gHelper.createAndLaunchGraph(stream);
 
             HIP_CHECK(hipPeekAtLastError());
             HIP_CHECK(hipDeviceSynchronize());
@@ -920,9 +888,7 @@ TYPED_TEST(HipcubDeviceScanTests, ExclusiveScanByKey)
                 test_utils::assert_near(output, expected, single_op_precision * size));
 
             if(TestFixture::use_graphs)
-            {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
-            }
+                gHelper.cleanupGraphHelper();
 
             HIP_CHECK(hipFree(d_keys));
             HIP_CHECK(hipFree(d_input));
@@ -932,9 +898,7 @@ TYPED_TEST(HipcubDeviceScanTests, ExclusiveScanByKey)
     }
 
     if(TestFixture::use_graphs)
-    {
         HIP_CHECK(hipStreamDestroy(stream));
-    }
 }
 
 // CUB does not support large indices in inclusive and exclusive scans
@@ -1221,11 +1185,9 @@ TYPED_TEST(HipcubDeviceScanTests, ExclusiveScanFuture)
             fill_initial_value<<<1, 1, 0, stream>>>(d_initial_value, initial_value);
             HIP_CHECK(hipGetLastError());
 
-            hipGraph_t graph;
-            if(TestFixture::use_graphs)
-            {
-                graph = test_utils::createGraphHelper(stream);
-            }
+            test_utils::GraphHelper gHelper;
+            if (TestFixture::use_graphs)
+                gHelper.startStreamCapture(stream);
 
             // Run
             HIP_CHECK(hipcub::DeviceScan::ExclusiveScan(d_temp_storage,
@@ -1237,11 +1199,8 @@ TYPED_TEST(HipcubDeviceScanTests, ExclusiveScanFuture)
                                                         input.size(),
                                                         stream));
 
-            hipGraphExec_t graph_instance;
-            if(TestFixture::use_graphs)
-            {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
-            }
+            if (TestFixture::use_graphs)
+                gHelper.createAndLaunchGraph(stream);
 
             HIP_CHECK(hipPeekAtLastError());
             HIP_CHECK(hipDeviceSynchronize());
@@ -1258,9 +1217,7 @@ TYPED_TEST(HipcubDeviceScanTests, ExclusiveScanFuture)
                 test_utils::assert_near(output, expected, single_op_precision * size));
 
             if(TestFixture::use_graphs)
-            {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
-            }
+                gHelper.cleanupGraphHelper();
 
             HIP_CHECK(hipFree(d_input));
             HIP_CHECK(hipFree(d_output));
@@ -1270,7 +1227,5 @@ TYPED_TEST(HipcubDeviceScanTests, ExclusiveScanFuture)
     }
 
     if(TestFixture::use_graphs)
-    {
         HIP_CHECK(hipStreamDestroy(stream));
-    }
 }

--- a/test/hipcub/test_hipcub_device_segmented_reduce.cpp
+++ b/test/hipcub/test_hipcub_device_segmented_reduce.cpp
@@ -193,11 +193,9 @@ TYPED_TEST(HipcubDeviceSegmentedReduceOp, Reduce)
             HIP_CHECK(
                 test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
-            hipGraph_t graph;
-            if(TestFixture::params::use_graphs)
-            {
-                graph = test_utils::createGraphHelper(stream);
-            }
+            test_utils::GraphHelper gHelper;
+            if (TestFixture::params::use_graphs)
+                gHelper.startStreamCapture(stream);
 
             HIP_CHECK(hipcub::DeviceSegmentedReduce::Reduce(d_temporary_storage,
                                                             temporary_storage_bytes,
@@ -210,11 +208,8 @@ TYPED_TEST(HipcubDeviceSegmentedReduceOp, Reduce)
                                                             init,
                                                             stream));
 
-            hipGraphExec_t graph_instance;
-            if(TestFixture::params::use_graphs)
-            {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
-            }
+            if (TestFixture::params::use_graphs)
+                gHelper.createAndLaunchGraph(stream);
 
             HIP_CHECK(hipFree(d_temporary_storage));
 
@@ -232,16 +227,12 @@ TYPED_TEST(HipcubDeviceSegmentedReduceOp, Reduce)
                 test_utils::assert_near(aggregates_output, aggregates_expected, precision));
 
             if(TestFixture::params::use_graphs)
-            {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
-            }
+                gHelper.cleanupGraphHelper();
         }
     }
 
     if(TestFixture::params::use_graphs)
-    {
         HIP_CHECK(hipStreamDestroy(stream));
-    }
 }
 
 template<class Input,
@@ -399,11 +390,9 @@ TYPED_TEST(HipcubDeviceSegmentedReduce, Sum)
             HIP_CHECK(
                 test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
-            hipGraph_t graph;
-            if(TestFixture::params::use_graphs)
-            {
-                graph = test_utils::createGraphHelper(stream);
-            }
+            test_utils::GraphHelper gHelper;
+            if (TestFixture::params::use_graphs)
+                gHelper.startStreamCapture(stream);
 
             HIP_CHECK(hipcub::DeviceSegmentedReduce::Sum(d_temporary_storage,
                                                          temporary_storage_bytes,
@@ -414,11 +403,8 @@ TYPED_TEST(HipcubDeviceSegmentedReduce, Sum)
                                                          d_offsets + 1,
                                                          stream));
 
-            hipGraphExec_t graph_instance;
-            if(TestFixture::params::use_graphs)
-            {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
-            }
+            if (TestFixture::params::use_graphs)
+                gHelper.createAndLaunchGraph(stream);
 
             HIP_CHECK(hipFree(d_temporary_storage));
 
@@ -436,16 +422,12 @@ TYPED_TEST(HipcubDeviceSegmentedReduce, Sum)
                 test_utils::assert_near(aggregates_output, aggregates_expected, precision));
 
             if(TestFixture::params::use_graphs)
-            {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
-            }
+                gHelper.cleanupGraphHelper();
         }
     }
 
     if(TestFixture::params::use_graphs)
-    {
         HIP_CHECK(hipStreamDestroy(stream));
-    }
 }
 
 TYPED_TEST(HipcubDeviceSegmentedReduce, Min)
@@ -565,11 +547,9 @@ TYPED_TEST(HipcubDeviceSegmentedReduce, Min)
             HIP_CHECK(
                 test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
-            hipGraph_t graph;
-            if(TestFixture::params::use_graphs)
-            {
-                graph = test_utils::createGraphHelper(stream);
-            }
+            test_utils::GraphHelper gHelper;
+            if (TestFixture::params::use_graphs)
+                gHelper.startStreamCapture(stream);
 
             HIP_CHECK(hipcub::DeviceSegmentedReduce::Min(d_temporary_storage,
                                                          temporary_storage_bytes,
@@ -580,11 +560,8 @@ TYPED_TEST(HipcubDeviceSegmentedReduce, Min)
                                                          d_offsets + 1,
                                                          stream));
 
-            hipGraphExec_t graph_instance;
-            if(TestFixture::params::use_graphs)
-            {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
-            }
+            if (TestFixture::params::use_graphs)
+                gHelper.createAndLaunchGraph(stream);
 
             HIP_CHECK(hipFree(d_temporary_storage));
 
@@ -602,16 +579,12 @@ TYPED_TEST(HipcubDeviceSegmentedReduce, Min)
                 test_utils::assert_near(aggregates_output, aggregates_expected, precision));
 
             if(TestFixture::params::use_graphs)
-            {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
-            }
+                gHelper.cleanupGraphHelper();
         }
     }
 
     if(TestFixture::params::use_graphs)
-    {
         HIP_CHECK(hipStreamDestroy(stream));
-    }
 }
 
 struct ArgMinDispatch
@@ -785,11 +758,9 @@ void test_argminmax(typename TestFixture::params::input_type empty_value)
                 test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
             HIP_CHECK(hipDeviceSynchronize());
 
-            hipGraph_t graph;
-            if(TestFixture::params::use_graphs)
-            {
-                graph = test_utils::createGraphHelper(stream);
-            }
+            test_utils::GraphHelper gHelper;
+            if (TestFixture::params::use_graphs)
+                gHelper.startStreamCapture(stream);
 
             HIP_CHECK(function(d_temporary_storage,
                                temporary_storage_bytes,
@@ -800,11 +771,8 @@ void test_argminmax(typename TestFixture::params::input_type empty_value)
                                d_offsets + 1,
                                stream));
 
-            hipGraphExec_t graph_instance;
-            if(TestFixture::params::use_graphs)
-            {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
-            }
+            if (TestFixture::params::use_graphs)
+                gHelper.createAndLaunchGraph(stream);
 
             HIP_CHECK(hipPeekAtLastError());
             HIP_CHECK(hipDeviceSynchronize());
@@ -830,16 +798,12 @@ void test_argminmax(typename TestFixture::params::input_type empty_value)
             }
 
             if(TestFixture::params::use_graphs)
-            {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
-            }
+                gHelper.cleanupGraphHelper();
         }
     }
 
     if(TestFixture::params::use_graphs)
-    {
         HIP_CHECK(hipStreamDestroy(stream));
-    }
 }
 
 TYPED_TEST(HipcubDeviceSegmentedReduce, ArgMin)

--- a/test/hipcub/test_hipcub_device_select.cpp
+++ b/test/hipcub/test_hipcub_device_select.cpp
@@ -170,20 +170,15 @@ TYPED_TEST(HipcubDeviceSelectTests, Flagged)
             // allocate temporary storage
             HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
 
-            hipGraph_t graph;
-            if(TestFixture::use_graphs)
-            {
-                graph = test_utils::createGraphHelper(stream);
-            }
+            test_utils::GraphHelper gHelper;
+            if (TestFixture::use_graphs)
+                gHelper.startStreamCapture(stream);
 
             // Run
             call(d_temp_storage, temp_storage_size_bytes);
 
-            hipGraphExec_t graph_instance;
-            if(TestFixture::use_graphs)
-            {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
-            }
+            if (TestFixture::use_graphs)
+                gHelper.createAndLaunchGraph(stream);
 
             HIP_CHECK(hipDeviceSynchronize());
 
@@ -215,9 +210,7 @@ TYPED_TEST(HipcubDeviceSelectTests, Flagged)
             ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(output, expected, expected.size()));
 
             if(TestFixture::use_graphs)
-            {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
-            }
+                gHelper.cleanupGraphHelper();
 
             HIP_CHECK(hipFree(d_input));
             HIP_CHECK(hipFree(d_flags));
@@ -231,9 +224,7 @@ TYPED_TEST(HipcubDeviceSelectTests, Flagged)
     }
 
     if(TestFixture::use_graphs)
-    {
         HIP_CHECK(hipStreamDestroy(stream));
-    }
 }
 
 TEST(HipcubDeviceSelectTests, FlagNormalization)
@@ -436,20 +427,15 @@ TYPED_TEST(HipcubDeviceSelectTests, SelectOp)
             // allocate temporary storage
             HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
 
-            hipGraph_t graph;
-            if(TestFixture::use_graphs)
-            {
-                graph = test_utils::createGraphHelper(stream);
-            }
+            test_utils::GraphHelper gHelper;
+            if (TestFixture::use_graphs)
+                gHelper.startStreamCapture(stream);
 
             // Run
             call(d_temp_storage, temp_storage_size_bytes);
 
-            hipGraphExec_t graph_instance;
-            if(TestFixture::use_graphs)
-            {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
-            }
+            if (TestFixture::use_graphs)
+                gHelper.createAndLaunchGraph(stream);
 
             HIP_CHECK(hipDeviceSynchronize());
 
@@ -481,9 +467,7 @@ TYPED_TEST(HipcubDeviceSelectTests, SelectOp)
             ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(output, expected, expected.size()));
 
             if(TestFixture::use_graphs)
-            {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
-            }
+                gHelper.cleanupGraphHelper();
 
             HIP_CHECK(hipFree(d_input));
             if(!inplace)
@@ -496,9 +480,7 @@ TYPED_TEST(HipcubDeviceSelectTests, SelectOp)
     }
 
     if(TestFixture::use_graphs)
-    {
         HIP_CHECK(hipStreamDestroy(stream));
-    }
 }
 
 TYPED_TEST(HipcubDeviceSelectTests, FlaggedIf)
@@ -610,20 +592,15 @@ TYPED_TEST(HipcubDeviceSelectTests, FlaggedIf)
             // allocate temporary storage
             HIP_CHECK(test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
 
-            hipGraph_t graph;
-            if(TestFixture::use_graphs)
-            {
-                graph = test_utils::createGraphHelper(stream);
-            }
+            test_utils::GraphHelper gHelper;
+            if (TestFixture::use_graphs)
+                gHelper.startStreamCapture(stream);
 
             // Run
             call(d_temp_storage, temp_storage_size_bytes);
 
-            hipGraphExec_t graph_instance;
-            if(TestFixture::use_graphs)
-            {
-                graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
-            }
+            if (TestFixture::use_graphs)
+                gHelper.createAndLaunchGraph(stream);
 
             HIP_CHECK(hipDeviceSynchronize());
 
@@ -655,9 +632,7 @@ TYPED_TEST(HipcubDeviceSelectTests, FlaggedIf)
             ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(output, expected, expected.size()));
 
             if(TestFixture::use_graphs)
-            {
-                test_utils::cleanupGraphHelper(graph, graph_instance);
-            }
+                gHelper.cleanupGraphHelper();
 
             HIP_CHECK(hipFree(d_input));
             HIP_CHECK(hipFree(d_flags));
@@ -671,9 +646,7 @@ TYPED_TEST(HipcubDeviceSelectTests, FlaggedIf)
     }
 
     if(TestFixture::use_graphs)
-    {
         HIP_CHECK(hipStreamDestroy(stream));
-    }
 }
 
 std::vector<float> get_discontinuity_probabilities()
@@ -770,11 +743,9 @@ TYPED_TEST(HipcubDeviceSelectTests, Unique)
                     test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
                 HIP_CHECK(hipDeviceSynchronize());
 
-                hipGraph_t graph;
-                if(TestFixture::use_graphs)
-                {
-                    graph = test_utils::createGraphHelper(stream);
-                }
+                test_utils::GraphHelper gHelper;
+                if (TestFixture::use_graphs)
+                    gHelper.startStreamCapture(stream);
 
                 // Run
                 HIP_CHECK(hipcub::DeviceSelect::Unique(d_temp_storage,
@@ -785,11 +756,8 @@ TYPED_TEST(HipcubDeviceSelectTests, Unique)
                                                        input.size(),
                                                        stream));
 
-                hipGraphExec_t graph_instance;
-                if(TestFixture::use_graphs)
-                {
-                    graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
-                }
+                if (TestFixture::use_graphs)
+                    gHelper.createAndLaunchGraph(stream);
 
                 HIP_CHECK(hipDeviceSynchronize());
 
@@ -813,9 +781,7 @@ TYPED_TEST(HipcubDeviceSelectTests, Unique)
                 ASSERT_NO_FATAL_FAILURE(test_utils::assert_eq(output, expected, expected.size()));
 
                 if(TestFixture::use_graphs)
-                {
-                    test_utils::cleanupGraphHelper(graph, graph_instance);
-                }
+                    gHelper.cleanupGraphHelper();
 
                 HIP_CHECK(hipFree(d_input));
                 HIP_CHECK(hipFree(d_output));
@@ -826,9 +792,7 @@ TYPED_TEST(HipcubDeviceSelectTests, Unique)
     }
 
     if(TestFixture::use_graphs)
-    {
         HIP_CHECK(hipStreamDestroy(stream));
-    }
 }
 
 TEST(HipcubDeviceSelectTests, UniqueDiscardOutputIterator)
@@ -1188,11 +1152,9 @@ TYPED_TEST(HipcubDeviceUniqueByKeyTests, UniqueByKey)
                 HIP_CHECK(
                     test_common_utils::hipMallocHelper(&d_temp_storage, temp_storage_size_bytes));
 
-                hipGraph_t graph;
-                if(TestFixture::use_graphs)
-                {
-                    graph = test_utils::createGraphHelper(stream);
-                }
+                test_utils::GraphHelper gHelper;
+                if (TestFixture::use_graphs)
+                    gHelper.startStreamCapture(stream);
 
                 // run
                 HIP_CHECK(hipcub::DeviceSelect::UniqueByKey(d_temp_storage,
@@ -1206,11 +1168,8 @@ TYPED_TEST(HipcubDeviceUniqueByKeyTests, UniqueByKey)
                                                             equality_op,
                                                             stream));
 
-                hipGraphExec_t graph_instance;
-                if(TestFixture::use_graphs)
-                {
-                    graph_instance = test_utils::endCaptureGraphHelper(graph, stream, true, true);
-                }
+                if (TestFixture::use_graphs)
+                    gHelper.createAndLaunchGraph(stream);
 
                 // Check if number of selected value is as expected
                 selected_count_type selected_count_output = 0;
@@ -1242,9 +1201,7 @@ TYPED_TEST(HipcubDeviceUniqueByKeyTests, UniqueByKey)
                     test_utils::assert_eq(output_values, expected_values, expected_values.size()));
 
                 if(TestFixture::use_graphs)
-                {
-                    test_utils::cleanupGraphHelper(graph, graph_instance);
-                }
+                    gHelper.cleanupGraphHelper();
 
                 HIP_CHECK(hipFree(d_keys_input));
                 HIP_CHECK(hipFree(d_values_input));
@@ -1257,9 +1214,7 @@ TYPED_TEST(HipcubDeviceUniqueByKeyTests, UniqueByKey)
     }
 
     if(TestFixture::use_graphs)
-    {
         HIP_CHECK(hipStreamDestroy(stream));
-    }
 }
 
 TEST(HipcubDeviceUniqueByKeyTests, LargeIndicesUniqueByKey)


### PR DESCRIPTION
Currently, the hipGraph tests overwrite the graph instance created by hipStreamStartCapture. This change moves the hipGraph helper functions into a class that encapsulates the graph instance, ensuring it doesn't get overwritten.