### PR TITLE
[hipCUB] Mergeback 6.4 changes (#466)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Full documentation for hipCUB is available at [https://rocm.docs.amd.com/projects/hipCUB/en/latest/](https://rocm.docs.amd.com/projects/hipCUB/en/latest/).
 
-## (Unreleased) hipCUB-3.5.0 for ROCm 6.5.0
+## hipCUB-3.5.0 for ROCm 6.5.0
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,9 @@ Full documentation for hipCUB is available at [https://rocm.docs.amd.com/project
 * The NVIDIA backend now requires CUB, Thrust and libcu++ 2.5.0. If it is not found it will be downloaded from the NVIDIA CCCL repository.
 * Changed the C++ version from 14 to 17. C++14 will be deprecated in the next major release.
 
+### Known issues
+* When building on Windows using HIP SDK for ROCm 6.4, ``hipMalloc`` returns ``hipSuccess`` even when the size passed to it is too large and the allocation fails. Because of this, limits have been set for the maximum test case sizes for some unit tests such as HipcubDeviceRadixSort's SortKeysLargeSizes .
+
 ## hipCUB 3.3.0 for ROCm 6.3.0
 
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,11 +105,11 @@ else()
       if(BUILD_ADDRESS_SANITIZER)
         # ASAN builds require xnack
         rocm_check_target_ids(DEFAULT_AMDGPU_TARGETS
-          TARGETS "gfx908:xnack+;gfx90a:xnack+;gfx942:xnack+;gfx950:xnack+"
+          TARGETS "gfx908:xnack+;gfx90a:xnack+;gfx942:xnack+"
         )
       else()
         rocm_check_target_ids(DEFAULT_AMDGPU_TARGETS
-          TARGETS "gfx803;gfx900:xnack-;gfx906:xnack-;gfx908:xnack-;gfx90a:xnack-;gfx90a:xnack+;gfx942;gfx950;gfx1030;gfx1100;gfx1101;gfx1102;gfx1151;gfx1200;gfx1201"
+          TARGETS "gfx803;gfx900:xnack-;gfx906:xnack-;gfx908:xnack-;gfx90a:xnack-;gfx90a:xnack+;gfx942;gfx1030;gfx1100;gfx1101;gfx1102;gfx1151;gfx1200;gfx1201"
         )
       endif()
       set(GPU_TARGETS "${DEFAULT_AMDGPU_TARGETS}" CACHE STRING "GPU architectures to compile for" FORCE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,7 +129,7 @@ if(BUILD_ADDRESS_SANITIZER)
 endif()
 
 # Setup VERSION
-set(VERSION_STRING "3.4.0")
+set(VERSION_STRING "3.5.0")
 rocm_setup_version(VERSION ${VERSION_STRING})
 math(EXPR hipcub_VERSION_NUMBER "${hipcub_VERSION_MAJOR} * 100000 + ${hipcub_VERSION_MINOR} * 100 + ${hipcub_VERSION_PATCH}")
 

--- a/test/hipcub/test_hipcub_device_radix_sort.hpp
+++ b/test/hipcub/test_hipcub_device_radix_sort.hpp
@@ -1179,7 +1179,13 @@ inline void sort_keys_large_sizes()
 
     hipStream_t stream = 0;
 
+    // Workaround: `hipMalloc` always returns `hipSuccess` even when allocation fails.
+    // We limit the maximum size so this bug doesn't occur.
+#ifdef _WIN32
+    const std::vector<size_t> sizes = test_utils::get_large_sizes<34>(seeds[0]);
+#else
     const std::vector<size_t> sizes = test_utils::get_large_sizes(seeds[0]);
+#endif
     for(const size_t size : sizes)
     {
         SCOPED_TRACE(testing::Message() << "with size = " << size);

--- a/test/hipcub/test_utils_data_generation.hpp
+++ b/test/hipcub/test_utils_data_generation.hpp
@@ -469,18 +469,19 @@ inline std::vector<T> get_random_data01(size_t size, float p, int seed_value)
     return data;
 }
 
+template<unsigned int MaxPow2 = 35>
 inline std::vector<size_t> get_large_sizes(int seed_value)
 {
     // clang-format off
     std::vector<size_t> sizes = {
         (size_t{1} << 32) - 1, size_t{1} << 32,
-        (size_t{1} << 35) - 1, size_t{1} << 35
+        (size_t{1} << MaxPow2) - 1, size_t{1} << MaxPow2
     };
     // clang-format on
     const std::vector<size_t> random_sizes
         = test_utils::get_random_data<size_t>(2,
                                               (size_t{1} << 30) + 1,
-                                              (size_t{1} << 35) - 2,
+                                              (size_t{1} << MaxPow2) - 2,
                                               seed_value);
     sizes.insert(sizes.end(), random_sizes.begin(), random_sizes.end());
     std::sort(sizes.begin(), sizes.end());


### PR DESCRIPTION
Merge back changes from the release-staging/rocm-rel-6.5 branch.

* Include device_copy header (#433)

* [windows][hipCUB] Removed usage of std::unary_function and std::binary_function to prevent syntax error (#435)

* Enable CMake HIP language (#434)

* Add hipcub::AliasTemporaries and some macros (#438)

* Created installation section (#440) (#458)

* Limit test_hipcub_device_radix_sort memory usage (#454)