### PR TITLE
Prevent GTest from printing 128-bit values on Windows

### DIFF
--- a/test/hipcub/test_hipcub_single_pass_scan_operators.cpp
+++ b/test/hipcub/test_hipcub_single_pass_scan_operators.cpp
@@ -365,6 +365,6 @@ TYPED_TEST(HipcubRunningPrefixTest, IntSum)
         std::partial_sum(input.begin(), input.end(), expected.begin());
 
         // We can do direct comparison because we're working on integral types.
-        ASSERT_EQ(expected, output);
+        test_utils::assert_eq(output, expected);
     }
 }

--- a/test/hipcub/test_utils_assertions.hpp
+++ b/test/hipcub/test_utils_assertions.hpp
@@ -51,7 +51,23 @@ inline void assert_eq(const std::vector<T>& result, const std::vector<T>& expect
     for(size_t i = 0; i < std::min(result.size(), max_length); i++)
     {
         if(bit_equal(result[i], expected[i])) continue; // Check to also regard equality of NaN's, -NaN, +inf, -inf as correct.
+
+#if defined(_WIN32)
+        // GTest's ASSERT_EQ prints the values if the test fails. On Windows, the version of GTest provided by vcpkg doesn't
+        // provide overloads for printing 128 bit types, resulting in linker errors.
+        // Check if we're testing with 128 bit types. If so, test using bools so GTest doesn't try to print them on failure.
+        if (test_utils::is_int128<T>::value || test_utils::is_uint128<T>::value)
+        {
+            const bool values_equal = (result[i] == expected[i]);
+            ASSERT_EQ(values_equal, true) << "where index = " << i;
+        }
+        else
+        {
+            ASSERT_EQ(result[i], expected[i]) << "where index = " << i;
+        }
+#else
         ASSERT_EQ(result[i], expected[i]) << "where index = " << i;
+#endif
     }
 }
 


### PR DESCRIPTION
GTest's ASSERT_EQ prints the values if the test fails. On Windows, the version of GTest provided by vcpkg doesn't contain overloads for printing 128 bit types, resulting in linker errors.

This change adds a check to test_utils::assert_eq to see if we're testing with 128 bit types. If so, it performs the comparison before calling ASSERT_EQ, then compares the boolean result to true using ASSERT_EQ.

This change also makes a small modification to the test_hipcub_single_pass_scan_operators source to avoid calling ASSERT_EQ directly.