### PR TITLE
Limit test_hipcub_device_radix_sort memory usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ Full documentation for hipCUB is available at [https://rocm.docs.amd.com/project
 * The NVIDIA backend now requires CUB, Thrust and libcu++ 2.5.0. If it is not found it will be downloaded from the NVIDIA CCCL repository.
 * Changed the C++ version from 14 to 17. C++14 will be deprecated in the next major release.
 
+### Known issues
+* When building on Windows using the HIP SDK release for ROCm 6.4, hipMalloc currently returns hipSuccess for some sizes that are larger than it can allocate. For this reason, we've limited the maximum test case sizes for some unit tests (eg. HipcubDeviceRadixSort's SortKeysLargeSizes test).
+
 ## hipCUB 3.3.0 for ROCm 6.3.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ Full documentation for hipCUB is available at [https://rocm.docs.amd.com/project
 * Changed the C++ version from 14 to 17. C++14 will be deprecated in the next major release.
 
 ### Known issues
-* When building on Windows using the HIP SDK release for ROCm 6.4, hipMalloc currently returns hipSuccess for some sizes that are larger than it can allocate. For this reason, we've limited the maximum test case sizes for some unit tests (eg. HipcubDeviceRadixSort's SortKeysLargeSizes test).
+* When building on Windows using HIP SDK for ROCm 6.4, ``hipMalloc`` returns ``hipSuccess`` even when the size passed to it is too large and the allocation fails. Because of this, limits have been set for the maximum test case sizes for some unit tests such as HipcubDeviceRadixSort's SortKeysLargeSizes .
 
 ## hipCUB 3.3.0 for ROCm 6.3.0
 

--- a/test/hipcub/test_hipcub_device_radix_sort.hpp
+++ b/test/hipcub/test_hipcub_device_radix_sort.hpp
@@ -1215,7 +1215,7 @@ inline void sort_keys_large_sizes()
 
     hipStream_t stream = 0;
 
-    const std::vector<size_t> sizes = test_utils::get_large_sizes(seeds[0]);
+    const std::vector<size_t> sizes = test_utils::get_large_sizes<34>(seeds[0]);
     for(const size_t size : sizes)
     {
         SCOPED_TRACE(testing::Message() << "with size = " << size);

--- a/test/hipcub/test_hipcub_device_radix_sort.hpp
+++ b/test/hipcub/test_hipcub_device_radix_sort.hpp
@@ -1215,7 +1215,13 @@ inline void sort_keys_large_sizes()
 
     hipStream_t stream = 0;
 
+    // Workaround: `hipMalloc` always returns `hipSuccess` even when allocation fails.
+    // We limit the maximum size so this bug doesn't occur.
+#ifdef _WIN32
     const std::vector<size_t> sizes = test_utils::get_large_sizes<34>(seeds[0]);
+#else
+    const std::vector<size_t> sizes = test_utils::get_large_sizes(seeds[0]);
+#endif
     for(const size_t size : sizes)
     {
         SCOPED_TRACE(testing::Message() << "with size = " << size);

--- a/test/hipcub/test_utils_data_generation.hpp
+++ b/test/hipcub/test_utils_data_generation.hpp
@@ -473,18 +473,19 @@ inline std::vector<T> get_random_data01(size_t size, float p, int seed_value)
     return data;
 }
 
+template<unsigned int MaxPow2 = 35>
 inline std::vector<size_t> get_large_sizes(int seed_value)
 {
     // clang-format off
     std::vector<size_t> sizes = {
         (size_t{1} << 32) - 1, size_t{1} << 32,
-        (size_t{1} << 35) - 1, size_t{1} << 35
+        (size_t{1} << MaxPow2) - 1, size_t{1} << MaxPow2
     };
     // clang-format on
     const std::vector<size_t> random_sizes
         = test_utils::get_random_data<size_t>(2,
                                               (size_t{1} << 30) + 1,
-                                              (size_t{1} << 35) - 2,
+                                              (size_t{1} << MaxPow2) - 2,
                                               seed_value);
     sizes.insert(sizes.end(), random_sizes.begin(), random_sizes.end());
     std::sort(sizes.begin(), sizes.end());


### PR DESCRIPTION
On Windows, HipcubDeviceRadixSort.SortKeysLargeSizes fails due to an out of memory error on some devices. Limiting the data sizes that used are used for this test fixes this problem.