### PR TITLE
Add includes for standard chrono header

### DIFF
--- a/benchmark/common_benchmark_header.hpp
+++ b/benchmark/common_benchmark_header.hpp
@@ -32,6 +32,7 @@
 #include <cmath>
 #include <cstdlib>
 #include <numeric>
+#include <chrono>
 
 // Google Benchmark
 #include "benchmark/benchmark.h"

--- a/hipcub/include/hipcub/backend/rocprim/device/device_segmented_reduce.hpp
+++ b/hipcub/include/hipcub/backend/rocprim/device/device_segmented_reduce.hpp
@@ -41,6 +41,7 @@
 
 #include <rocprim/device/device_segmented_reduce.hpp>
 
+#include <chrono>
 #include <iterator>
 #include <limits>
 

--- a/hipcub/include/hipcub/backend/rocprim/device/device_spmv.hpp
+++ b/hipcub/include/hipcub/backend/rocprim/device/device_spmv.hpp
@@ -36,6 +36,8 @@
 #include "../iterator/tex_ref_input_iterator.hpp"
 #include "../util_sync.hpp"
 
+#include <chrono>
+
 BEGIN_HIPCUB_NAMESPACE
 
 class DeviceSpmv


### PR DESCRIPTION
Add include directives for the standard library chrono header to severy files that use it, but weren't directly including it. This resolves some build problems on Windows.
Previously, we relied on HIP to include some of these standard library headers for us.