### PR TITLE
refactor: migrate to new wavefront api

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -94,7 +94,7 @@ copyright-date:
       -D GPU_TARGETS="$GPU_TARGETS"
       -D CMAKE_C_COMPILER_LAUNCHER=phc_sccache_c
       -D CMAKE_CXX_COMPILER_LAUNCHER=phc_sccache_cxx
-      -D CMAKE_CXX_STANDARD=14
+      -D CMAKE_CXX_STANDARD=17
       -B $CI_PROJECT_DIR/rocPRIM/build
       -S $CI_PROJECT_DIR/rocPRIM
     - cd $CI_PROJECT_DIR/rocPRIM/build

--- a/benchmark/benchmark_utils.hpp
+++ b/benchmark/benchmark_utils.hpp
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -408,6 +408,14 @@ bool is_warp_size_supported(const unsigned required_warp_size)
 template<unsigned int LogicalWarpSize>
 __device__ constexpr bool device_test_enabled_for_warp_size_v
     = HIPCUB_DEVICE_WARP_THREADS >= LogicalWarpSize;
+
+template<class T>
+__device__
+inline constexpr bool is_power_of_two(const T x)
+{
+    static_assert(std::is_integral<T>::value, "T must be integer type");
+    return (x > 0) && ((x & (x - 1)) == 0);
+}
 
 template<typename Iterator>
 using it_value_t = typename std::iterator_traits<Iterator>::value_type;

--- a/benchmark/benchmark_warp_scan.cpp
+++ b/benchmark/benchmark_warp_scan.cpp
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -106,7 +106,8 @@ struct broadcast
     template<class T, unsigned int WarpSize, unsigned int Trials>
     __device__
     static auto run(const T* input, T* output, const T init)
-        -> std::enable_if_t<benchmark_utils::device_test_enabled_for_warp_size_v<WarpSize>>
+        -> std::enable_if_t<(benchmark_utils::device_test_enabled_for_warp_size_v<WarpSize>
+                             && benchmark_utils::is_power_of_two(WarpSize))>
     {
         (void)init;
 
@@ -127,7 +128,8 @@ struct broadcast
     template<class T, unsigned int WarpSize, unsigned int Trials>
     __device__
     static auto run(const T* /*input*/, T* /*output*/, const T /*init*/)
-        -> std::enable_if_t<!benchmark_utils::device_test_enabled_for_warp_size_v<WarpSize>>
+        -> std::enable_if_t<!(benchmark_utils::device_test_enabled_for_warp_size_v<WarpSize>
+                              && benchmark_utils::is_power_of_two(WarpSize))>
     {}
 };
 

--- a/hipcub/include/hipcub/backend/rocprim/util_ptx.hpp
+++ b/hipcub/include/hipcub/backend/rocprim/util_ptx.hpp
@@ -1,7 +1,7 @@
 /******************************************************************************
  * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
  * Copyright (c) 2011-2018, NVIDIA CORPORATION.  All rights reserved.
- * Modifications Copyright (c) 2017-2024, Advanced Micro Devices, Inc.  All rights reserved.
+ * Modifications Copyright (c) 2017-2025, Advanced Micro Devices, Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -81,8 +81,7 @@ template <int LOGICAL_WARP_THREADS, int /* ARCH */ = 0>
 HIPCUB_DEVICE inline 
 uint64_t WarpMask(unsigned int warp_id) {
     constexpr bool is_pow_of_two = ::rocprim::detail::is_power_of_two(LOGICAL_WARP_THREADS);
-    constexpr bool is_arch_warp =
-        LOGICAL_WARP_THREADS == ::rocprim::device_warp_size();
+    const bool     is_arch_warp  = LOGICAL_WARP_THREADS == ::rocprim::arch::wavefront::size();
 
     uint64_t member_mask = uint64_t(-1) >> (64 - LOGICAL_WARP_THREADS);
 

--- a/hipcub/include/hipcub/config.hpp
+++ b/hipcub/include/hipcub/config.hpp
@@ -76,6 +76,7 @@
     #define HIPCUB_RUNTIME_FUNCTION __host__
 
     #include <rocprim/device/config_types.hpp>
+    #include <rocprim/intrinsics/arch.hpp>
     #include <rocprim/intrinsics/thread.hpp>
 
 BEGIN_HIPCUB_NAMESPACE
@@ -99,9 +100,11 @@ inline unsigned int host_warp_size_wrapper()
 }
 } // namespace detail
 END_HIPCUB_NAMESPACE
+    #include <rocprim/intrinsics/arch.hpp>
 
     #define HIPCUB_WARP_THREADS ::rocprim::warp_size()
-    #define HIPCUB_DEVICE_WARP_THREADS ::rocprim::device_warp_size()
+    // HIPCUB (and CUB) don't have a method to express min and max warp size.
+    #define HIPCUB_DEVICE_WARP_THREADS ::rocprim::arch::wavefront::max_size()
     #define HIPCUB_HOST_WARP_THREADS ::hipcub::detail::host_warp_size_wrapper()
     #define HIPCUB_ARCH 1 // ignored with rocPRIM backend
 #elif defined(__HIP_PLATFORM_NVIDIA__)


### PR DESCRIPTION
Fixed warnings thrown in https://github.com/ROCm/rocPRIM/pull/705.